### PR TITLE
Fix multiple instances of ExecutorService not being shutdown

### DIFF
--- a/src/main/java/net/preibisch/mvrecon/fiji/plugin/Image_Deconvolution.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/plugin/Image_Deconvolution.java
@@ -89,6 +89,13 @@ public class Image_Deconvolution implements PlugIn
 		return deconvolve( spimData, views, DeconViews.createExecutorService() );
 	}
 
+	/**
+	 * 
+	 * @param spimData
+	 * @param viewList
+	 * @param service Will be shutdown.
+	 * @return
+	 */
 	public static boolean deconvolve(
 			final SpimData2 spimData,
 			final List< ViewId > viewList,

--- a/src/main/java/net/preibisch/mvrecon/fiji/plugin/Image_Fusion.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/plugin/Image_Fusion.java
@@ -276,6 +276,8 @@ public class Image_Fusion implements PlugIn
 		}
 
 		exporter.finish();
+		
+		taskExecutor.shutdown();
 
 		IOFunctions.println( "(" + new Date(System.currentTimeMillis()) + "): DONE." );
 

--- a/src/main/java/net/preibisch/mvrecon/fiji/plugin/Image_Quality.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/plugin/Image_Quality.java
@@ -172,6 +172,8 @@ public class Image_Quality implements PlugIn
 		}
 
 		exporter.finish();
+		
+		taskExecutor.shutdown();
 
 		IOFunctions.println( "(" + new Date(System.currentTimeMillis()) + "): DONE." );
 

--- a/src/main/java/net/preibisch/mvrecon/fiji/plugin/Interest_Point_Registration.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/plugin/Interest_Point_Registration.java
@@ -1158,6 +1158,7 @@ public class Interest_Point_Registration implements PlugIn
 			final List< PairwiseMatch > pairs = subset.getViewPairs();
 
 			final ExecutorService taskExecutor = Executors.newFixedThreadPool( Threads.numThreads() );
+			// *** @@@ NOTE @@@ *** this taskExecutor is never shutdown()
 			final ArrayList< Callable< PairwiseMatch > > tasks = new ArrayList< Callable< PairwiseMatch > >(); // your tasks
 
 			for ( final PairwiseMatch pair : pairs )

--- a/src/main/java/net/preibisch/mvrecon/fiji/plugin/interactive/MultiResolutionSource.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/plugin/interactive/MultiResolutionSource.java
@@ -183,6 +183,8 @@ public class MultiResolutionSource implements Source< VolatileFloatType >
 						minDS,
 						maxDS,
 						dsInc );
+		
+		service.shutdown();
 
 		/*
 		for ( int i = 0; i < multiResNonRigid.size(); ++i )

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/VisualizeNonRigid.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/VisualizeNonRigid.java
@@ -172,6 +172,8 @@ public class VisualizeNonRigid extends JMenuItem implements ExplorerWindowSetabl
 										minDS,
 										maxDS,
 										dsInc );
+						
+						service.shutdown();
 
 						BdvOptions options = Bdv.options().numSourceGroups( 2 ).frameTitle( "Affine (magenta) vs. NonRigid (green)" );
 						BdvStackSource< ? > affine = BdvFunctions.show( new MultiResolutionSource( MultiResolutionTools.createVolatileRAIs( multiResAffine ), "affine" ), options );
@@ -265,6 +267,8 @@ public class VisualizeNonRigid extends JMenuItem implements ExplorerWindowSetabl
 											minDS,
 											maxDS,
 											dsInc );
+							
+							service.shutdown();
 	
 							if ( nr != null )
 								options.addTo( nr );

--- a/src/main/java/net/preibisch/mvrecon/headless/boundingbox/TestRealDataBoundingBox.java
+++ b/src/main/java/net/preibisch/mvrecon/headless/boundingbox/TestRealDataBoundingBox.java
@@ -73,6 +73,8 @@ public class TestRealDataBoundingBox
 
 		final BoundingBox bb = estimation.estimate( "MinFilterThresholdBoundingBoxGUI" );
 
+		service.shutdown();
+
 		FusionTools.displayCopy( FusionTools.fuseVirtual( spimData, viewIds, true, false, 1, bb, 2.0, null ).getA(), estimation.getMinIntensity(), estimation.getMaxIntensity() ).show();
 	}
 }

--- a/src/main/java/net/preibisch/mvrecon/headless/fusion/TestNonRigid.java
+++ b/src/main/java/net/preibisch/mvrecon/headless/fusion/TestNonRigid.java
@@ -140,6 +140,8 @@ public class TestNonRigid
 						downsampling,
 						null,
 						service ).getA();
+		
+		service.shutdown();
 
 		//final RandomAccessibleInterval< FloatType > out = FusionTools.copyImgByPlane3d( virtual, new ImagePlusImgFactory< FloatType >( new FloatType() ), service, true );
 		//final RandomAccessibleInterval< FloatType > out = FusionTools.copyImg( virtual, new ImagePlusImgFactory< FloatType >(), new FloatType(), service, true );

--- a/src/main/java/net/preibisch/mvrecon/process/boundingbox/BoundingBoxMinFilterThreshold.java
+++ b/src/main/java/net/preibisch/mvrecon/process/boundingbox/BoundingBoxMinFilterThreshold.java
@@ -259,6 +259,8 @@ public class BoundingBoxMinFilterThreshold implements BoundingBoxEstimation
 			}
 		}
 		
+		taskExecutor.shutdown();
+		
 		return true;
 	}
 	

--- a/src/main/java/net/preibisch/mvrecon/process/cuda/Block.java
+++ b/src/main/java/net/preibisch/mvrecon/process/cuda/Block.java
@@ -135,6 +135,10 @@ public class Block extends AbstractInterval
 	public long[] getBlockSize() { return blockSize.clone(); }
 	public long[] getEffectiveSize() { return effectiveSize.clone(); }
 
+	/** WARNING: this method may never get invoked, unless the garbage collector processes this instance;
+	 *           what is likely to happen is that the native memory consumed by the {@link ExecutorService}
+	 *           is never released.
+	 *           It would be preferable to declare a "destroy()" method that does so explictly. */
 	@Override
 	public void finalize()
 	{

--- a/src/main/java/net/preibisch/mvrecon/process/deconvolution/DeconViews.java
+++ b/src/main/java/net/preibisch/mvrecon/process/deconvolution/DeconViews.java
@@ -46,7 +46,7 @@ public class DeconViews
 		this.views = new ArrayList<>();
 		this.views.addAll( input );
 
-		this.service = FFTConvolution.createExecutorService( Threads.numThreads() );
+		this.service = service;
 
 		if ( ThreadPoolExecutor.class.isInstance( service ) )
 			this.numThreads = ((ThreadPoolExecutor)service).getMaximumPoolSize();

--- a/src/main/java/net/preibisch/mvrecon/process/export/DisplayImage.java
+++ b/src/main/java/net/preibisch/mvrecon/process/export/DisplayImage.java
@@ -44,8 +44,6 @@ public class DisplayImage implements ImgExport, Calibrateable
 {
 	final boolean virtualDisplay;
 
-	public static ExecutorService service = DeconViews.createExecutorService();
-
 	String unit = "px";
 	double cal = 1.0;
 
@@ -152,7 +150,12 @@ public class DisplayImage implements ImgExport, Calibrateable
 			final double min,
 			final double max )
 	{
-		return getImagePlusInstance( img, virtualDisplay, title, min, max, service );
+		final ExecutorService service = DeconViews.createExecutorService();
+		try {
+			return getImagePlusInstance( img, virtualDisplay, title, min, max, service );
+		} finally {
+			service.shutdown();
+		}
 	}
 
 	@SuppressWarnings("unchecked")

--- a/src/main/java/net/preibisch/mvrecon/process/fusion/FusionTools.java
+++ b/src/main/java/net/preibisch/mvrecon/process/fusion/FusionTools.java
@@ -826,7 +826,7 @@ public class FusionTools
 	{
 		final ExecutorService taskExecutor = Executors.newFixedThreadPool( nThreads );
 
-		execTasks( tasks, Executors.newFixedThreadPool( nThreads ), jobDescription );
+		execTasks( tasks, taskExecutor, jobDescription );
 
 		taskExecutor.shutdown();
 	}

--- a/src/main/java/util/FFTConvolution.java
+++ b/src/main/java/util/FFTConvolution.java
@@ -682,15 +682,21 @@ public class FFTConvolution< R extends RealType< R > >
 	/**
 	 * Set the executor service to use.
 	 * 
+	 * When null, a new {@link ExecutorService} is created with the maximum number of available threads,
+	 * and then it is returned (so that it can be shutdown elsewhere to avoid consuming native memory).
+	 * Otherwise, returns the service that was provided as argument.
+	 * 
 	 * @param service
 	 *            - Executor service to use.
 	 */
-	public void setExecutorService( final ExecutorService service )
+	public ExecutorService setExecutorService( final ExecutorService service )
 	{
 		if ( service == null )
 			this.service = Executors.newFixedThreadPool( Runtime.getRuntime( ).availableProcessors());
 		else
 			this.service = service;
+		
+		return this.service;
 	}
 
 	/**


### PR DESCRIPTION
When an ```ExecutorService``` is not ```shutdown()```, it remains in RAM consuming native memory, and when the latter runs out, no new threads can be created.

This PR fixes multiple cases of lack of ```shutdown()``` calls for method-local instances of an ```ExecutorService```, provides comments for several cases that may need further inspection, and changes a method return signature from ```void``` to ```ExecutorService``` to enable the caller to invoke ```shutdown()``` when appropriate.