### PR TITLE
Make sure XMLs are always saved unless a PSF plugin is run from a popup

### DIFF
--- a/src/main/java/net/preibisch/mvrecon/fiji/plugin/PSF_Assign.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/plugin/PSF_Assign.java
@@ -79,21 +79,22 @@ public class PSF_Assign implements PlugIn
 
 		assign(result.getData(), SpimData2.getAllViewIdsSorted(result.getData(),
 			result.getViewSetupsToProcess(), result.getTimePointsToProcess()), result
-				.getClusterExtension(), result.getXMLFileName());
+				.getClusterExtension(), result.getXMLFileName(), true);
 	}
 	
 	public static boolean assign(
 		final SpimData2 spimData,
 		final Collection< ? extends ViewId > viewCollection)
 	{
-		return assign(spimData, viewCollection, null, null);
+		return assign(spimData, viewCollection, null, null, false);
 	}
 
 	public static boolean assign(
 			final SpimData2 spimData,
 			final Collection< ? extends ViewId > viewCollection,
 			final String clusterExtension,
-			final String xmlFileName)
+			final String xmlFileName,
+			final boolean saveXml )
 	{
 		final ArrayList< ViewId > viewIds = new ArrayList<>();
 		viewIds.addAll( viewCollection );
@@ -112,8 +113,6 @@ public class PSF_Assign implements PlugIn
 
 		final int assignType = defaultAssignType = gd.getNextChoiceIndex();
 		
-		final boolean save = clusterExtension != null && !clusterExtension.isEmpty() && xmlFileName != null && !xmlFileName.isEmpty();
-
 		if ( assignType == 0 ) // "Assign existing PSF to all selected views"
 		{
 			final GenericDialog gd1 = new GenericDialog( "Assign existing PSF to views" );
@@ -143,7 +142,7 @@ public class PSF_Assign implements PlugIn
 			{
 				IOFunctions.println( "(" + new Date( System.currentTimeMillis() ) + "): Assigning '" + file + "' to " + Group.pvid( viewId ) );
 				spimData.getPointSpreadFunctions().addPSF( viewId, new PointSpreadFunction( spimData.getBasePath(), file ) );
-				if ( save )
+				if ( saveXml )
 					SpimData2.saveXML( spimData, xmlFileName, clusterExtension );
 			}
 		}
@@ -178,13 +177,13 @@ public class PSF_Assign implements PlugIn
 					localFileName = psf.getFile();
 					IOFunctions.println( "(" + new Date( System.currentTimeMillis() ) + "): Local filename '" + localFileName + "' assigned" );
 					spimData.getPointSpreadFunctions().addPSF( viewId, psf );
-					if ( save )
+					if ( saveXml )
 						SpimData2.saveXML( spimData, xmlFileName, clusterExtension );
 				}
 				else
 				{
 					spimData.getPointSpreadFunctions().addPSF( viewId, new PointSpreadFunction( spimData.getBasePath(), localFileName ) );
-					if ( save )
+					if ( saveXml )
 						SpimData2.saveXML( spimData, xmlFileName, clusterExtension );
 				}
 			}
@@ -303,7 +302,7 @@ public class PSF_Assign implements PlugIn
 
 						spimData.getPointSpreadFunctions().addPSF( viewId, new PointSpreadFunction( spimData.getBasePath(), file ) );
 						
-						if ( save )
+						if ( saveXml )
 							SpimData2.saveXML( spimData, xmlFileName, clusterExtension );
 					}
 				}
@@ -393,7 +392,7 @@ public class PSF_Assign implements PlugIn
 
 						spimData.getPointSpreadFunctions().addPSF( viewId, new PointSpreadFunction( spimData.getBasePath(), file ) );
 						
-						if ( save )
+						if ( saveXml )
 							SpimData2.saveXML( spimData, xmlFileName, clusterExtension );
 					}
 				}

--- a/src/main/java/net/preibisch/mvrecon/fiji/plugin/PSF_Extract.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/plugin/PSF_Extract.java
@@ -58,21 +58,22 @@ public class PSF_Extract implements PlugIn
 		if ( !result.queryXML( "Dataset Fusion", true, true, true, true, true ) )
 			return;
 
-		extract( result.getData(), SpimData2.getAllViewIdsSorted( result.getData(), result.getViewSetupsToProcess(), result.getTimePointsToProcess() ), result.getClusterExtension(), result.getXMLFileName() );
+		extract( result.getData(), SpimData2.getAllViewIdsSorted( result.getData(), result.getViewSetupsToProcess(), result.getTimePointsToProcess() ), result.getClusterExtension(), result.getXMLFileName(), true );
 	}
 
 	public static boolean extract(
 		final SpimData2 spimData,
 		final Collection< ? extends ViewId > viewCollection )
 	{
-		return extract( spimData, viewCollection, null, null );
+		return extract( spimData, viewCollection, null, null, false );
 	}
 
 	public static boolean extract(
 			final SpimData2 spimData,
 			final Collection< ? extends ViewId > viewCollection,
 			final String clusterExtension,
-			final String xmlFileName )
+			final String xmlFileName,
+			final boolean saveXml )
 	{
 		final ArrayList< ViewId > viewIds = new ArrayList<>();
 		viewIds.addAll( viewCollection );
@@ -154,8 +155,6 @@ public class PSF_Extract implements PlugIn
 
 		int count = 0;
 
-		final boolean save = clusterExtension != null && !clusterExtension.isEmpty() && xmlFileName != null && !xmlFileName.isEmpty();
-
 		for ( final ViewId viewId : viewIds )
 		{
 			IOFunctions.println( "(" + new Date(System.currentTimeMillis()) + "): Extracting PSF for " + Group.pvid( viewId ) + " ... " );
@@ -171,7 +170,7 @@ public class PSF_Extract implements PlugIn
 
 				spimData.getPointSpreadFunctions().addPSF( viewId, new PointSpreadFunction( spimData, viewId, psf.getPSF() ) );
 				
-				if ( save )
+				if ( saveXml )
 					SpimData2.saveXML( spimData, xmlFileName, clusterExtension );
 			}
 		}


### PR DESCRIPTION
In #26 the ability to save xmls upon running PSF extraction or PSF assignment was introduced. However it has been poorly implemented and required cluster extension to be set. This pull request addresses that and makes sure that XMLs are always going to be saved unless run from a popup. The implementation took the interest point detection plugin as a template. Thank you very much @StephanPreibisch for reviewing the pull request.