### PR TITLE
Update to more recent bigdataviewer-core API (WIP)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>36.0.0</version>
+		<version>37.0.0</version>
 		<relativePath />
 	</parent>
 
@@ -105,12 +105,8 @@ like Selective Plane Illumination Microscopy (SPIM) Data.</description>
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>sign,deploy-to-scijava</releaseProfiles>
 
-		<imglib2.version>6.1.0</imglib2.version>
-		<imglib2-algorithm.version>0.13.2</imglib2-algorithm.version>
-		<imglib2-cache.version>1.0.0-beta-17</imglib2-cache.version>
-		<bigdataviewer-core.version>10.4.6</bigdataviewer-core.version>
-		<bigdataviewer-vistools.version>1.0.0-beta-32</bigdataviewer-vistools.version>
-		<n5-imglib2.version>5.0.0</n5-imglib2.version>
+		<bigdataviewer-core.version>10.4.12</bigdataviewer-core.version>
+		<bigdataviewer-vistools.version>1.0.0-beta-33</bigdataviewer-vistools.version>
 	</properties>
 
 	<repositories>

--- a/src/main/java/net/preibisch/mvrecon/fiji/datasetmanager/grid/RegularTranformHelpers.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/datasetmanager/grid/RegularTranformHelpers.java
@@ -264,8 +264,8 @@ public class RegularTranformHelpers
 	}
 
 	public static <AS extends AbstractSpimData<?> > void applyToSpimData(
-			AS data, 
-			List<? extends Group< ? extends BasicViewDescription< ? extends BasicViewSetup > > > viewDescriptions,
+			AS data,
+			List<? extends Group< ? extends BasicViewDescription< ? > > > viewDescriptions,
 			RegularTranslationParameters params,
 			boolean applyToAllTimePoints)
 	{
@@ -313,8 +313,8 @@ public class RegularTranformHelpers
 	}
 
 	private static <AS extends AbstractSpimData<?> > void applyToSpimDataSingleTP(
-			AS data, 
-			List< ? extends Group< ? extends BasicViewDescription< ? extends BasicViewSetup > > > viewDescriptions,
+			AS data,
+			List< ? extends Group< ? extends BasicViewDescription< ? > > > viewDescriptions,
 			RegularTranslationParameters params,
 			TimePoint tp)
 	{

--- a/src/main/java/net/preibisch/mvrecon/fiji/plugin/Data_Explorer.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/plugin/Data_Explorer.java
@@ -73,7 +73,7 @@ public class Data_Explorer implements PlugIn
 		final String xml = result.getXMLFileName();
 		final XmlIoSpimData2 io = result.getIO();
 
-		final ViewSetupExplorer< SpimData2, XmlIoSpimData2 > explorer = new ViewSetupExplorer<SpimData2, XmlIoSpimData2 >( data, xml, io );
+		final ViewSetupExplorer< SpimData2 > explorer = new ViewSetupExplorer<>( data, xml, io );
 
 		explorer.getFrame().toFront();
 	}

--- a/src/main/java/net/preibisch/mvrecon/fiji/plugin/Interest_Point_Detection.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/plugin/Interest_Point_Detection.java
@@ -66,7 +66,7 @@ public class Interest_Point_Detection implements PlugIn
 
 	public static boolean defaultGroupTiles = true;
 	public static boolean defaultGroupIllums = true;
-	public static ExplorerWindow< ?, ? > currentPanel;
+	public static ExplorerWindow< ? > currentPanel;
 
 	static
 	{

--- a/src/main/java/net/preibisch/mvrecon/fiji/plugin/Split_Views.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/plugin/Split_Views.java
@@ -86,7 +86,7 @@ public class Split_Views implements PlugIn
 
 		if ( display )
 		{
-			final ViewSetupExplorer< SpimData2, XmlIoSpimData2 > explorer = new ViewSetupExplorer<SpimData2, XmlIoSpimData2 >( newSD, saveAs, new XmlIoSpimData2( "" ) );
+			final ViewSetupExplorer< SpimData2 > explorer = new ViewSetupExplorer<>( newSD, saveAs, new XmlIoSpimData2( "" ) );
 			explorer.getFrame().toFront();
 		}
 		else

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/ExplorerWindow.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/ExplorerWindow.java
@@ -32,9 +32,9 @@ import mpicbg.spim.data.generic.sequence.BasicViewDescription;
 import mpicbg.spim.data.generic.sequence.BasicViewSetup;
 import mpicbg.spim.data.sequence.ViewId;
 
-public interface ExplorerWindow< AS extends AbstractSpimData< ? >, X extends XmlIoAbstractSpimData< ?, AS > >
+public interface ExplorerWindow< AS extends AbstractSpimData< ? > >
 {
-	public List< BasicViewDescription< ? extends BasicViewSetup > > selectedRows();
+	public List< BasicViewDescription< ? > > selectedRows();
 	public List< ViewId > selectedRowsViewId();
 	public AS getSpimData();
 	public void updateContent();
@@ -48,5 +48,5 @@ public interface ExplorerWindow< AS extends AbstractSpimData< ? >, X extends Xml
 	// BDV-specific
 	public BasicBDVPopup bdvPopup();
 	public boolean colorMode();
-	public BasicViewDescription< ? extends BasicViewSetup > firstSelectedVD();
+	public BasicViewDescription< ? > firstSelectedVD();
 }

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/FilteredAndGroupedExplorer.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/FilteredAndGroupedExplorer.java
@@ -27,19 +27,18 @@ import java.util.ArrayList;
 import javax.swing.JFrame;
 
 import mpicbg.spim.data.generic.AbstractSpimData;
-import mpicbg.spim.data.generic.XmlIoAbstractSpimData;
 
-public abstract class FilteredAndGroupedExplorer<AS extends AbstractSpimData< ? >, X extends XmlIoAbstractSpimData< ?, AS >>
+public abstract class FilteredAndGroupedExplorer<AS extends AbstractSpimData< ? > >
 {
 
 	protected JFrame frame;
-	protected FilteredAndGroupedExplorerPanel< AS, X > panel;
+	protected FilteredAndGroupedExplorerPanel< AS > panel;
 
 
 	public AS getSpimData()
 	{ return panel.getSpimData(); }
 
-	public FilteredAndGroupedExplorerPanel< AS, X > getPanel()
+	public FilteredAndGroupedExplorerPanel< AS > getPanel()
 	{ return panel; }
 
 	public JFrame getFrame()

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/FilteredAndGroupedExplorerPanel.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/FilteredAndGroupedExplorerPanel.java
@@ -69,10 +69,10 @@ import net.preibisch.mvrecon.fiji.spimdata.interestpoints.ViewInterestPointLists
 import net.preibisch.mvrecon.fiji.spimdata.interestpoints.ViewInterestPoints;
 import net.preibisch.mvrecon.process.interestpointregistration.TransformationTools;
 
-public abstract class FilteredAndGroupedExplorerPanel<AS extends AbstractSpimData< ? >, X extends XmlIoAbstractSpimData< ?, AS >>
-		extends JPanel implements ExplorerWindow< AS, X >, GroupedRowWindow
+public abstract class FilteredAndGroupedExplorerPanel<AS extends AbstractSpimData< ? > >
+		extends JPanel implements ExplorerWindow< AS >, GroupedRowWindow
 {
-	public static FilteredAndGroupedExplorerPanel< ?, ? > currentInstance = null;
+	public static FilteredAndGroupedExplorerPanel< ? > currentInstance = null;
 
 	protected ArrayList< ExplorerWindowSetable > popups;
 
@@ -89,18 +89,17 @@ public abstract class FilteredAndGroupedExplorerPanel<AS extends AbstractSpimDat
 	protected ISpimDataTableModel< AS > tableModel;
 	protected ArrayList< SelectedViewDescriptionListener< AS > > listeners;
 	protected AS data;
-	protected FilteredAndGroupedExplorer< AS, X > explorer;
+	protected FilteredAndGroupedExplorer< AS > explorer;
 	protected final String xml;
-	protected final X io;
+	protected final XmlIoAbstractSpimData< ?, AS > io;
 	protected final boolean isMac;
 	protected boolean colorMode = false;
-	
 
-	final protected HashSet< List<BasicViewDescription< ? extends BasicViewSetup >> > selectedRows;
+	final protected HashSet< List< BasicViewDescription< ? > > > selectedRows;
 	protected BasicViewDescription< ? extends BasicViewSetup > firstSelectedVD;
 
-	public FilteredAndGroupedExplorerPanel(final FilteredAndGroupedExplorer< AS, X > explorer, final AS data,
-			final String xml, final X io)
+	public FilteredAndGroupedExplorerPanel(final FilteredAndGroupedExplorer< AS > explorer, final AS data,
+			final String xml, final XmlIoAbstractSpimData< ?, AS > io)
 	{
 		
 		
@@ -165,12 +164,12 @@ public abstract class FilteredAndGroupedExplorerPanel<AS extends AbstractSpimDat
 		return xml;
 	}
 
-	public X io()
+	public XmlIoAbstractSpimData< ?, AS > io()
 	{
 		return io;
 	}
 
-	public FilteredAndGroupedExplorer< AS, X > explorer()
+	public FilteredAndGroupedExplorer< AS > explorer()
 	{
 		return explorer;
 	}
@@ -220,8 +219,8 @@ public abstract class FilteredAndGroupedExplorerPanel<AS extends AbstractSpimDat
 	{
 		this.listeners.add( listener );
 
-		List<List<BasicViewDescription< ? extends BasicViewSetup >>> selectedList = new ArrayList<>();
-		for (List<BasicViewDescription< ? extends BasicViewSetup >> selectedI : selectedRows)
+		List<List<BasicViewDescription<?>>> selectedList = new ArrayList<>();
+		for (List<BasicViewDescription<?>> selectedI : selectedRows)
 			selectedList.add( selectedI );
 		
 		listener.selectedViewDescriptions( selectedList );
@@ -238,7 +237,7 @@ public abstract class FilteredAndGroupedExplorerPanel<AS extends AbstractSpimDat
 	{
 		ArrayList<Entity> selectedInstances = new ArrayList<>();
 		selectedInstances.add( selectedInstance );
-		tableModel.addFilter( entityClass, selectedInstances );		
+		tableModel.addFilter( entityClass, selectedInstances );
 	}
 	
 	protected static List<String> getEntityNamesOrIds(List<? extends Entity> entities)
@@ -300,8 +299,9 @@ public abstract class FilteredAndGroupedExplorerPanel<AS extends AbstractSpimDat
 					selectedRows.add( tableModel.getElements().get( row ) );
 				}
 				
-				List<List<BasicViewDescription< ? extends BasicViewSetup >>> selectedList = new ArrayList<>();
-				for (List<BasicViewDescription< ? extends BasicViewSetup >> selectedI : selectedRows)
+
+				List<List<BasicViewDescription< ? >>> selectedList = new ArrayList<>();
+				for (List<BasicViewDescription< ? >> selectedI : selectedRows)
 					selectedList.add( selectedI );
 								
 				for ( int i = 0; i < listeners.size(); ++i )
@@ -385,7 +385,7 @@ public abstract class FilteredAndGroupedExplorerPanel<AS extends AbstractSpimDat
 	
 	public static void updateBDV(final BigDataViewer bdv, final boolean colorMode, final AbstractSpimData< ? > data,
 			BasicViewDescription< ? extends BasicViewSetup > firstVD,
-			final Collection< List< BasicViewDescription< ? extends BasicViewSetup >> > selectedRows)
+			final Collection< List< BasicViewDescription< ? > > > selectedRows )
 	{
 		
 		// bdv is not open
@@ -720,7 +720,7 @@ public abstract class FilteredAndGroupedExplorerPanel<AS extends AbstractSpimDat
 	public abstract ArrayList< ExplorerWindowSetable > initPopups();
 
 	@Override
-	public Collection< List< BasicViewDescription< ? extends BasicViewSetup > > > selectedRowsGroups()
+	public Collection< List< BasicViewDescription< ? > > > selectedRowsGroups()
 	{
 		return selectedRows;
 	}

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/FilteredAndGroupedExplorerPanel.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/FilteredAndGroupedExplorerPanel.java
@@ -32,6 +32,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
+import java.util.Set;
 import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
 import javax.swing.JTable;
@@ -97,7 +98,7 @@ public abstract class FilteredAndGroupedExplorerPanel< AS extends AbstractSpimDa
 	protected boolean colorMode = false;
 
 	final protected HashSet< List< BasicViewDescription< ? > > > selectedRows;
-	protected BasicViewDescription< ? extends BasicViewSetup > firstSelectedVD;
+	protected BasicViewDescription< ? > firstSelectedVD;
 
 	public FilteredAndGroupedExplorerPanel(final FilteredAndGroupedExplorer< AS > explorer, final AS data,
 			final String xml, final XmlIoAbstractSpimData< ?, AS > io)
@@ -373,7 +374,7 @@ public abstract class FilteredAndGroupedExplorerPanel< AS extends AbstractSpimDa
 			final BigDataViewer bdv,
 			final boolean colorMode,
 			final AbstractSpimData< ? > data,
-			BasicViewDescription< ? extends BasicViewSetup > firstVD,
+			BasicViewDescription< ? > firstVD,
 			final Collection< List< BasicViewDescription< ? > > > selectedRows )
 	{
 
@@ -399,7 +400,7 @@ public abstract class FilteredAndGroupedExplorerPanel< AS extends AbstractSpimDa
 
 		final boolean[] active = new boolean[data.getSequenceDescription().getViewSetupsOrdered().size()];
 
-		for ( final List< ? extends BasicViewDescription< ? extends BasicViewSetup > > vds : selectedRows )
+		for ( final List< ? extends BasicViewDescription< ? > > vds : selectedRows )
 			for ( BasicViewDescription< ? > vd : vds){
 				if ( vd.getTimePointId() == firstTP.getId() )
 					active[getBDVSourceIndex( vd.getViewSetup(), data )] = true;
@@ -477,7 +478,7 @@ public abstract class FilteredAndGroupedExplorerPanel< AS extends AbstractSpimDa
 		return 0;
 	}
 
-	public HashSet< List< BasicViewDescription< ? extends BasicViewSetup > > > getSelectedRows()
+	public Set< List< BasicViewDescription< ? > > > getSelectedRows()
 	{
 		return selectedRows;
 	}

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/FilteredAndGroupedTableModel.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/FilteredAndGroupedTableModel.java
@@ -57,8 +57,8 @@ public class FilteredAndGroupedTableModel < AS extends AbstractSpimData< ? > > e
 	private static final long serialVersionUID = -6526338840427674269L;
 
 	protected List< List< BasicViewDescription< ? > >> elements = null;
-	
-	final ExplorerWindow< AS, ? > panel;
+
+	final ExplorerWindow< AS > panel;
 	Set<Class<? extends Entity>> groupingFactors;
 	Map<Class<? extends Entity>, List<? extends Entity>> filters;
 	List<Class<? extends Entity>> columnClasses;
@@ -68,7 +68,7 @@ public class FilteredAndGroupedTableModel < AS extends AbstractSpimData< ? > > e
 	 * @see gui.ISpimDataTableModel#getPanel()
 	 */
 	@Override
-	public ExplorerWindow< AS, ? > getPanel() {
+	public ExplorerWindow< AS > getPanel() {
 		return panel;
 	}
 
@@ -155,7 +155,7 @@ public class FilteredAndGroupedTableModel < AS extends AbstractSpimData< ? > > e
 		return res;
 	}
 
-	public FilteredAndGroupedTableModel( final ExplorerWindow< AS, ? > panel )
+	public FilteredAndGroupedTableModel( final ExplorerWindow< AS > panel )
 	{
 		groupingFactors = new HashSet<>();
 		filters = new HashMap<>();

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/FilteredAndGroupedTableModel.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/FilteredAndGroupedTableModel.java
@@ -170,12 +170,12 @@ public class FilteredAndGroupedTableModel < AS extends AbstractSpimData< ? > > e
 		elements();
 	}
 
-	protected List<List< BasicViewDescription< ? extends BasicViewSetup > >> elements()
+	protected List<List< BasicViewDescription< ? > >> elements()
 	{
 		return elements(false);
 	}
 
-	protected List<List< BasicViewDescription< ? extends BasicViewSetup > >> elements( boolean forceUpdate )
+	protected List<List< BasicViewDescription< ? > >> elements( boolean forceUpdate )
 	{
 		if (!forceUpdate && elements != null)
 			return elements;
@@ -235,12 +235,12 @@ public class FilteredAndGroupedTableModel < AS extends AbstractSpimData< ? > > e
 	@Override
 	public Object getValueAt( final int row, final int column )
 	{
-		final List<BasicViewDescription< ? extends BasicViewSetup >> vds = elements().get( row );
+		final List<BasicViewDescription< ? >> vds = elements().get( row );
 
 		Class <? extends Entity> c = columnClasses.get(column);
 		final HashSet<Entity> entries = new HashSet<>();
-		
-		for (BasicViewDescription< ? extends BasicViewSetup > vd : vds)
+
+		for (BasicViewDescription< ? > vd : vds)
 		{
 			if ( c == TimePoint.class )
 				entries.add(vd.getTimePoint());

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/GroupedRowWindow.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/GroupedRowWindow.java
@@ -31,6 +31,6 @@ import mpicbg.spim.data.sequence.ViewId;
 
 public interface GroupedRowWindow
 {
-	public Collection<List< BasicViewDescription< ? extends BasicViewSetup > >> selectedRowsGroups();
+	public Collection< List< BasicViewDescription< ? > > > selectedRowsGroups();
 	public List<List< ViewId >> selectedRowsViewIdGroups();
 }

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/ISpimDataTableModel.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/ISpimDataTableModel.java
@@ -42,9 +42,9 @@ public interface ISpimDataTableModel<AS extends AbstractSpimData<?>> extends Tab
 	}
 	
 	public int getSpecialColumn(SpecialColumnType type);
-	
-	public ExplorerWindow< AS, ? > getPanel();
-	
+
+	public ExplorerWindow< AS > getPanel();
+
 	public Set<Class<? extends Entity>> getGroupingFactors();
 	
 	public void clearSortingFactors();
@@ -61,7 +61,7 @@ public interface ISpimDataTableModel<AS extends AbstractSpimData<?>> extends Tab
 
 	public Map<Class<? extends Entity> , List<? extends Entity>> getFilters();
 
-	public List<List< BasicViewDescription< ?  >> > getElements();
+	public List< List< BasicViewDescription< ? > > > getElements();
 
 	public void updateElements();
 

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/MissingViewsTableModelDecorator.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/MissingViewsTableModelDecorator.java
@@ -117,7 +117,7 @@ public class MissingViewsTableModelDecorator < AS extends AbstractSpimData< ? > 
 	}
 
 	@Override
-	public ExplorerWindow< AS, ? > getPanel()
+	public ExplorerWindow< AS > getPanel()
 	{
 		return decorated.getPanel();
 	}

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/MultiViewTableModelDecorator.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/MultiViewTableModelDecorator.java
@@ -244,7 +244,7 @@ public class MultiViewTableModelDecorator < AS extends AbstractSpimData< ? > > i
 	}
 
 	@Override
-	public ExplorerWindow<AS, ?> getPanel() { return decorated.getPanel(); }
+	public ExplorerWindow<AS> getPanel() { return decorated.getPanel(); }
 
 	@Override
 	public void setValueAt(Object aValue, int rowIndex, int columnIndex)

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/MultiViewTableModelDecorator.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/MultiViewTableModelDecorator.java
@@ -124,7 +124,7 @@ public class MultiViewTableModelDecorator < AS extends AbstractSpimData< ? > > i
 
 		if ( vds.size() == 1 )
 		{
-			final BasicViewDescription< ? extends BasicViewSetup > vd = vds.get( 0 );
+			final BasicViewDescription< ? > vd = vds.get( 0 );
 
 			if ( vd.isPresent() )
 			{

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/SelectedViewDescriptionListener.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/SelectedViewDescriptionListener.java
@@ -30,7 +30,7 @@ import java.util.List;
 public interface SelectedViewDescriptionListener< AS extends AbstractSpimData< ? > >
 {
 	//public void firstSelectedViewDescriptions( List< BasicViewDescription< ? extends BasicViewSetup > > viewDescriptions );
-	public void selectedViewDescriptions( List< List< BasicViewDescription< ? extends BasicViewSetup > > > viewDescriptions );
+	public void selectedViewDescriptions( List< List< BasicViewDescription< ? > > > viewDescriptions );
 	public void updateContent( final AS data );
 	public void save();
 	public void quit();

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/ViewSetupExplorer.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/ViewSetupExplorer.java
@@ -34,17 +34,17 @@ import net.preibisch.mvrecon.fiji.spimdata.explorer.popup.BasicBDVPopup;
 import mpicbg.spim.data.generic.AbstractSpimData;
 import mpicbg.spim.data.generic.XmlIoAbstractSpimData;
 
-public class ViewSetupExplorer< AS extends AbstractSpimData< ? >, X extends XmlIoAbstractSpimData< ?, AS > > extends FilteredAndGroupedExplorer< AS, X >
+public class ViewSetupExplorer< AS extends AbstractSpimData< ? > > extends FilteredAndGroupedExplorer< AS >
 {
 	public static final double xPos = 0.4;
 	public static final double yPos = 0.4;
 	public static final double xPosLog = 0.0;
 	public static final double yPosLog = 0.8;
 
-	public ViewSetupExplorer( final AS data, final String xml, final X io )
+	public ViewSetupExplorer( final AS data, final String xml, final XmlIoAbstractSpimData< ?, AS > io )
 	{
 		frame = new JFrame( "ViewSetup Explorer" );
-		panel = new ViewSetupExplorerPanel< AS, X >( this, data, xml, io, true );
+		panel = new ViewSetupExplorerPanel< AS >( this, data, xml, io, true );
 
 		frame.add( panel, BorderLayout.CENTER );
 		frame.setSize( panel.getPreferredSize() );

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/ViewSetupExplorerPanel.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/ViewSetupExplorerPanel.java
@@ -344,9 +344,9 @@ public class ViewSetupExplorerPanel< AS extends AbstractSpimData< ? > > extends 
 
 					selectedRows.add( tableModel.getElements().get( row ) );
 				}
-				
-				List<List<BasicViewDescription< ? extends BasicViewSetup >>> selectedList = new ArrayList<>();
-				for (List<BasicViewDescription< ? extends BasicViewSetup >> selectedI : selectedRows)
+
+				List<List<BasicViewDescription< ? >>> selectedList = new ArrayList<>();
+				for (List<BasicViewDescription< ? >> selectedI : selectedRows)
 					selectedList.add( selectedI );
 								
 				for ( int i = 0; i < listeners.size(); ++i )
@@ -415,8 +415,8 @@ public class ViewSetupExplorerPanel< AS extends AbstractSpimData< ? > > extends 
 	}
 	
 	public static void updateBDV(final BigDataViewer bdv, final boolean colorMode, final AbstractSpimData< ? > data,
-			BasicViewDescription< ? extends BasicViewSetup > firstVD,
-			final Collection< List< BasicViewDescription< ? extends BasicViewSetup >> > selectedRows)
+			BasicViewDescription< ? > firstVD,
+			final Collection< List< BasicViewDescription< ? >> > selectedRows)
 	{
 		// we always set the fused mode
 		setFusedModeSimple( bdv, data );

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/ViewSetupExplorerPanel.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/ViewSetupExplorerPanel.java
@@ -111,7 +111,7 @@ import net.preibisch.mvrecon.fiji.spimdata.interestpoints.ViewInterestPoints;
 import net.preibisch.mvrecon.process.interestpointregistration.pairwise.constellation.grouping.Group;
 
 
-public class ViewSetupExplorerPanel< AS extends AbstractSpimData< ? >, X extends XmlIoAbstractSpimData< ?, AS > > extends FilteredAndGroupedExplorerPanel< AS, X > implements ExplorerWindow< AS, X >
+public class ViewSetupExplorerPanel< AS extends AbstractSpimData< ? > > extends FilteredAndGroupedExplorerPanel< AS > implements ExplorerWindow< AS >
 {
 	private static final long serialVersionUID = -2512096359830259015L;
 
@@ -145,7 +145,7 @@ public class ViewSetupExplorerPanel< AS extends AbstractSpimData< ? >, X extends
 	@Override
 	public boolean channelsGrouped() { return false; }
 
-	public ViewSetupExplorerPanel( final FilteredAndGroupedExplorer< AS, X > explorer, final AS data, final String xml, final X io, boolean requestStartBDV )
+	public ViewSetupExplorerPanel( final FilteredAndGroupedExplorer< AS > explorer, final AS data, final String xml, final XmlIoAbstractSpimData< ?, AS > io, boolean requestStartBDV )
 	{
 		super( explorer, data, xml, io );
 

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/bdv/BDVUtils.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/bdv/BDVUtils.java
@@ -1,0 +1,40 @@
+package net.preibisch.mvrecon.fiji.spimdata.explorer.bdv;
+
+import bdv.AbstractSpimSource;
+import bdv.tools.transformation.TransformedSource;
+import bdv.viewer.Source;
+import bdv.viewer.SourceAndConverter;
+import java.util.Collection;
+import java.util.function.BiConsumer;
+
+public class BDVUtils
+{
+	public static void forEachAbstractSpimSource(
+			final Collection< ? extends SourceAndConverter< ? > > sources,
+			final BiConsumer< ? super SourceAndConverter< ? >, ? super AbstractSpimSource< ? > > action )
+	{
+		for ( final SourceAndConverter< ? > soc : sources )
+		{
+			Source< ? > source = soc.getSpimSource();
+
+			if ( source instanceof TransformedSource )
+				source = ( ( TransformedSource< ? > ) source ).getWrappedSource();
+
+			if ( source instanceof AbstractSpimSource )
+				action.accept( soc, ( AbstractSpimSource< ? > ) source );
+		}
+	}
+
+	public static void forEachTransformedSource(
+			final Collection< ? extends SourceAndConverter< ? > > sources,
+			final BiConsumer< ? super SourceAndConverter< ? >, ? super TransformedSource< ? > > action )
+	{
+		for ( final SourceAndConverter< ? > soc : sources )
+		{
+			Source< ? > source = soc.getSpimSource();
+
+			if ( source instanceof TransformedSource )
+				action.accept( soc, ( TransformedSource< ? > ) source );
+		}
+	}
+}

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/interestpoint/InterestPointExplorer.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/interestpoint/InterestPointExplorer.java
@@ -46,15 +46,15 @@ import net.preibisch.mvrecon.fiji.spimdata.explorer.SelectedViewDescriptionListe
 import net.preibisch.mvrecon.fiji.spimdata.explorer.popup.BasicBDVPopup;
 import net.preibisch.mvrecon.fiji.spimdata.interestpoints.InterestPoints;
 
-public class InterestPointExplorer< AS extends SpimData2, X extends XmlIoAbstractSpimData< ?, AS > >
+public class InterestPointExplorer< AS extends SpimData2 >
 	implements SelectedViewDescriptionListener< AS >
 {
 	final String xml;
 	final JFrame frame;
 	final InterestPointExplorerPanel panel;
-	final FilteredAndGroupedExplorer< AS, X > viewSetupExplorer;
+	final FilteredAndGroupedExplorer< AS > viewSetupExplorer;
 
-	public InterestPointExplorer( final String xml, final X io, final FilteredAndGroupedExplorer< AS, X > viewSetupExplorer )
+	public InterestPointExplorer( final String xml, final XmlIoAbstractSpimData< ?, AS > io, final FilteredAndGroupedExplorer< AS > viewSetupExplorer )
 	{
 		this.xml = xml;
 		this.viewSetupExplorer = viewSetupExplorer;

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/interestpoint/InterestPointExplorer.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/interestpoint/InterestPointExplorer.java
@@ -91,12 +91,12 @@ public class InterestPointExplorer< AS extends SpimData2 >
 	public JFrame frame() { return frame; }
 
 	@Override
-	public void selectedViewDescriptions( final List< List< BasicViewDescription< ? extends BasicViewSetup > > > viewDescriptions )
+	public void selectedViewDescriptions( final List< List< BasicViewDescription< ? > > > viewDescriptions )
 	{
-		final ArrayList< BasicViewDescription< ? extends BasicViewSetup > > fullList = new ArrayList<>();
+		final ArrayList< BasicViewDescription< ? > > fullList = new ArrayList<>();
 
-		for ( final List< BasicViewDescription< ? extends BasicViewSetup > > list : viewDescriptions )
-			for ( final BasicViewDescription< ? extends BasicViewSetup > vd : list )
+		for ( final List< BasicViewDescription< ? > > list : viewDescriptions )
+			for ( final BasicViewDescription< ? > vd : list )
 				if ( vd.isPresent() )
 					fullList.add( vd );
 

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/interestpoint/InterestPointExplorerPanel.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/interestpoint/InterestPointExplorerPanel.java
@@ -63,7 +63,7 @@ public class InterestPointExplorerPanel extends JPanel
 {
 	private static final long serialVersionUID = -3767947754096099774L;
 
-	final FilteredAndGroupedExplorer< ?, ? > viewSetupExplorer;
+	final FilteredAndGroupedExplorer< ? > viewSetupExplorer;
 
 	protected JTable table;
 	protected InterestPointTableModel tableModel;
@@ -73,7 +73,7 @@ public class InterestPointExplorerPanel extends JPanel
 	//protected ArrayList< Pair< InterestPointList, ViewId > > save;
 	protected ArrayList< Pair< InterestPoints, ViewId > > delete;
 
-	public InterestPointExplorerPanel( final ViewInterestPoints viewInterestPoints, final FilteredAndGroupedExplorer< ?, ? > viewSetupExplorer )
+	public InterestPointExplorerPanel( final ViewInterestPoints viewInterestPoints, final FilteredAndGroupedExplorer< ? > viewSetupExplorer )
 	{
 		//this.save = new ArrayList< Pair< InterestPointList, ViewId > >();
 		this.delete = new ArrayList< Pair< InterestPoints, ViewId > >();

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/interestpoint/InterestPointExplorerPanel.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/interestpoint/InterestPointExplorerPanel.java
@@ -84,12 +84,12 @@ public class InterestPointExplorerPanel extends JPanel
 
 	public InterestPointTableModel getTableModel() { return tableModel; }
 	public JTable getTable() { return table; }
-	
-	public void updateViewDescription( final List< BasicViewDescription< ? extends BasicViewSetup > > viewDescriptionsUnfiltered )
-	{
-		final ArrayList< BasicViewDescription< ? extends BasicViewSetup > > viewDescriptions = new ArrayList<>();
 
-		for ( final BasicViewDescription< ? extends BasicViewSetup > vd : viewDescriptionsUnfiltered )
+	public void updateViewDescription( final List< BasicViewDescription< ? > > viewDescriptionsUnfiltered )
+	{
+		final ArrayList< BasicViewDescription< ? > > viewDescriptions = new ArrayList<>();
+
+		for ( final BasicViewDescription< ? > vd : viewDescriptionsUnfiltered )
 			if ( vd.isPresent() )
 				viewDescriptions.add( vd );
 

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/ApplyTransformationPopup.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/ApplyTransformationPopup.java
@@ -47,7 +47,7 @@ public class ApplyTransformationPopup extends JMenuItem implements ExplorerWindo
 	private static final long serialVersionUID = 5234649267634013390L;
 	public static boolean showWarning = true;
 
-	ExplorerWindow< ?, ? > panel;
+	ExplorerWindow< ? > panel;
 
 	public ApplyTransformationPopup()
 	{
@@ -57,19 +57,19 @@ public class ApplyTransformationPopup extends JMenuItem implements ExplorerWindo
 	}
 
 	@Override
-	public JMenuItem setExplorerWindow( final ExplorerWindow< ?, ? > panel )
+	public JMenuItem setExplorerWindow( final ExplorerWindow< ? > panel )
 	{
 		this.panel = panel;
 		return this;
 	}
 
-	public static final List< ViewId > getSelectedViews( final ExplorerWindow< ?, ? > panel )
+	public static final List< ViewId > getSelectedViews( final ExplorerWindow< ? > panel )
 	{
 		return getSelectedViews( panel, true );
 	}
 
 	public static final List< ViewId > getSelectedViews(
-			final ExplorerWindow< ?, ? > panel,
+			final ExplorerWindow< ? > panel,
 			final boolean filterMissing )
 	{
 		final List< ViewId > viewIds = new ArrayList<>();

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/ApplyTransformationPopup.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/ApplyTransformationPopup.java
@@ -39,8 +39,6 @@ import net.preibisch.mvrecon.fiji.spimdata.explorer.ExplorerWindow;
 import net.preibisch.mvrecon.fiji.spimdata.explorer.GroupedRowWindow;
 
 import mpicbg.spim.data.SpimData;
-import mpicbg.spim.data.generic.AbstractSpimData;
-import mpicbg.spim.data.generic.sequence.AbstractSequenceDescription;
 import mpicbg.spim.data.sequence.ViewDescription;
 import mpicbg.spim.data.sequence.ViewId;
 
@@ -49,7 +47,7 @@ public class ApplyTransformationPopup extends JMenuItem implements ExplorerWindo
 	private static final long serialVersionUID = 5234649267634013390L;
 	public static boolean showWarning = true;
 
-	ExplorerWindow< ? extends AbstractSpimData< ? extends AbstractSequenceDescription< ?, ?, ? > >, ? > panel;
+	ExplorerWindow< ?, ? > panel;
 
 	public ApplyTransformationPopup()
 	{
@@ -59,20 +57,20 @@ public class ApplyTransformationPopup extends JMenuItem implements ExplorerWindo
 	}
 
 	@Override
-	public JMenuItem setExplorerWindow( final ExplorerWindow< ? extends AbstractSpimData< ? extends AbstractSequenceDescription< ?, ?, ? > >, ? > panel )
+	public JMenuItem setExplorerWindow( final ExplorerWindow< ?, ? > panel )
 	{
 		this.panel = panel;
 		return this;
 	}
 
-	public static final List< ViewId > getSelectedViews(
-			final ExplorerWindow< ? extends AbstractSpimData< ? extends AbstractSequenceDescription< ?, ?, ? > >, ? > panel)
+	public static final List< ViewId > getSelectedViews( final ExplorerWindow< ?, ? > panel )
 	{
 		return getSelectedViews( panel, true );
 	}
+
 	public static final List< ViewId > getSelectedViews(
-			final ExplorerWindow< ? extends AbstractSpimData< ? extends AbstractSequenceDescription< ?, ?, ? > >, ? > panel,
-			final boolean filterMissing)
+			final ExplorerWindow< ?, ? > panel,
+			final boolean filterMissing )
 	{
 		final List< ViewId > viewIds = new ArrayList<>();
 		if (GroupedRowWindow.class.isInstance( panel ))

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/BDVPopup.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/BDVPopup.java
@@ -78,7 +78,7 @@ public class BDVPopup extends JMenuItem implements ExplorerWindowSetable, BasicB
 	}
 
 	@Override
-	public JMenuItem setExplorerWindow( final ExplorerWindow< ? extends AbstractSpimData< ? >, ? > panel )
+	public JMenuItem setExplorerWindow( final ExplorerWindow< ?, ? > panel )
 	{
 		this.panel = panel;
 		return this;

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/BDVPopup.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/BDVPopup.java
@@ -70,7 +70,7 @@ public class BDVPopup extends JMenuItem implements ExplorerWindowSetable, BasicB
 {
 	private static final long serialVersionUID = 5234649267634013390L;
 
-	public ExplorerWindow< ?, ? > panel;
+	public ExplorerWindow< ? > panel;
 	public BigDataViewer bdv = null;
 
 	public BDVPopup()
@@ -81,7 +81,7 @@ public class BDVPopup extends JMenuItem implements ExplorerWindowSetable, BasicB
 	}
 
 	@Override
-	public JMenuItem setExplorerWindow( final ExplorerWindow< ?, ? > panel )
+	public JMenuItem setExplorerWindow( final ExplorerWindow< ? > panel )
 	{
 		this.panel = panel;
 		return this;
@@ -281,7 +281,7 @@ public class BDVPopup extends JMenuItem implements ExplorerWindowSetable, BasicB
 			return new Bounds( 0, 65535 );
 	}
 
-	public static BigDataViewer createBDV( final ExplorerWindow< ?, ? > panel )
+	public static BigDataViewer createBDV( final ExplorerWindow< ? > panel )
 	{
 		final BigDataViewer bdv = createBDV( panel.getSpimData(), panel.xml() );
 

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/BDVPopup.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/BDVPopup.java
@@ -78,7 +78,7 @@ public class BDVPopup extends JMenuItem implements ExplorerWindowSetable, BasicB
 	}
 
 	@Override
-	public JMenuItem setExplorerWindow( final ExplorerWindow< ?, ? > panel )
+	public JMenuItem setExplorerWindow( final ExplorerWindow< ? extends AbstractSpimData< ? >, ? > panel )
 	{
 		this.panel = panel;
 		return this;

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/BakeManualTransformationPopup.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/BakeManualTransformationPopup.java
@@ -24,7 +24,6 @@ package net.preibisch.mvrecon.fiji.spimdata.explorer.popup;
 
 import java.awt.event.ActionEvent;
 import java.util.ArrayList;
-import java.util.List;
 
 import javax.swing.JComponent;
 import javax.swing.JMenuItem;
@@ -33,8 +32,6 @@ import bdv.AbstractSpimSource;
 import bdv.tools.transformation.TransformedSource;
 import bdv.viewer.state.SourceState;
 import bdv.viewer.state.ViewerState;
-import mpicbg.spim.data.generic.AbstractSpimData;
-import mpicbg.spim.data.generic.sequence.AbstractSequenceDescription;
 import mpicbg.spim.data.registration.ViewRegistration;
 import mpicbg.spim.data.registration.ViewRegistrations;
 import mpicbg.spim.data.registration.ViewTransform;
@@ -44,8 +41,6 @@ import net.imglib2.realtransform.AffineTransform3D;
 import net.preibisch.legacy.io.IOFunctions;
 import net.preibisch.mvrecon.fiji.spimdata.SpimData2;
 import net.preibisch.mvrecon.fiji.spimdata.explorer.ExplorerWindow;
-import net.preibisch.mvrecon.fiji.spimdata.explorer.ViewSetupExplorerPanel;
-import net.preibisch.mvrecon.process.interestpointregistration.pairwise.constellation.grouping.Group;
 
 public class BakeManualTransformationPopup extends JMenuItem implements ExplorerWindowSetable
 {
@@ -61,7 +56,7 @@ public class BakeManualTransformationPopup extends JMenuItem implements Explorer
 	}
 
 	@Override
-	public JComponent setExplorerWindow( ExplorerWindow<? extends AbstractSpimData<? extends AbstractSequenceDescription<?, ?, ?>>, ?> panel )
+	public JComponent setExplorerWindow( ExplorerWindow< ?, ? > panel )
 	{
 		this.panel = panel;
 		return this;

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/BakeManualTransformationPopup.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/BakeManualTransformationPopup.java
@@ -46,7 +46,7 @@ public class BakeManualTransformationPopup extends JMenuItem implements Explorer
 {
 	private static final long serialVersionUID = 4627408819269954486L;
 
-	ExplorerWindow< ?, ? > panel;
+	ExplorerWindow< ? > panel;
 
 	public BakeManualTransformationPopup()
 	{
@@ -56,7 +56,7 @@ public class BakeManualTransformationPopup extends JMenuItem implements Explorer
 	}
 
 	@Override
-	public JComponent setExplorerWindow( ExplorerWindow< ?, ? > panel )
+	public JComponent setExplorerWindow( ExplorerWindow< ? > panel )
 	{
 		this.panel = panel;
 		return this;

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/BoundingBoxPopup.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/BoundingBoxPopup.java
@@ -42,7 +42,7 @@ public class BoundingBoxPopup extends JMenuItem implements ExplorerWindowSetable
 {
 	private static final long serialVersionUID = 5234649267634013390L;
 
-	ExplorerWindow< ?, ? > panel;
+	ExplorerWindow< ? > panel;
 
 	public BoundingBoxPopup()
 	{
@@ -52,7 +52,7 @@ public class BoundingBoxPopup extends JMenuItem implements ExplorerWindowSetable
 	}
 
 	@Override
-	public JComponent setExplorerWindow( ExplorerWindow<? extends AbstractSpimData<? extends AbstractSequenceDescription<?, ?, ?>>, ?> panel )
+	public JComponent setExplorerWindow( ExplorerWindow< ? > panel )
 	{
 		this.panel = panel;
 		return this;

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/DeconvolutionPopup.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/DeconvolutionPopup.java
@@ -39,7 +39,7 @@ public class DeconvolutionPopup extends JMenuItem implements ExplorerWindowSetab
 {
 	private static final long serialVersionUID = 5234649267634013390L;
 
-	ExplorerWindow< ?, ? > panel;
+	ExplorerWindow< ? > panel;
 
 	public DeconvolutionPopup()
 	{
@@ -49,7 +49,7 @@ public class DeconvolutionPopup extends JMenuItem implements ExplorerWindowSetab
 	}
 
 	@Override
-	public JMenuItem setExplorerWindow( final ExplorerWindow< ?, ? > panel )
+	public JMenuItem setExplorerWindow( final ExplorerWindow< ? > panel )
 	{
 		this.panel = panel;
 		return this;

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/DetectInterestPointsPopup.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/DetectInterestPointsPopup.java
@@ -39,7 +39,7 @@ public class DetectInterestPointsPopup extends JMenuItem implements ExplorerWind
 {
 	private static final long serialVersionUID = 5234649267634013390L;
 
-	ExplorerWindow< ?, ? > panel;
+	ExplorerWindow< ? > panel;
 
 	public DetectInterestPointsPopup()
 	{
@@ -49,7 +49,7 @@ public class DetectInterestPointsPopup extends JMenuItem implements ExplorerWind
 	}
 
 	@Override
-	public JMenuItem setExplorerWindow( final ExplorerWindow< ?, ? > panel )
+	public JMenuItem setExplorerWindow( final ExplorerWindow< ? > panel )
 	{
 		this.panel = panel;
 		return this;

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/DisplayFusedImagesPopup.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/DisplayFusedImagesPopup.java
@@ -71,7 +71,7 @@ public class DisplayFusedImagesPopup extends JMenu implements ExplorerWindowSeta
 
 	private static final long serialVersionUID = -4895470813542722644L;
 
-	ExplorerWindow< ?, ? > panel = null;
+	ExplorerWindow< ? > panel = null;
 
 	public DisplayFusedImagesPopup()
 	{
@@ -162,7 +162,7 @@ public class DisplayFusedImagesPopup extends JMenu implements ExplorerWindowSeta
 	}
 
 	@Override
-	public JMenuItem setExplorerWindow( final ExplorerWindow< ?, ? > panel )
+	public JMenuItem setExplorerWindow( final ExplorerWindow< ? > panel )
 	{
 		this.panel = panel;
 

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/DisplayRawImagesPopup.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/DisplayRawImagesPopup.java
@@ -42,7 +42,7 @@ public class DisplayRawImagesPopup extends JMenu implements ExplorerWindowSetabl
 	public static final int askWhenMoreThan = 5;
 	private static final long serialVersionUID = 5234649262342301390L;
 
-	ExplorerWindow< ?, ? > panel = null;
+	ExplorerWindow< ? > panel = null;
 
 	public DisplayRawImagesPopup()
 	{
@@ -59,7 +59,7 @@ public class DisplayRawImagesPopup extends JMenu implements ExplorerWindowSetabl
 	}
 
 	@Override
-	public JMenuItem setExplorerWindow( final ExplorerWindow< ?, ? > panel )
+	public JMenuItem setExplorerWindow( final ExplorerWindow< ? > panel )
 	{
 		this.panel = panel;
 

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/ExplorerWindowSetable.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/ExplorerWindowSetable.java
@@ -31,6 +31,6 @@ import mpicbg.spim.data.generic.sequence.AbstractSequenceDescription;
 
 public interface ExplorerWindowSetable
 {
-	public JComponent setExplorerWindow( final ExplorerWindow< ?, ? > panel );
+	public JComponent setExplorerWindow( final ExplorerWindow< ? > panel );
 }
 // AbstractSpimData< ? extends AbstractSequenceDescription< ?, ?, ? > >

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/ExplorerWindowSetable.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/ExplorerWindowSetable.java
@@ -31,6 +31,6 @@ import mpicbg.spim.data.generic.sequence.AbstractSequenceDescription;
 
 public interface ExplorerWindowSetable
 {
-	public JComponent setExplorerWindow( final ExplorerWindow< ? extends AbstractSpimData< ? extends AbstractSequenceDescription< ?, ?, ? > >, ? > panel );
+	public JComponent setExplorerWindow( final ExplorerWindow< ?, ? > panel );
 }
 // AbstractSpimData< ? extends AbstractSequenceDescription< ?, ?, ? > >

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/FlatFieldCorrectionPopup.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/FlatFieldCorrectionPopup.java
@@ -35,8 +35,6 @@ import javax.swing.JComponent;
 import javax.swing.JMenuItem;
 
 import fiji.util.gui.GenericDialogPlus;
-import mpicbg.spim.data.generic.AbstractSpimData;
-import mpicbg.spim.data.generic.sequence.AbstractSequenceDescription;
 import mpicbg.spim.data.sequence.Channel;
 import mpicbg.spim.data.sequence.Illumination;
 import mpicbg.spim.data.sequence.ImgLoader;
@@ -54,7 +52,7 @@ public class FlatFieldCorrectionPopup extends JMenuItem implements ExplorerWindo
 {
 
 	private static final long serialVersionUID = 950277697000203629L;
-	private ExplorerWindow< ? extends AbstractSpimData< ? extends AbstractSequenceDescription< ?, ?, ? > >, ? > panel;
+	private ExplorerWindow< ?, ? > panel;
 
 	public FlatFieldCorrectionPopup()
 	{
@@ -63,8 +61,7 @@ public class FlatFieldCorrectionPopup extends JMenuItem implements ExplorerWindo
 	}
 
 	@Override
-	public JComponent setExplorerWindow(
-			ExplorerWindow< ? extends AbstractSpimData< ? extends AbstractSequenceDescription< ?, ?, ? > >, ? > panel)
+	public JComponent setExplorerWindow( ExplorerWindow< ?, ? > panel )
 	{
 		this.panel = panel;
 		return this;

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/FlatFieldCorrectionPopup.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/FlatFieldCorrectionPopup.java
@@ -52,7 +52,7 @@ public class FlatFieldCorrectionPopup extends JMenuItem implements ExplorerWindo
 {
 
 	private static final long serialVersionUID = 950277697000203629L;
-	private ExplorerWindow< ?, ? > panel;
+	private ExplorerWindow< ? > panel;
 
 	public FlatFieldCorrectionPopup()
 	{
@@ -61,7 +61,7 @@ public class FlatFieldCorrectionPopup extends JMenuItem implements ExplorerWindo
 	}
 
 	@Override
-	public JComponent setExplorerWindow( ExplorerWindow< ?, ? > panel )
+	public JComponent setExplorerWindow( ExplorerWindow< ? > panel )
 	{
 		this.panel = panel;
 		return this;

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/FusionPopup.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/FusionPopup.java
@@ -39,7 +39,7 @@ public class FusionPopup extends JMenuItem implements ExplorerWindowSetable
 {
 	private static final long serialVersionUID = 5234649267634013390L;
 
-	ExplorerWindow< ?, ? > panel;
+	ExplorerWindow< ? > panel;
 
 	public FusionPopup()
 	{
@@ -49,7 +49,7 @@ public class FusionPopup extends JMenuItem implements ExplorerWindowSetable
 	}
 
 	@Override
-	public JMenuItem setExplorerWindow( final ExplorerWindow< ?, ? > panel )
+	public JMenuItem setExplorerWindow( final ExplorerWindow< ? > panel )
 	{
 		this.panel = panel;
 		return this;

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/IntensityAdjustmentPopup.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/IntensityAdjustmentPopup.java
@@ -43,7 +43,7 @@ public class IntensityAdjustmentPopup extends JMenu implements ExplorerWindowSet
 {
 	private static final long serialVersionUID = 1L;
 
-	ExplorerWindow< ?, ? > panel;
+	ExplorerWindow< ? > panel;
 
 	protected static String[] types = new String[]{ "Compute ...", "List all", "Remove" };
 
@@ -65,7 +65,7 @@ public class IntensityAdjustmentPopup extends JMenu implements ExplorerWindowSet
 	}
 
 	@Override
-	public JMenuItem setExplorerWindow( final ExplorerWindow< ?, ? > panel )
+	public JMenuItem setExplorerWindow( final ExplorerWindow< ? > panel )
 	{
 		this.panel = panel;
 		return this;

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/InterestPointsExplorerPopup.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/InterestPointsExplorerPopup.java
@@ -40,8 +40,8 @@ public class InterestPointsExplorerPopup extends JMenuItem implements ExplorerWi
 {
 	private static final long serialVersionUID = 5234649267634013390L;
 
-	ViewSetupExplorerPanel< ?, ? > panel;
-	InterestPointExplorer< ?, ? > ipe = null;
+	ViewSetupExplorerPanel< ? > panel;
+	InterestPointExplorer< ? > ipe = null;
 
 	public InterestPointsExplorerPopup()
 	{
@@ -52,9 +52,9 @@ public class InterestPointsExplorerPopup extends JMenuItem implements ExplorerWi
 
 
 	@Override
-	public JMenuItem setExplorerWindow( final ExplorerWindow< ?, ? > panel )
+	public JMenuItem setExplorerWindow( final ExplorerWindow< ? > panel )
 	{
-		this.panel = (ViewSetupExplorerPanel< ?, ? >)panel;
+		this.panel = (ViewSetupExplorerPanel< ? >)panel;
 		return this;
 	}
 
@@ -94,8 +94,8 @@ public class InterestPointsExplorerPopup extends JMenuItem implements ExplorerWi
 		}
 	}
 
-	private static final < AS extends SpimData2, X extends XmlIoAbstractSpimData< ?, AS > > InterestPointExplorer< AS, X > instanceFor( final FilteredAndGroupedExplorerPanel< AS, X > panel )
+	private static < AS extends SpimData2 > InterestPointExplorer< AS > instanceFor( final FilteredAndGroupedExplorerPanel< AS > panel )
 	{
-		return new InterestPointExplorer< AS, X >( panel.xml(), panel.io(), panel.explorer() );
+		return new InterestPointExplorer<>( panel.xml(), panel.io(), panel.explorer() );
 	}
 }

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/LabelPopUp.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/LabelPopUp.java
@@ -41,7 +41,7 @@ public class LabelPopUp extends JLabel implements ExplorerWindowSetable
 	}
 
 	@Override
-	public JLabel setExplorerWindow( final ExplorerWindow< ?, ? > panel )
+	public JLabel setExplorerWindow( final ExplorerWindow< ? > panel )
 	{
 		return this;
 	}

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/MaxProjectPopup.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/MaxProjectPopup.java
@@ -44,7 +44,7 @@ public class MaxProjectPopup extends JMenuItem implements ExplorerWindowSetable
 	private static final long serialVersionUID = 5234649267634013390L;
 	public static boolean showWarning = true;
 
-	ExplorerWindow< ? extends AbstractSpimData< ? extends AbstractSequenceDescription< ?, ?, ? > >, ? > panel;
+	ExplorerWindow< ?, ? > panel;
 
 	public MaxProjectPopup()
 	{
@@ -54,7 +54,7 @@ public class MaxProjectPopup extends JMenuItem implements ExplorerWindowSetable
 	}
 
 	@Override
-	public JMenuItem setExplorerWindow( final ExplorerWindow< ? extends AbstractSpimData< ? extends AbstractSequenceDescription< ?, ?, ? > >, ? > panel )
+	public JMenuItem setExplorerWindow( final ExplorerWindow< ?, ? > panel )
 	{
 		this.panel = panel;
 		return this;

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/MaxProjectPopup.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/MaxProjectPopup.java
@@ -44,7 +44,7 @@ public class MaxProjectPopup extends JMenuItem implements ExplorerWindowSetable
 	private static final long serialVersionUID = 5234649267634013390L;
 	public static boolean showWarning = true;
 
-	ExplorerWindow< ?, ? > panel;
+	ExplorerWindow< ? > panel;
 
 	public MaxProjectPopup()
 	{
@@ -54,7 +54,7 @@ public class MaxProjectPopup extends JMenuItem implements ExplorerWindowSetable
 	}
 
 	@Override
-	public JMenuItem setExplorerWindow( final ExplorerWindow< ?, ? > panel )
+	public JMenuItem setExplorerWindow( final ExplorerWindow< ? > panel )
 	{
 		this.panel = panel;
 		return this;

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/PointSpreadFunctionsPopup.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/PointSpreadFunctionsPopup.java
@@ -50,10 +50,10 @@ public class PointSpreadFunctionsPopup extends JMenu implements ExplorerWindowSe
 {
 	private static final long serialVersionUID = 1L;
 
-	ExplorerWindow< ?, ? > panel = null;
+	ExplorerWindow< ? > panel = null;
 
 	@Override
-	public JMenuItem setExplorerWindow( final ExplorerWindow< ?, ? > panel )
+	public JMenuItem setExplorerWindow( final ExplorerWindow< ? > panel )
 	{
 		this.panel = panel;
 

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/QualityPopup.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/QualityPopup.java
@@ -40,7 +40,7 @@ public class QualityPopup extends JMenuItem implements ExplorerWindowSetable
 {
 	private static final long serialVersionUID = 5234649267634013390L;
 
-	ExplorerWindow< ?, ? > panel;
+	ExplorerWindow< ? > panel;
 
 	public QualityPopup()
 	{
@@ -50,7 +50,7 @@ public class QualityPopup extends JMenuItem implements ExplorerWindowSetable
 	}
 
 	@Override
-	public JMenuItem setExplorerWindow( final ExplorerWindow< ?, ? > panel )
+	public JMenuItem setExplorerWindow( final ExplorerWindow< ? > panel )
 	{
 		this.panel = panel;
 		return this;

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/RegisterInterestPointsPopup.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/RegisterInterestPointsPopup.java
@@ -39,7 +39,7 @@ public class RegisterInterestPointsPopup extends JMenuItem implements ExplorerWi
 {
 	private static final long serialVersionUID = 5234649267634013390L;
 
-	ExplorerWindow< ?, ? > panel;
+	ExplorerWindow< ? > panel;
 
 	public RegisterInterestPointsPopup()
 	{
@@ -49,7 +49,7 @@ public class RegisterInterestPointsPopup extends JMenuItem implements ExplorerWi
 	}
 
 	@Override
-	public JMenuItem setExplorerWindow( final ExplorerWindow< ?, ? > panel )
+	public JMenuItem setExplorerWindow( final ExplorerWindow< ? > panel )
 	{
 		this.panel = panel;
 		return this;

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/RegistrationExplorerPopup.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/RegistrationExplorerPopup.java
@@ -41,8 +41,8 @@ public class RegistrationExplorerPopup extends JMenuItem implements ExplorerWind
 {
 	private static final long serialVersionUID = 5234649267634013390L;
 
-	FilteredAndGroupedExplorerPanel< ?, ? > panel;
-	RegistrationExplorer< ?, ? > re = null;
+	FilteredAndGroupedExplorerPanel< ? > panel;
+	RegistrationExplorer< ? > re = null;
 
 	public RegistrationExplorerPopup()
 	{
@@ -52,9 +52,9 @@ public class RegistrationExplorerPopup extends JMenuItem implements ExplorerWind
 	}
 
 	@Override
-	public JMenuItem setExplorerWindow( final ExplorerWindow< ?, ? > panel )
+	public JMenuItem setExplorerWindow( final ExplorerWindow< ? > panel )
 	{
-		this.panel = (FilteredAndGroupedExplorerPanel< ?, ? >)panel;
+		this.panel = ( FilteredAndGroupedExplorerPanel< ? > ) panel;
 		return this;
 	}
 
@@ -88,8 +88,8 @@ public class RegistrationExplorerPopup extends JMenuItem implements ExplorerWind
 		}
 	}
 
-	private static final < AS extends AbstractSpimData< ? >, X extends XmlIoAbstractSpimData< ?, AS > > RegistrationExplorer< AS, X > instanceFor( final FilteredAndGroupedExplorerPanel< AS, X > panel )
+	private static < AS extends AbstractSpimData< ? > > RegistrationExplorer< AS > instanceFor( final FilteredAndGroupedExplorerPanel< AS > panel )
 	{
-		return new RegistrationExplorer< AS, X >( panel.xml(), panel.io(), panel.explorer() );
+		return new RegistrationExplorer<>( panel.xml(), panel.io(), panel.explorer() );
 	}
 }

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/RemoveDetectionsPopup.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/RemoveDetectionsPopup.java
@@ -57,7 +57,7 @@ public class RemoveDetectionsPopup extends JMenu implements ExplorerWindowSetabl
 {
 	private static final long serialVersionUID = 1L;
 
-	ExplorerWindow< ?, ? > panel = null;
+	ExplorerWindow< ? > panel = null;
 
 	public static int defaultLabel = 0;
 	public static String defaultNewLabel = "Manually removed";
@@ -141,7 +141,7 @@ public class RemoveDetectionsPopup extends JMenu implements ExplorerWindowSetabl
 	}
 
 	@Override
-	public JMenuItem setExplorerWindow( final ExplorerWindow< ?, ? > panel )
+	public JMenuItem setExplorerWindow( final ExplorerWindow< ? > panel )
 	{
 		this.panel = panel;
 

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/RemoveTransformationPopup.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/RemoveTransformationPopup.java
@@ -42,7 +42,7 @@ public class RemoveTransformationPopup extends JMenu implements ExplorerWindowSe
 	public static final int askWhenMoreThan = 5;
 	private static final long serialVersionUID = 5234649267634013390L;
 
-	ExplorerWindow< ?, ? > panel;
+	ExplorerWindow< ? > panel;
 
 	protected static String[] types = new String[]{ "Latest/Newest Transformation", "First/Oldest Transformation" };
 
@@ -61,7 +61,7 @@ public class RemoveTransformationPopup extends JMenu implements ExplorerWindowSe
 	}
 
 	@Override
-	public JMenuItem setExplorerWindow( final ExplorerWindow< ?, ? > panel )
+	public JMenuItem setExplorerWindow( final ExplorerWindow< ? > panel )
 	{
 		this.panel = panel;
 		return this;

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/ReorientSamplePopup.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/ReorientSamplePopup.java
@@ -46,7 +46,7 @@ public class ReorientSamplePopup extends JMenuItem implements ExplorerWindowSeta
 	private static final long serialVersionUID = 5234649267634013390L;
 	public static boolean showWarning = true;
 
-	ExplorerWindow< ?, ? > panel;
+	ExplorerWindow< ? > panel;
 
 	public ReorientSamplePopup()
 	{
@@ -56,7 +56,7 @@ public class ReorientSamplePopup extends JMenuItem implements ExplorerWindowSeta
 	}
 
 	@Override
-	public JMenuItem setExplorerWindow( final ExplorerWindow< ?, ? > panel )
+	public JMenuItem setExplorerWindow( final ExplorerWindow< ? > panel )
 	{
 		this.panel = panel;
 		return this;

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/ReorientSamplePopup.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/ReorientSamplePopup.java
@@ -31,8 +31,6 @@ import javax.swing.JMenuItem;
 
 import bdv.BigDataViewer;
 import mpicbg.spim.data.SpimData;
-import mpicbg.spim.data.generic.AbstractSpimData;
-import mpicbg.spim.data.generic.sequence.AbstractSequenceDescription;
 import mpicbg.spim.data.sequence.ViewDescription;
 import mpicbg.spim.data.sequence.ViewId;
 import net.imglib2.realtransform.AffineTransform3D;
@@ -48,7 +46,7 @@ public class ReorientSamplePopup extends JMenuItem implements ExplorerWindowSeta
 	private static final long serialVersionUID = 5234649267634013390L;
 	public static boolean showWarning = true;
 
-	ExplorerWindow< ? extends AbstractSpimData< ? extends AbstractSequenceDescription< ?, ?, ? > >, ? > panel;
+	ExplorerWindow< ?, ? > panel;
 
 	public ReorientSamplePopup()
 	{
@@ -58,7 +56,7 @@ public class ReorientSamplePopup extends JMenuItem implements ExplorerWindowSeta
 	}
 
 	@Override
-	public JMenuItem setExplorerWindow( final ExplorerWindow< ? extends AbstractSpimData< ? extends AbstractSequenceDescription< ?, ?, ? > >, ? > panel )
+	public JMenuItem setExplorerWindow( final ExplorerWindow< ?, ? > panel )
 	{
 		this.panel = panel;
 		return this;

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/ResavePopup.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/ResavePopup.java
@@ -58,7 +58,7 @@ public class ResavePopup extends JMenu implements ExplorerWindowSetable
 	public static final int askWhenMoreThan = 5;
 	private static final long serialVersionUID = 5234649267634013390L;
 
-	FilteredAndGroupedExplorerPanel< ?, ? > panel;
+	FilteredAndGroupedExplorerPanel< ? > panel;
 
 	protected static String[] types = new String[]{ "As TIFF ...", "As compressed TIFF ...", "As HDF5 ...", "As compressed HDF5 ...", "As compressed N5 ..." };
 
@@ -86,9 +86,9 @@ public class ResavePopup extends JMenu implements ExplorerWindowSetable
 	}
 
 	@Override
-	public JMenuItem setExplorerWindow( ExplorerWindow< ?, ? > panel )
+	public JMenuItem setExplorerWindow( ExplorerWindow< ? > panel )
 	{
-		this.panel = ( FilteredAndGroupedExplorerPanel< ?, ? > ) panel;
+		this.panel = ( FilteredAndGroupedExplorerPanel< ? > ) panel;
 		return this;
 	}
 

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/ResavePopup.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/ResavePopup.java
@@ -25,10 +25,7 @@ package net.preibisch.mvrecon.fiji.spimdata.explorer.popup;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -38,22 +35,11 @@ import javax.swing.JMenu;
 import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
 
-import org.janelia.saalfeldlab.n5.GzipCompression;
-
 import bdv.export.ExportMipmapInfo;
 import bdv.export.ProgressWriter;
-import bdv.export.ProposeMipmaps;
-import bdv.export.WriteSequenceToHdf5;
-import bdv.export.ExportScalePyramid;
-import bdv.export.n5.WriteSequenceToN5;
 import bdv.img.n5.N5ImageLoader;
-import mpicbg.spim.data.generic.AbstractSpimData;
-import mpicbg.spim.data.generic.sequence.AbstractSequenceDescription;
 import mpicbg.spim.data.sequence.ViewId;
 import mpicbg.spim.data.sequence.ViewSetup;
-import net.imglib2.img.array.ArrayImgFactory;
-import net.imglib2.img.cell.CellImgFactory;
-import net.imglib2.type.numeric.real.FloatType;
 import net.preibisch.legacy.io.IOFunctions;
 import net.preibisch.mvrecon.fiji.ImgLib2Temp.Pair;
 import net.preibisch.mvrecon.fiji.plugin.resave.Generic_Resave_HDF5;
@@ -66,8 +52,6 @@ import net.preibisch.mvrecon.fiji.plugin.resave.Resave_TIFF.Parameters;
 import net.preibisch.mvrecon.fiji.spimdata.SpimData2;
 import net.preibisch.mvrecon.fiji.spimdata.explorer.ExplorerWindow;
 import net.preibisch.mvrecon.fiji.spimdata.explorer.FilteredAndGroupedExplorerPanel;
-import net.preibisch.mvrecon.fiji.spimdata.imgloaders.AbstractImgFactoryImgLoader;
-import net.preibisch.mvrecon.fiji.spimdata.imgloaders.MicroManagerImgLoader;
 
 public class ResavePopup extends JMenu implements ExplorerWindowSetable
 {
@@ -102,9 +86,9 @@ public class ResavePopup extends JMenu implements ExplorerWindowSetable
 	}
 
 	@Override
-	public JMenuItem setExplorerWindow(ExplorerWindow<? extends AbstractSpimData<? extends AbstractSequenceDescription<?, ?, ?>>, ?> panel )
+	public JMenuItem setExplorerWindow( ExplorerWindow< ?, ? > panel )
 	{
-		this.panel = (FilteredAndGroupedExplorerPanel< ?, ? >)panel;
+		this.panel = ( FilteredAndGroupedExplorerPanel< ?, ? > ) panel;
 		return this;
 	}
 

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/Separator.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/Separator.java
@@ -31,7 +31,7 @@ public class Separator extends JSeparator implements ExplorerWindowSetable
 	private static final long serialVersionUID = 5234649267634013390L;
 
 	@Override
-	public JSeparator setExplorerWindow( final ExplorerWindow< ?, ? > panel )
+	public JSeparator setExplorerWindow( final ExplorerWindow< ? > panel )
 	{
 		return this;
 	}

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/SimpleHyperlinkPopup.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/SimpleHyperlinkPopup.java
@@ -34,10 +34,7 @@ import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JMenuItem;
 
-import mpicbg.spim.data.generic.AbstractSpimData;
-import mpicbg.spim.data.generic.sequence.AbstractSequenceDescription;
 import net.preibisch.mvrecon.fiji.spimdata.explorer.ExplorerWindow;
-import net.preibisch.mvrecon.fiji.spimdata.explorer.popup.ExplorerWindowSetable;
 
 public class SimpleHyperlinkPopup extends JMenuItem implements ExplorerWindowSetable
 {
@@ -55,8 +52,7 @@ public class SimpleHyperlinkPopup extends JMenuItem implements ExplorerWindowSet
 	}
 
 	@Override
-	public JComponent setExplorerWindow(
-			ExplorerWindow< ? extends AbstractSpimData< ? extends AbstractSequenceDescription< ?, ?, ? > >, ? > panel)
+	public JComponent setExplorerWindow( ExplorerWindow< ?, ? > panel )
 	{
 		return this;
 	}

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/SimpleHyperlinkPopup.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/SimpleHyperlinkPopup.java
@@ -52,7 +52,7 @@ public class SimpleHyperlinkPopup extends JMenuItem implements ExplorerWindowSet
 	}
 
 	@Override
-	public JComponent setExplorerWindow( ExplorerWindow< ?, ? > panel )
+	public JComponent setExplorerWindow( ExplorerWindow< ? > panel )
 	{
 		return this;
 	}

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/SpecifyCalibrationPopup.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/SpecifyCalibrationPopup.java
@@ -45,7 +45,7 @@ public class SpecifyCalibrationPopup extends JMenuItem implements ExplorerWindow
 	private static final long serialVersionUID = 5234649267634013390L;
 	public static boolean showWarning = true;
 
-	ExplorerWindow< ? extends AbstractSpimData< ? extends AbstractSequenceDescription< ?, ?, ? > >, ? > panel;
+	ExplorerWindow< ?, ? > panel;
 
 	public SpecifyCalibrationPopup()
 	{
@@ -55,7 +55,7 @@ public class SpecifyCalibrationPopup extends JMenuItem implements ExplorerWindow
 	}
 
 	@Override
-	public JMenuItem setExplorerWindow( final ExplorerWindow< ? extends AbstractSpimData< ? extends AbstractSequenceDescription< ?, ?, ? > >, ? > panel )
+	public JMenuItem setExplorerWindow( final ExplorerWindow< ?, ? > panel )
 	{
 		this.panel = panel;
 		return this;

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/SpecifyCalibrationPopup.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/SpecifyCalibrationPopup.java
@@ -45,7 +45,7 @@ public class SpecifyCalibrationPopup extends JMenuItem implements ExplorerWindow
 	private static final long serialVersionUID = 5234649267634013390L;
 	public static boolean showWarning = true;
 
-	ExplorerWindow< ?, ? > panel;
+	ExplorerWindow< ? > panel;
 
 	public SpecifyCalibrationPopup()
 	{
@@ -55,7 +55,7 @@ public class SpecifyCalibrationPopup extends JMenuItem implements ExplorerWindow
 	}
 
 	@Override
-	public JMenuItem setExplorerWindow( final ExplorerWindow< ?, ? > panel )
+	public JMenuItem setExplorerWindow( final ExplorerWindow< ? > panel )
 	{
 		this.panel = panel;
 		return this;

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/VisualizeDetectionsPopup.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/VisualizeDetectionsPopup.java
@@ -34,15 +34,13 @@ import net.preibisch.mvrecon.fiji.plugin.Visualize_Detections.Params;
 import net.preibisch.mvrecon.fiji.spimdata.SpimData2;
 import net.preibisch.mvrecon.fiji.spimdata.explorer.ExplorerWindow;
 
-import mpicbg.spim.data.generic.AbstractSpimData;
-import mpicbg.spim.data.generic.sequence.AbstractSequenceDescription;
 import mpicbg.spim.data.sequence.ViewId;
 
 public class VisualizeDetectionsPopup extends JMenuItem implements ExplorerWindowSetable
 {
 	private static final long serialVersionUID = 5234649267634013390L;
 
-	ExplorerWindow< ? extends AbstractSpimData< ? extends AbstractSequenceDescription< ?, ?, ? > >, ? > panel;
+	ExplorerWindow< ?, ? > panel;
 
 	public VisualizeDetectionsPopup()
 	{
@@ -52,7 +50,7 @@ public class VisualizeDetectionsPopup extends JMenuItem implements ExplorerWindo
 	}
 
 	@Override
-	public JMenuItem setExplorerWindow( final ExplorerWindow< ? extends AbstractSpimData< ? extends AbstractSequenceDescription< ?, ?, ? > >, ? > panel )
+	public JMenuItem setExplorerWindow( final ExplorerWindow< ?, ? > panel )
 	{
 		this.panel = panel;
 		return this;

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/VisualizeDetectionsPopup.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/VisualizeDetectionsPopup.java
@@ -40,7 +40,7 @@ public class VisualizeDetectionsPopup extends JMenuItem implements ExplorerWindo
 {
 	private static final long serialVersionUID = 5234649267634013390L;
 
-	ExplorerWindow< ?, ? > panel;
+	ExplorerWindow< ? > panel;
 
 	public VisualizeDetectionsPopup()
 	{
@@ -50,7 +50,7 @@ public class VisualizeDetectionsPopup extends JMenuItem implements ExplorerWindo
 	}
 
 	@Override
-	public JMenuItem setExplorerWindow( final ExplorerWindow< ?, ? > panel )
+	public JMenuItem setExplorerWindow( final ExplorerWindow< ? > panel )
 	{
 		this.panel = panel;
 		return this;

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/VisualizeNonRigid.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/VisualizeNonRigid.java
@@ -69,7 +69,7 @@ public class VisualizeNonRigid extends JMenuItem implements ExplorerWindowSetabl
 {
 	private static final long serialVersionUID = -4858927229313796971L;
 
-	ExplorerWindow< ?, ? > panel;
+	ExplorerWindow< ? > panel;
 
 	final private static String[] displayOptions = new String[] {
 					"Overlay all views affine vs. non-rigid",
@@ -87,7 +87,7 @@ public class VisualizeNonRigid extends JMenuItem implements ExplorerWindowSetabl
 	}
 
 	@Override
-	public JMenuItem setExplorerWindow( final ExplorerWindow< ?, ? > panel )
+	public JMenuItem setExplorerWindow( final ExplorerWindow< ? > panel )
 	{
 		this.panel = panel;
 		return this;

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/VisualizeNonRigid.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/VisualizeNonRigid.java
@@ -69,7 +69,7 @@ public class VisualizeNonRigid extends JMenuItem implements ExplorerWindowSetabl
 {
 	private static final long serialVersionUID = -4858927229313796971L;
 
-	ExplorerWindow< ? extends AbstractSpimData< ? extends AbstractSequenceDescription< ?, ?, ? > >, ? > panel;
+	ExplorerWindow< ?, ? > panel;
 
 	final private static String[] displayOptions = new String[] {
 					"Overlay all views affine vs. non-rigid",
@@ -87,7 +87,7 @@ public class VisualizeNonRigid extends JMenuItem implements ExplorerWindowSetabl
 	}
 
 	@Override
-	public JMenuItem setExplorerWindow( final ExplorerWindow< ? extends AbstractSpimData< ? extends AbstractSequenceDescription< ?, ?, ? > >, ? > panel )
+	public JMenuItem setExplorerWindow( final ExplorerWindow< ?, ? > panel )
 	{
 		this.panel = panel;
 		return this;

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/registration/RegistrationExplorer.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/registration/RegistrationExplorer.java
@@ -40,15 +40,15 @@ import mpicbg.spim.data.generic.XmlIoAbstractSpimData;
 import mpicbg.spim.data.generic.sequence.BasicViewDescription;
 import mpicbg.spim.data.generic.sequence.BasicViewSetup;
 
-public class RegistrationExplorer< AS extends AbstractSpimData< ? >, X extends XmlIoAbstractSpimData< ?, AS > >
+public class RegistrationExplorer< AS extends AbstractSpimData< ? > >
 	implements SelectedViewDescriptionListener< AS >
 {
 	final String xml;
 	final JFrame frame;
 	final RegistrationExplorerPanel panel;
-	final FilteredAndGroupedExplorer< AS, X > viewSetupExplorer;
-	
-	public RegistrationExplorer( final String xml, final X io, final FilteredAndGroupedExplorer< AS, X > viewSetupExplorer )
+	final FilteredAndGroupedExplorer< AS > viewSetupExplorer;
+
+	public RegistrationExplorer( final String xml, final XmlIoAbstractSpimData< ?, AS > io, final FilteredAndGroupedExplorer< AS > viewSetupExplorer )
 	{
 		this.xml = xml;
 		this.viewSetupExplorer = viewSetupExplorer;

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/registration/RegistrationExplorer.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/registration/RegistrationExplorer.java
@@ -78,10 +78,10 @@ public class RegistrationExplorer< AS extends AbstractSpimData< ? > >
 	public void save() {}
 
 	@Override
-	public void selectedViewDescriptions( final List<List< BasicViewDescription< ? extends BasicViewSetup > >> viewDescriptions )
+	public void selectedViewDescriptions( final List<List< BasicViewDescription< ? > >> viewDescriptions )
 	{
-		List<BasicViewDescription< ? extends BasicViewSetup >> vdsFlat = new ArrayList<>();
-		for (List<BasicViewDescription< ? extends BasicViewSetup >> vdsI : viewDescriptions)
+		List<BasicViewDescription< ? >> vdsFlat = new ArrayList<>();
+		for (List<BasicViewDescription< ? >> vdsI : viewDescriptions)
 			vdsFlat.addAll( vdsI );
 		panel.updateViewDescriptions( vdsFlat );
 		System.out.println( viewDescriptions );

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/registration/RegistrationExplorerPanel.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/registration/RegistrationExplorerPanel.java
@@ -77,9 +77,9 @@ import net.imglib2.util.Pair;
 public class RegistrationExplorerPanel extends JPanel
 {
 	private static final long serialVersionUID = -3767947754096099774L;
-	
-	final RegistrationExplorer< ?, ? > explorer;
-	
+
+	final RegistrationExplorer< ? > explorer;
+
 	protected JTable table;
 	protected RegistrationTableModel tableModel;
 	protected JLabel label;
@@ -89,8 +89,8 @@ public class RegistrationExplorerPanel extends JPanel
 	protected List<BasicViewDescription<?>> lastSelectedVDs;
 	
 	protected ArrayList< ViewTransform > cache;
-	
-	public RegistrationExplorerPanel( final ViewRegistrations viewRegistrations, final RegistrationExplorer< ?, ? > explorer )
+
+	public RegistrationExplorerPanel( final ViewRegistrations viewRegistrations, final RegistrationExplorer< ? > explorer )
 	{
 		this.cache = new ArrayList< ViewTransform >();
 		this.explorer = explorer;

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/DHMImgLoader.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/DHMImgLoader.java
@@ -43,7 +43,7 @@ public class DHMImgLoader extends LegacyImgLoaderWrapper< UnsignedShortType, Leg
 			final String extension,
 			final int ampChannelId,
 			final int phaseChannelId,
-			final AbstractSequenceDescription< ? extends BasicViewSetup, ? extends BasicViewDescription< ? >, ? > sd )
+			final AbstractSequenceDescription< ?, ?, ? > sd )
 	{
 		super( new LegacyDHMImgLoader( directory, stackDir, amplitudeDir, phaseDir, timepoints, zPlanes, extension, ampChannelId, phaseChannelId, sd ) );
 	}

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/LegacyDHMImgLoader.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/LegacyDHMImgLoader.java
@@ -51,7 +51,7 @@ import util.ImgLib2Tools;
 public class LegacyDHMImgLoader extends AbstractImgLoader
 {
 	final File directory;
-	final AbstractSequenceDescription< ? extends BasicViewSetup, ? extends BasicViewDescription< ? >, ? > sd;
+	final AbstractSequenceDescription< ?, ?, ? > sd;
 	final List< String > timepoints;
 	final List< String > zPlanes;
 	final String stackDir;
@@ -71,7 +71,7 @@ public class LegacyDHMImgLoader extends AbstractImgLoader
 			final String extension,
 			final int ampChannelId,
 			final int phaseChannelId,
-			final AbstractSequenceDescription< ? extends BasicViewSetup, ? extends BasicViewDescription< ? >, ? > sd )
+			final AbstractSequenceDescription< ?, ?, ? > sd )
 	{
 		this.directory = directory;
 		this.stackDir = stackDir;

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/LegacyMicroManagerImgLoader.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/LegacyMicroManagerImgLoader.java
@@ -53,11 +53,11 @@ import util.ImgLib2Tools;
 public class LegacyMicroManagerImgLoader extends AbstractImgLoader
 {
 	final File mmFile;
-	final AbstractSequenceDescription< ? extends BasicViewSetup, ? extends BasicViewDescription< ? >, ? > sequenceDescription;
+	final AbstractSequenceDescription< ?, ?, ? > sequenceDescription;
 
 	public LegacyMicroManagerImgLoader(
 			final File mmFile,
-			final AbstractSequenceDescription< ? extends BasicViewSetup, ? extends BasicViewDescription< ? >, ? > sequenceDescription )
+			final AbstractSequenceDescription< ?, ?, ? > sequenceDescription )
 	{
 		super();
 		this.mmFile = mmFile;

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/MicroManagerImgLoader.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/MicroManagerImgLoader.java
@@ -34,7 +34,7 @@ public class MicroManagerImgLoader extends LegacyImgLoaderWrapper< UnsignedShort
 {
 	public MicroManagerImgLoader(
 			final File mmFile,
-			final AbstractSequenceDescription< ? extends BasicViewSetup, ? extends BasicViewDescription< ? >, ? > sequenceDescription )
+			final AbstractSequenceDescription< ?, ?, ? > sequenceDescription )
 	{
 		super( new LegacyMicroManagerImgLoader( mmFile, sequenceDescription ) );
 	}

--- a/src/main/java/net/preibisch/mvrecon/headless/splitting/TestSplitting.java
+++ b/src/main/java/net/preibisch/mvrecon/headless/splitting/TestSplitting.java
@@ -60,7 +60,7 @@ public class TestSplitting
 		SpimData2 newSD = SplittingTools.splitImages( spimData, new long[] { 30, 30, 10 }, new long[] { 200, 200, 40 } );
 		// drosophila with 1000 views
 
-		final ViewSetupExplorer< SpimData2, XmlIoSpimData2 > explorer = new ViewSetupExplorer<SpimData2, XmlIoSpimData2 >( newSD, fileOut, new XmlIoSpimData2( "" ) );
+		final ViewSetupExplorer< SpimData2 > explorer = new ViewSetupExplorer<>( newSD, fileOut, new XmlIoSpimData2( "" ) );
 		explorer.getFrame().toFront();
 	}
 

--- a/src/main/java/net/preibisch/mvrecon/process/deconvolution/util/ProcessInputImages.java
+++ b/src/main/java/net/preibisch/mvrecon/process/deconvolution/util/ProcessInputImages.java
@@ -66,7 +66,7 @@ import net.preibisch.mvrecon.process.interestpointregistration.pairwise.constell
 
 public class ProcessInputImages< V extends ViewId >
 {
-	final AbstractSpimData< ? extends AbstractSequenceDescription< ? extends BasicViewSetup, ? extends BasicViewDescription< ? >, ? extends BasicImgLoader > > spimData;
+	final AbstractSpimData< ? > spimData;
 	final ArrayList< Group< V > > groups;
 	final Interval bb;
 	Interval downsampledBB;
@@ -81,7 +81,7 @@ public class ProcessInputImages< V extends ViewId >
 	final Map< ? extends ViewId, AffineModel1D > intensityAdjustments;
 
 	public ProcessInputImages(
-			final AbstractSpimData< ? extends AbstractSequenceDescription< ? extends BasicViewSetup, ? extends BasicViewDescription< ? >, ? extends BasicImgLoader > > spimData,
+			final AbstractSpimData< ? > spimData,
 			final Collection< Group< V > > groups,
 			final ExecutorService service,
 			final Interval bb,
@@ -116,7 +116,7 @@ public class ProcessInputImages< V extends ViewId >
 	}
 
 	public ProcessInputImages(
-			final AbstractSpimData< ? extends AbstractSequenceDescription< ? extends BasicViewSetup, ? extends BasicViewDescription< ? >, ? extends BasicImgLoader > > spimData,
+			final AbstractSpimData< ? > spimData,
 			final Collection< Group< V > > groups,
 			final ExecutorService service,
 			final Interval bb,
@@ -131,7 +131,7 @@ public class ProcessInputImages< V extends ViewId >
 	}
 
 	public ProcessInputImages(
-			final AbstractSpimData< ? extends AbstractSequenceDescription< ? extends BasicViewSetup, ? extends BasicViewDescription< ? >, ? extends BasicImgLoader > > spimData,
+			final AbstractSpimData< ? > spimData,
 			final Collection< Group< V > > groups,
 			final ExecutorService service,
 			final Interval bb,
@@ -275,7 +275,7 @@ public class ProcessInputImages< V extends ViewId >
 	}
 
 	public static < V extends ViewId > Interval fuseGroups(
-			final AbstractSpimData< ? extends AbstractSequenceDescription< ? extends BasicViewSetup, ? extends BasicViewDescription< ? >, ? extends BasicImgLoader > > spimData,
+			final AbstractSpimData< ? > spimData,
 			final HashMap< Group< V >, RandomAccessibleInterval< FloatType > > tImgs,
 			final HashMap< Group< V >, RandomAccessibleInterval< FloatType > > tWeights,
 			final HashMap< V, AffineTransform3D > models,

--- a/src/main/java/net/preibisch/mvrecon/process/fusion/FusionTools.java
+++ b/src/main/java/net/preibisch/mvrecon/process/fusion/FusionTools.java
@@ -662,7 +662,7 @@ public class FusionTools
 	 * @param border - the target blending border, e.g. 0
 	 * @param transformationModel - the transformation model used to map from the (downsampled) input to the output
 	 */
-	public static void adjustBlending( final BasicViewDescription< ? extends BasicViewSetup > vd, final float[] blending, final float[] border, final AffineTransform3D transformationModel )
+	public static void adjustBlending( final BasicViewDescription< ? > vd, final float[] blending, final float[] border, final AffineTransform3D transformationModel )
 	{
 		adjustBlending( vd.getViewSetup().getSize(), Group.pvid( vd ), blending, border, transformationModel );
 	}
@@ -691,7 +691,7 @@ public class FusionTools
 	 * @param sigma2 - the target sigma2 for entropy approximation, e.g. 40
 	 * @param usedDownsampleFactors - the downsampling factors used to load the input image
 	 */
-	public static void adjustContentBased( final BasicViewDescription< ? extends BasicViewSetup > vd, final double[] sigma1, final double[] sigma2, final double[] usedDownsampleFactors )
+	public static void adjustContentBased( final BasicViewDescription< ? > vd, final double[] sigma1, final double[] sigma2, final double[] usedDownsampleFactors )
 	{
 		for ( int d = 0; d < sigma1.length; ++d )
 		{
@@ -700,7 +700,7 @@ public class FusionTools
 		}
 	}
 
-	public static double getMinRes( final BasicViewDescription< ? extends BasicViewSetup > desc )
+	public static double getMinRes( final BasicViewDescription< ? > desc )
 	{
 		final VoxelDimensions size = ViewSetupUtils.getVoxelSize( desc.getViewSetup() );
 


### PR DESCRIPTION
- Start replacing usage of `@Deprecated` BDV API
- Simplify generics:
    - remove unnecessary `X` type parameter in
       `ExplorerWindow<AS extends AbstractSpimData<?>, X extends XmlIoAbstractSpimData<?, AS>>`
       and downstream classes.
    - remove unnecessary bounds that are already implied by the super-type's generics, e.g.,
       `AbstractSpimData<? extends AbstractSequenceDescription<? extends BasicViewSetup, ? extends BasicViewDescription<?>, ? extends BasicImgLoader>>`
       adds nothing over `AbstractSpimData<?>`
- fix (hopefully) reloading of registrations in `BDVPopup`