### PR TITLE
Save SPIM data upon PSF assignment

### DIFF
--- a/src/main/java/net/preibisch/mvrecon/fiji/plugin/PSF_Assign.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/plugin/PSF_Assign.java
@@ -77,12 +77,16 @@ public class PSF_Assign implements PlugIn
 		if ( !result.queryXML( "Dataset Fusion", true, true, true, true, true ) )
 			return;
 
-		assign( result.getData(), SpimData2.getAllViewIdsSorted( result.getData(), result.getViewSetupsToProcess(), result.getTimePointsToProcess() ) );
+		assign(result.getData(), SpimData2.getAllViewIdsSorted(result.getData(),
+			result.getViewSetupsToProcess(), result.getTimePointsToProcess()), result
+				.getClusterExtension(), result.getXMLFileName());
 	}
 
 	public static boolean assign(
 			final SpimData2 spimData,
-			final Collection< ? extends ViewId > viewCollection )
+			final Collection< ? extends ViewId > viewCollection,
+			final String clusterExtension,
+			final String xmlFileName)
 	{
 		final ArrayList< ViewId > viewIds = new ArrayList<>();
 		viewIds.addAll( viewCollection );
@@ -130,6 +134,7 @@ public class PSF_Assign implements PlugIn
 			{
 				IOFunctions.println( "(" + new Date( System.currentTimeMillis() ) + "): Assigning '" + file + "' to " + Group.pvid( viewId ) );
 				spimData.getPointSpreadFunctions().addPSF( viewId, new PointSpreadFunction( spimData.getBasePath(), file ) );
+				SpimData2.saveXML( spimData, xmlFileName, clusterExtension );
 			}
 		}
 		else if ( assignType == 1 ) // "Assign new PSF to all selected views"
@@ -163,10 +168,12 @@ public class PSF_Assign implements PlugIn
 					localFileName = psf.getFile();
 					IOFunctions.println( "(" + new Date( System.currentTimeMillis() ) + "): Local filename '" + localFileName + "' assigned" );
 					spimData.getPointSpreadFunctions().addPSF( viewId, psf );
+					SpimData2.saveXML( spimData, xmlFileName, clusterExtension );
 				}
 				else
 				{
 					spimData.getPointSpreadFunctions().addPSF( viewId, new PointSpreadFunction( spimData.getBasePath(), localFileName ) );
+					SpimData2.saveXML( spimData, xmlFileName, clusterExtension );
 				}
 			}
 		}
@@ -283,6 +290,8 @@ public class PSF_Assign implements PlugIn
 						IOFunctions.println( "(" + new Date( System.currentTimeMillis() ) + "): Assigning '" + file + "' from " +  Group.pvid( corresponding ) + " to " + Group.pvid( viewId ) );
 
 						spimData.getPointSpreadFunctions().addPSF( viewId, new PointSpreadFunction( spimData.getBasePath(), file ) );
+						
+						SpimData2.saveXML( spimData, xmlFileName, clusterExtension );
 					}
 				}
 			}
@@ -370,6 +379,8 @@ public class PSF_Assign implements PlugIn
 						IOFunctions.println( "(" + new Date( System.currentTimeMillis() ) + "): Assigning '" + file + "' from " +  Group.pvid( corresponding ) + " to " + Group.pvid( viewId ) );
 
 						spimData.getPointSpreadFunctions().addPSF( viewId, new PointSpreadFunction( spimData.getBasePath(), file ) );
+						
+						SpimData2.saveXML( spimData, xmlFileName, clusterExtension );
 					}
 				}
 			}


### PR DESCRIPTION
Most multiview-reconstruction plugins save modified SPIM data into the corresponding XML file, but PSF assignment does not do so. This pull request proposes a change which would enable SPIM data resave following a PSF assignment.

Bigger picture: I would like to employ the plugin for PSF assignment in an automated pipeline