### PR TITLE
fix dialog "Parse angles from file pattern" too big on large datasets

### DIFF
--- a/src/main/java/net/preibisch/mvrecon/fiji/datasetmanager/FileListDatasetDefinition.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/datasetmanager/FileListDatasetDefinition.java
@@ -994,12 +994,19 @@ public class FileListDatasetDefinition implements MultiViewDatasetDefinition
 		if (state.getMultiplicityMap().get( Angle.class ).equals( CheckResult.SINGLE ) && fileVariableToUse.get( Angle.class ).size() == 1)
 		{
 			final GenericDialogPlus gdAnglesFromPattern = new GenericDialogPlus( "Parse Angles from file pattern" );
+			final List<String> seenAngles = new ArrayList<>();
 
 			StringBuilder sbAngleInfo = new StringBuilder();
 			sbAngleInfo.append( "<html>No metadata for sample rotation found, but numeric patterns for Angle in filenames:" );
 			sbAngleInfo.append( "<ul>" );
 			for (String s: patternDetector.getValuesForVariable( fileVariableToUse.get( Angle.class ).get( 0 ) ) )
-				sbAngleInfo.append( "<li>" + s + "</li>" );
+			{
+				if(!seenAngles.contains(s))
+				{
+    				seenAngles.add(s);
+    				sbAngleInfo.append( "<li>" + s + "</li>" );
+				}
+			}
 			sbAngleInfo.append( "</ul>You can choose to interpret the pattern as rotation angles."
 					+ "<br/>Please check \"apply angle rotation\" in the next step to apply rotations to data immediately" );
 			sbAngleInfo.append( "</html>" );


### PR DESCRIPTION
When automatic loader is used to define a new dataset with many files (i.e. many channels or timepoints or illuminations, etc) using file pattern recognition, the same angles are displayed repeatedly, making dialog box too big.  Cannot click "OK" since it is off the screen.  Patch only displays unique angles.

![Parse_02](https://user-images.githubusercontent.com/69379072/225646325-16b3430b-c372-465d-8094-e98b9bf7e3cf.PNG)
