### PR TITLE
Fix crazy Interactive DoG

### DIFF
--- a/src/main/java/net/preibisch/mvrecon/fiji/plugin/interestpointdetection/interactive/HelperFunctions.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/plugin/interestpointdetection/interactive/HelperFunctions.java
@@ -3,7 +3,7 @@
  * Software for the reconstruction of multi-view microscopic acquisitions
  * like Selective Plane Illumination Microscopy (SPIM) Data.
  * %%
- * Copyright (C) 2012 - 2024 Multiview Reconstruction developers.
+ * Copyright (C) 2012 - 2022 Multiview Reconstruction developers.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -110,18 +110,19 @@ public class HelperFunctions {
 
 		for (final L peak : peaks) {
 
-			// we only draw a 3d peak when it is +- 1.0 pixel away
-			if ( peak.numDimensions() > 2 && imp.getNSlices() > 1 )
-				if ( Math.abs( peak.getDoublePosition( 2 ) - currentSlice ) > 1.0 )
-					continue;
-
+			// determine Z distance from peak center and adjust scale radius
 			final float x = peak.getFloatPosition(0);
 			final float y = peak.getFloatPosition(1);
+			final float zDistance = Math.abs(peak.getFloatPosition(2) - currentSlice) + 1;
+			double drawRadius = 1.5 * radius / Math.sqrt( zDistance );
 
-			// +0.5 is to center in on the middle of the detection pixel
-			final OvalRoi or = new OvalRoi(x - radius + 0.5, y - radius + 0.5, radius * 2, radius * 2);
-			or.setStrokeColor(col);
-			overlay.add(or);
+			// only draw nearby peaks
+			if ( drawRadius > 0.67 )
+			{
+				final OvalRoi or = new OvalRoi(x - radius + 0.5, y - radius + 0.5, drawRadius * 2, drawRadius * 2);
+				or.setStrokeColor(col);
+				overlay.add(or);
+			}
 		}
 
 		// this part might be useful for debugging

--- a/src/main/java/net/preibisch/mvrecon/fiji/plugin/interestpointdetection/interactive/HelperFunctions.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/plugin/interestpointdetection/interactive/HelperFunctions.java
@@ -3,7 +3,7 @@
  * Software for the reconstruction of multi-view microscopic acquisitions
  * like Selective Plane Illumination Microscopy (SPIM) Data.
  * %%
- * Copyright (C) 2012 - 2022 Multiview Reconstruction developers.
+ * Copyright (C) 2012 - 2024 Multiview Reconstruction developers.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/net/preibisch/mvrecon/fiji/plugin/interestpointdetection/interactive/InteractiveDoG.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/plugin/interestpointdetection/interactive/InteractiveDoG.java
@@ -296,8 +296,8 @@ public class InteractiveDoG
 		}
 
 		final double radius = ( ( params.sigma + HelperFunctions.computeSigma2( params.sigma, sensitivity ) ) / 2.0 );
-		final ArrayList< RefinedPeak< Point > > filteredPeaksMax = HelperFunctions.filterPeaks( peaksMax, rectangle, params.threshold );
-		final ArrayList< RefinedPeak< Point > > filteredPeaksMin = HelperFunctions.filterPeaks( peaksMin, rectangle, params.threshold );
+		final ArrayList< RefinedPeak< Point > > filteredPeaksMax = HelperFunctions.filterPeaks( peaksMax, rectangle, params.threshold / 2.5 ); // correction factor of 2.5 applied to match thresholding in final DoG IP detection
+		final ArrayList< RefinedPeak< Point > > filteredPeaksMin = HelperFunctions.filterPeaks( peaksMin, rectangle, params.threshold / 2.5 ); // correction factor of 2.5 applied to match thresholding in
 
 		HelperFunctions.drawRealLocalizable( filteredPeaksMax, imagePlus, radius, Color.RED, true );
 		HelperFunctions.drawRealLocalizable( filteredPeaksMin, imagePlus, radius, Color.GREEN, false );

--- a/src/main/java/net/preibisch/mvrecon/fiji/plugin/interestpointdetection/interactive/InteractiveDoG.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/plugin/interestpointdetection/interactive/InteractiveDoG.java
@@ -104,7 +104,7 @@ public class InteractiveDoG
 	public static final float sigmaMin = 0.5f;
 	public static final float sigmaMax = 10f;
 	public static final float thresholdMin = 0.00001f;
-	public static final float thresholdMax = 1f;
+	public static final float thresholdMax = 0.3f;
 	
 	final int scrollbarSize = 1000;
 	// ----------------------------------------

--- a/src/main/java/net/preibisch/mvrecon/fiji/plugin/interestpointdetection/interactive/InteractiveDoG.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/plugin/interestpointdetection/interactive/InteractiveDoG.java
@@ -104,7 +104,7 @@ public class InteractiveDoG
 	public static final float sigmaMin = 0.5f;
 	public static final float sigmaMax = 10f;
 	public static final float thresholdMin = 0.00001f;
-	public static final float thresholdMax = 0.3f;
+	public static final float thresholdMax = 1f;
 	
 	final int scrollbarSize = 1000;
 	// ----------------------------------------
@@ -265,11 +265,11 @@ public class InteractiveDoG
 				min = new long []{
 						rectangle.x,
 						rectangle.y,
-						Math.max( imgTmp.min( 2 ), currentSlice - 1 ) };
+						Math.max( imgTmp.min( 2 ), currentSlice - (long) (2.5 * Math.ceil(params.sigma) ) ) };
 				max = new long []{
 						rectangle.width + rectangle.x - 1,
 						rectangle.height + rectangle.y - 1,
-						Math.min( imgTmp.max( 2 ), currentSlice + 1 ) };
+						Math.min( imgTmp.max( 2 ), currentSlice + (long) (2.5 * Math.ceil(params.sigma) ) ) };
 			}
 			else { // 2d or 2d+t case
 


### PR DESCRIPTION
Interactive DoG started behaving differently after 0.11.5, when code was migrated from legacy imglib1 to imglib2.algorithm.dog.DogDetection, approximately October 2022.  Unfortunately, interest point detection in the interactive window has changed, with odd and missing detections.  It is challenging to optimize sigma and threshold in real-time using this new interactive DoG, which is its main purpose.

The new imglib2 implementation computes a 3d DoG, which is desirable compared with the legacy's 2d algorithm.  But there are issues: 1. Only a narrow 3-slice interval of the stack is subjected to DoG computation, which dramatically lowers peak detection sensitivity except with very small sigmas; and 2. The interest point drawing function filtered away interest points more than one z slice away from the current slice, thereby eliminating even relatively close peak centers (again larger sigmas suffer more here). 3. Thresholding in the final Dog IP detection is more sensitive than what is displayed in interactive mode, resulting in far more peaks detected than expected.

The pull request fixes these issues by 1. making the Z interval for DoG computation dependent on sigma with sufficient excess; 2. adjusting the drawn peak radius for the Z distance from the peak; and 3. decreasing the threshold for filtered peaks to display in interactive mode, better matching what will occur when the final DoG IP detection is run.