### PR TITLE
updates dependencies to bigdataviewer-core 10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,10 +157,6 @@ like Selective Plane Illumination Microscopy (SPIM) Data.</description>
 
 		<!-- vistools temporary -->
 		<dependency>
-			<groupId>net.imglib2</groupId>
-			<artifactId>imglib2-ui</artifactId>
-		</dependency>
-		<dependency>
 			<!-- NB: dependency:analyze erroneously flags this, but it's required -->
 			<groupId>sc.fiji</groupId>
 			<artifactId>bigdataviewer-vistools</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>net.preibisch</groupId>
 	<artifactId>multiview-reconstruction</artifactId>
-	<version>0.9.2-SNAPSHOT</version>
+	<version>0.9.2-SNAPSHOT-BDVCORE10</version>
 
 	<name>Multiview Reconstruction</name>
 	<description>Software for the reconstruction of multi-view microscopic acquisitions

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,8 @@ like Selective Plane Illumination Microscopy (SPIM) Data.</description>
 
 		<multiview-simulation.version>0.2.0</multiview-simulation.version>
 
+		<bigdataviewer-core.version>10.0.2</bigdataviewer-core.version>
+		<bigdataviewer-vistools.version>1.0.0-beta-23</bigdataviewer-vistools.version>
 <!-- 
 		<bigdataviewer-core.version>9.0.6</bigdataviewer-core.version>
 		<imglib2.version>5.9.0</imglib2.version>

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/bdv/BDVFlyThrough.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/bdv/BDVFlyThrough.java
@@ -70,7 +70,7 @@ public class BDVFlyThrough
 
 	public static void addCurrentViewerTransform( final BigDataViewer bdv )
 	{
-		AffineTransform3D currentViewerTransform = bdv.getViewer().getDisplay().getTransformEventHandler().getTransform().copy();
+		AffineTransform3D currentViewerTransform = bdv.getViewer().state().getViewerTransform();
 		viewerTransforms.add( currentViewerTransform );
 		IOFunctions.println( "Added transform: " + currentViewerTransform  + ", #transforms=" + viewerTransforms.size() );
 	}
@@ -121,7 +121,7 @@ public class BDVFlyThrough
 		renderState.setViewerTransform( affine );
 
 		final MyRenderTarget target = new MyRenderTarget( width, height );
-		final MultiResolutionRenderer renderer = new MultiResolutionRenderer(
+		/*final MultiResolutionRenderer renderer = new MultiResolutionRenderer(
 				target, new PainterThread( null ), new double[] { 1 }, 0, false, 1, null, false,
 				viewer.getOptionValues().getAccumulateProjectorFactory(), new CacheControl.Dummy() );
 
@@ -131,7 +131,7 @@ public class BDVFlyThrough
 		renderScalebar( showScaleBar ? new ScaleBarOverlayRenderer() : null, target, renderState, width, height );
 		renderBoxes( showBoxes ? new MultiBoxOverlayRenderer( width, height ) : null, target, renderState, width, height );
 
-		new ImagePlus( "BDV Screenshot", new ColorProcessor( target.bi ) ).show();
+		new ImagePlus( "BDV Screenshot", new ColorProcessor( target.bi ) ).show();*/
 	}
 
 	public static void record( final BigDataViewer bdv )
@@ -209,7 +209,7 @@ public class BDVFlyThrough
 		final MultiBoxOverlayRenderer boxRender = defaultBoxes ? new MultiBoxOverlayRenderer( width, height ) : null;
 
 		final MyRenderTarget target = new MyRenderTarget( width, height );
-		final MultiResolutionRenderer renderer = new MultiResolutionRenderer(
+		/*final MultiResolutionRenderer renderer = new MultiResolutionRenderer(
 				target, new PainterThread( null ), new double[] { 1 }, 0, false, 1, null, false,
 				viewer.getOptionValues().getAccumulateProjectorFactory(), new CacheControl.Dummy() );
 
@@ -257,7 +257,7 @@ public class BDVFlyThrough
 
 		viewer.setCurrentViewerTransform( transforms.get( 0 ) );
 
-		IOFunctions.println( "Done" );
+		IOFunctions.println( "Done" );*/
 	}
 
 	protected static void renderScalebar( final ScaleBarOverlayRenderer scalebar, final MyRenderTarget target, final ViewerState renderState, final int width, final int height )

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/bdv/BDVFlyThrough.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/bdv/BDVFlyThrough.java
@@ -32,11 +32,14 @@ import javax.imageio.ImageIO;
 
 import bdv.BigDataViewer;
 import bdv.cache.CacheControl;
+import bdv.viewer.BasicViewerState;
 import bdv.viewer.ViewerPanel;
 import bdv.viewer.overlay.MultiBoxOverlayRenderer;
 import bdv.viewer.overlay.ScaleBarOverlayRenderer;
 import bdv.viewer.render.MultiResolutionRenderer;
-import bdv.viewer.state.ViewerState;
+import bdv.viewer.render.RenderTarget;
+import bdv.viewer.render.awt.BufferedImageRenderResult;
+import bdv.viewer.ViewerState;
 import fiji.util.gui.GenericDialogPlus;
 import ij.IJ;
 import ij.ImagePlus;
@@ -46,8 +49,6 @@ import net.imglib2.algorithm.gauss3.Gauss3;
 import net.imglib2.img.list.ListImg;
 import net.imglib2.img.list.ListLocalizingCursor;
 import net.imglib2.realtransform.AffineTransform3D;
-import net.imglib2.ui.PainterThread;
-import net.imglib2.ui.RenderTarget;
 import net.imglib2.view.Views;
 import net.preibisch.legacy.io.IOFunctions;
 import net.preibisch.mvrecon.process.fusion.transformed.nonrigid.grid.NumericAffineTransform3D;
@@ -84,7 +85,7 @@ public class BDVFlyThrough
 	public static void renderScreenshot( final BigDataViewer bdv )
 	{
 		final ViewerPanel viewer = bdv.getViewer();
-		final ViewerState renderState = viewer.getState();
+		final ViewerState renderState = new BasicViewerState( viewer.state().snapshot() );
 		final int canvasW = viewer.getDisplay().getWidth();
 		final int canvasH = viewer.getDisplay().getHeight();
 
@@ -121,17 +122,18 @@ public class BDVFlyThrough
 		renderState.setViewerTransform( affine );
 
 		final MyRenderTarget target = new MyRenderTarget( width, height );
-		/*final MultiResolutionRenderer renderer = new MultiResolutionRenderer(
-				target, new PainterThread( null ), new double[] { 1 }, 0, false, 1, null, false,
+		final MultiResolutionRenderer renderer = new MultiResolutionRenderer(
+				target, () -> {}, new double[] { 1 }, 0, 1, null, false,
 				viewer.getOptionValues().getAccumulateProjectorFactory(), new CacheControl.Dummy() );
 
 		renderer.requestRepaint();
 		renderer.paint( renderState );
+		final BufferedImage bi = target.renderResult.getBufferedImage();
 
-		renderScalebar( showScaleBar ? new ScaleBarOverlayRenderer() : null, target, renderState, width, height );
-		renderBoxes( showBoxes ? new MultiBoxOverlayRenderer( width, height ) : null, target, renderState, width, height );
+		renderScalebar( showScaleBar ? new ScaleBarOverlayRenderer() : null, bi, renderState, width, height );
+		renderBoxes( showBoxes ? new MultiBoxOverlayRenderer( width, height ) : null, bi, renderState, width, height );
 
-		new ImagePlus( "BDV Screenshot", new ColorProcessor( target.bi ) ).show();*/
+		new ImagePlus( "BDV Screenshot", new ColorProcessor( bi ) ).show();
 	}
 
 	public static void record( final BigDataViewer bdv )
@@ -189,13 +191,13 @@ public class BDVFlyThrough
 
 
 		final ViewerPanel viewer = bdv.getViewer();
-		final ViewerState renderState = viewer.getState();
+		final ViewerState renderState = new BasicViewerState( viewer.state().snapshot() );
 		final int canvasW = viewer.getDisplay().getWidth();
 		final int canvasH = viewer.getDisplay().getHeight();
 
 		final int width = canvasW;
 		final int height = canvasH;
-		
+
 		final AffineTransform3D affine = new AffineTransform3D();
 		renderState.getViewerTransform( affine );
 		affine.set( affine.get( 0, 3 ) - canvasW / 2, 0, 3 );
@@ -209,8 +211,8 @@ public class BDVFlyThrough
 		final MultiBoxOverlayRenderer boxRender = defaultBoxes ? new MultiBoxOverlayRenderer( width, height ) : null;
 
 		final MyRenderTarget target = new MyRenderTarget( width, height );
-		/*final MultiResolutionRenderer renderer = new MultiResolutionRenderer(
-				target, new PainterThread( null ), new double[] { 1 }, 0, false, 1, null, false,
+		final MultiResolutionRenderer renderer = new MultiResolutionRenderer(
+				target, () -> {}, new double[] { 1 }, 0, 1, null, false,
 				viewer.getOptionValues().getAccumulateProjectorFactory(), new CacheControl.Dummy() );
 
 		final ArrayList< AffineTransform3D > transforms = interpolateTransforms( viewerTransformsLocal, defaultMethod == 2, defaultSigma, interpolateSteps );
@@ -233,16 +235,17 @@ public class BDVFlyThrough
 
 			renderer.requestRepaint();
 			renderer.paint( renderState );
+			final BufferedImage bi = target.renderResult.getBufferedImage();
 
-			renderScalebar( scalebar, target, renderState, width, height );
-			renderBoxes( boxRender, target, renderState, width, height );
+			renderScalebar( scalebar, bi, renderState, width, height );
+			renderBoxes( boxRender, bi, renderState, width, height );
 
 			try
 			{
 				final File file = new File( String.format( "%s/img-%05d.png", dir, i ) );
 				IOFunctions.println( "Writing file: " + file.getAbsolutePath() );
 
-				ImageIO.write( target.bi, "png", file );
+				ImageIO.write( bi, "png", file );
 			}
 			catch ( IOException e )
 			{
@@ -255,27 +258,27 @@ public class BDVFlyThrough
 
 		IJ.showProgress( 1.0 );
 
-		viewer.setCurrentViewerTransform( transforms.get( 0 ) );
+		viewer.state().setViewerTransform( transforms.get( 0 ) );
 
-		IOFunctions.println( "Done" );*/
+		IOFunctions.println( "Done" );
 	}
 
-	protected static void renderScalebar( final ScaleBarOverlayRenderer scalebar, final MyRenderTarget target, final ViewerState renderState, final int width, final int height )
+	protected static void renderScalebar( final ScaleBarOverlayRenderer scalebar, final BufferedImage bi, final ViewerState renderState, final int width, final int height )
 	{
 		if ( scalebar != null )
 		{
-			final Graphics2D g2 = target.bi.createGraphics();
+			final Graphics2D g2 = bi.createGraphics();
 			g2.setClip( 0, 0, width, height );
 			scalebar.setViewerState( renderState );
 			scalebar.paint( g2 );
 		}
 	}
 
-	protected static void renderBoxes( final MultiBoxOverlayRenderer boxRender, final MyRenderTarget target, final ViewerState renderState, final int width, final int height )
+	protected static void renderBoxes( final MultiBoxOverlayRenderer boxRender, final BufferedImage bi, final ViewerState renderState, final int width, final int height )
 	{
 		if ( boxRender != null )
 		{
-			final Graphics2D g2 = target.bi.createGraphics();
+			final Graphics2D g2 = bi.createGraphics();
 			g2.setClip( 0, 0, width, height );
 			boxRender.setViewerState( renderState );
 			boxRender.paint( g2 );
@@ -368,9 +371,9 @@ public class BDVFlyThrough
 		}
 	}
 
-	static class MyRenderTarget implements RenderTarget
+	static class MyRenderTarget implements RenderTarget< BufferedImageRenderResult >
 	{
-		BufferedImage bi;
+		final BufferedImageRenderResult renderResult = new BufferedImageRenderResult();
 
 		final int width;
 		final int height;
@@ -382,11 +385,20 @@ public class BDVFlyThrough
 		}
 
 		@Override
-		public BufferedImage setBufferedImage( final BufferedImage bufferedImage )
+		public BufferedImageRenderResult getReusableRenderResult()
 		{
-			bi = bufferedImage;
-			return null;
+			return renderResult;
 		}
+
+		@Override
+		public BufferedImageRenderResult createRenderResult()
+		{
+			return new BufferedImageRenderResult();
+		}
+
+		@Override
+		public void setRenderResult( final BufferedImageRenderResult renderResult )
+		{}
 
 		@Override
 		public int getWidth()

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/interestpoint/InterestPointOverlay.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/interestpoint/InterestPointOverlay.java
@@ -30,8 +30,8 @@ import java.util.HashMap;
 
 import net.imglib2.RealLocalizable;
 import net.imglib2.realtransform.AffineTransform3D;
-import net.imglib2.ui.OverlayRenderer;
-import net.imglib2.ui.TransformListener;
+import bdv.viewer.OverlayRenderer;
+import bdv.viewer.TransformListener;
 import bdv.viewer.ViewerPanel;
 import mpicbg.spim.data.sequence.ViewId;
 

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/interestpoint/InterestPointTableModel.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/interestpoint/InterestPointTableModel.java
@@ -312,8 +312,8 @@ public class InterestPointTableModel extends AbstractTableModel implements Inter
 			{
 				final BigDataViewer bdv = bdvPopup.getBDV();
 				interestPointOverlay = new InterestPointOverlay( bdv.getViewer(), interestPointSources );
-				bdv.getViewer().addRenderTransformListener( interestPointOverlay );
-				bdv.getViewer().getDisplay().addOverlayRenderer( interestPointOverlay );
+				bdv.getViewer().renderTransformListeners().add( interestPointOverlay );
+				bdv.getViewer().getDisplay().overlays().add( interestPointOverlay );
 				bdvPopup.updateBDV();
 			}
 		}

--- a/src/main/java/net/preibisch/mvrecon/process/interestpointregistration/TransformationTools.java
+++ b/src/main/java/net/preibisch/mvrecon/process/interestpointregistration/TransformationTools.java
@@ -81,7 +81,7 @@ public class TransformationTools
 
 	public static void reCenterViews(final BigDataViewer viewer, final Collection<BasicViewDescription< ? >> selectedViews, final ViewRegistrations viewRegistrations)
 	{
-		AffineTransform3D currentViewerTransform = viewer.getViewer().getDisplay().getTransformEventHandler().getTransform().copy();
+		AffineTransform3D currentViewerTransform = viewer.getViewer().state().getViewerTransform();
 		final int cX = viewer.getViewer().getWidth() / 2; // size of the display area of the frame
 		final int cY = viewer.getViewer().getHeight() / 2; // size of the display area of the frame
 


### PR DESCRIPTION
Hello the BigStitcher team!

So this PR is the minimal amount of modifications needed to work with `bigdataviewer-core-10+`, on the multiview-reconstruction side.

There is a functionality which I couldn't fix  (`BDVFlyThrough`) because I don't know what the changes in `RenderTarget` are.