### PR TITLE
Add UI support for blending range parameter

### DIFF
--- a/src/main/java/net/preibisch/mvrecon/fiji/plugin/Image_Fusion.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/plugin/Image_Fusion.java
@@ -216,6 +216,7 @@ public class Image_Fusion implements PlugIn
 						fusion.getNonRigidParameters().getAlpha(),
 						false,
 						fusion.getInterpolation(),
+						fusion.getBlendingRange(),
 						fusion.adjustIntensities() ? spimData.getIntensityAdjustments().getIntensityAdjustments() : null,
 						taskExecutor,
 						fusion.getBoundingBox(),
@@ -256,6 +257,7 @@ public class Image_Fusion implements PlugIn
 						spimData.getSequenceDescription().getViewDescriptions(),
 						fusion.getFusionType(),
 						fusion.getInterpolation(), // linear interpolatio
+						fusion.getBlendingRange(),
 						fusion.adjustIntensities() ? spimData.getIntensityAdjustments().getIntensityAdjustments() : null,
 						fusion.getBoundingBox(),
 						(RealType & NativeType)type,

--- a/src/main/java/net/preibisch/mvrecon/fiji/plugin/fusion/FusionGUI.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/plugin/fusion/FusionGUI.java
@@ -75,6 +75,7 @@ public class FusionGUI implements FusionExportInterface
 	public static int maxCacheSize = Integer.MAX_VALUE;
 
 	public static double defaultDownsampling = 1.0;
+	public static float defaultBlendingRange = 40;
 	public static int defaultBB = 0;
 
 	public static String[] interpolationTypes = new String[]{ "Nearest Neighbor", "Linear Interpolation" };
@@ -114,6 +115,7 @@ public class FusionGUI implements FusionExportInterface
 	protected double max = defaultMax;
 	protected int splittingType = defaultSplittingType;
 	protected double downsampling = defaultDownsampling;
+	protected float blendingRange = defaultBlendingRange;
 	protected int fusionType = defaultFusionType;
 	protected boolean adjustIntensities = defaultAdjustIntensities;
 	protected boolean preserveAnisotropy = defaultPreserveAnisotropy;
@@ -204,6 +206,8 @@ public class FusionGUI implements FusionExportInterface
 
 	@Override
 	public double getDownsampling(){ return downsampling; }
+
+	public float getBlendingRange(){ return blendingRange; }
 
 	public FusionType getFusionType() { return FusionType.values()[ fusionType ]; }
 
@@ -312,6 +316,8 @@ public class FusionGUI implements FusionExportInterface
 		gd.addSlider( "Downsampling", 1.0, 16.0, defaultDownsampling );
 		downsampleField = PluginHelper.isHeadless() ? null : (TextField)gd.getNumericFields().lastElement();
 
+		gd.addNumericField("Blending_range", defaultBlendingRange);
+
 		gd.addChoice( "Interpolation", interpolationTypes, interpolationTypes[ defaultInterpolation ] );
 
 		gd.addChoice( "Fusion_type", fusionTypes, fusionTypes[ defaultFusionType ] );
@@ -412,6 +418,8 @@ public class FusionGUI implements FusionExportInterface
 		if ( downsampling == 1.0 )
 			downsampling = Double.NaN;
 
+		blendingRange = defaultBlendingRange = (float) gd.getNextNumber();
+
 		interpolation = defaultInterpolation = gd.getNextChoiceIndex();
 		fusionType = defaultFusionType = gd.getNextChoiceIndex();
 		pixelType = defaultPixelType = gd.getNextChoiceIndex();
@@ -460,6 +468,7 @@ public class FusionGUI implements FusionExportInterface
 
 		IOFunctions.println( new Date( System.currentTimeMillis() ) + ": Selected Fusion Parameters: " );
 		IOFunctions.println( "Downsampling: " + DownsampleTools.printDownsampling( getDownsampling() ) );
+		IOFunctions.println( "BlendingRange: " + blendingRange );
 		IOFunctions.println( "BoundingBox: " + getBoundingBox() );
 		IOFunctions.println( "DownsampledBoundingBox: " + getDownsampledBoundingBox() );
 		IOFunctions.println( "PixelType: " + pixelTypes1[ getPixelType() ] );

--- a/src/main/java/net/preibisch/mvrecon/fiji/plugin/interactive/MultiResolutionTools.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/plugin/interactive/MultiResolutionTools.java
@@ -85,7 +85,7 @@ public class MultiResolutionTools
 			final int maxDS,
 			final int dsInc )
 	{
-		return createMultiResolutionNonRigid( spimData, viewsToFuse, viewsToUse, labels, FusionType.AVG_BLEND, false, controlPointDistance, 1.0, 1, boundingBox, null, service, minDS, maxDS, dsInc );
+		return createMultiResolutionNonRigid( spimData, viewsToFuse, viewsToUse, labels, FusionType.AVG_BLEND, false, controlPointDistance, 1.0, 1, FusionTools.defaultBlendingRange, boundingBox, null, service, minDS, maxDS, dsInc );
 	}
 
 	public static ArrayList< Pair< RandomAccessibleInterval< FloatType >, AffineTransform3D > > createMultiResolutionNonRigid(
@@ -98,6 +98,7 @@ public class MultiResolutionTools
 			final long controlPointDistance,
 			final double alpha,
 			final int interpolation,
+			final float blendingRange,
 			final Interval boundingBox,
 			final Map< ? extends ViewId, AffineModel1D > intensityAdjustments,
 			final ExecutorService service,
@@ -125,7 +126,7 @@ public class MultiResolutionTools
 
 		final Map< ViewId, ? extends BasicViewDescription< ? > > viewDescriptions = spimData.getSequenceDescription().getViewDescriptions();
 
-		return createMultiResolutionNonRigid( imgLoader, viewRegistrations, spimData.getViewInterestPoints().getViewInterestPoints(), viewDescriptions, viewsToFuse, viewsToUse, labels, fusionType, displayDistances, controlPointDistance, alpha, interpolation, boundingBox, intensityAdjustments, service, minDS, maxDS, dsInc );
+		return createMultiResolutionNonRigid( imgLoader, viewRegistrations, spimData.getViewInterestPoints().getViewInterestPoints(), viewDescriptions, viewsToFuse, viewsToUse, labels, fusionType, displayDistances, controlPointDistance, alpha, interpolation, blendingRange, boundingBox, intensityAdjustments, service, minDS, maxDS, dsInc );
 	}
 
 	public static ArrayList< Pair< RandomAccessibleInterval< FloatType >, AffineTransform3D > > createMultiResolutionNonRigid(
@@ -141,6 +142,7 @@ public class MultiResolutionTools
 			final long controlPointDistance,
 			final double alpha,
 			final int interpolation,
+			final float blendingRange,
 			final Interval boundingBox,
 			final Map< ? extends ViewId, AffineModel1D > intensityAdjustments,
 			final ExecutorService service,
@@ -197,6 +199,7 @@ public class MultiResolutionTools
 							fusionType,
 							displayDistances,
 							interpolation,
+							blendingRange,
 							intensityAdjustments,
 							NonRigidTools.defaultOverlapExpansion( uniquePointsData.getB() ) );
 
@@ -236,7 +239,7 @@ public class MultiResolutionTools
 				spimData.getSequenceDescription().getImgLoader(),
 				registrations,
 				spimData.getSequenceDescription().getViewDescriptions(),
-				viewIds, FusionType.AVG_BLEND, 1, boundingBox, null, minDS, maxDS, dsInc );
+				viewIds, FusionType.AVG_BLEND, 1, FusionTools.defaultBlendingRange, boundingBox, null, minDS, maxDS, dsInc );
 	}
 
 	public static ArrayList< Pair< RandomAccessibleInterval< FloatType >, AffineTransform3D > > createMultiResolutionAffine(
@@ -246,6 +249,7 @@ public class MultiResolutionTools
 			final Collection< ? extends ViewId > views,
 			final FusionType fusionType,
 			final int interpolation,
+			final float blendingRange,
 			final Interval boundingBox,
 			final Map< ? extends ViewId, AffineModel1D > intensityAdjustments,
 			final int minDS,
@@ -277,6 +281,7 @@ public class MultiResolutionTools
 									views,
 									fusionType,
 									interpolation,
+									blendingRange,
 									pair.getA(), // bounding box
 									intensityAdjustments ),
 							pair.getB() ) );

--- a/src/main/java/net/preibisch/mvrecon/fiji/plugin/interestpointdetection/DifferenceOfGUI.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/plugin/interestpointdetection/DifferenceOfGUI.java
@@ -696,6 +696,7 @@ public abstract class DifferenceOfGUI extends InterestPointDetectionGUI
 				group.getViews(),
 				FusionType.FIRST,
 				DisplayFusedImagesPopup.defaultInterpolation,
+				FusionTools.defaultBlendingRange,
 				bbDS,
 				null );
 

--- a/src/main/java/net/preibisch/mvrecon/headless/boundingbox/TestRealDataBoundingBox.java
+++ b/src/main/java/net/preibisch/mvrecon/headless/boundingbox/TestRealDataBoundingBox.java
@@ -78,6 +78,6 @@ public class TestRealDataBoundingBox
 
 		service.shutdown();
 
-		FusionTools.displayCopy( FusionTools.fuseVirtual( spimData, viewIds, FusionType.AVG_BLEND, 1, bb, null ), estimation.getMinIntensity(), estimation.getMaxIntensity() ).show();
+		FusionTools.displayCopy( FusionTools.fuseVirtual( spimData, viewIds, FusionType.AVG_BLEND, 1, FusionTools.defaultBlendingRange, bb, null ), estimation.getMinIntensity(), estimation.getMaxIntensity() ).show();
 	}
 }

--- a/src/main/java/net/preibisch/mvrecon/headless/fusion/TestIntensityAdjustment.java
+++ b/src/main/java/net/preibisch/mvrecon/headless/fusion/TestIntensityAdjustment.java
@@ -150,14 +150,14 @@ public class TestIntensityAdjustment
 						spimData.getSequenceDescription().getImgLoader(),
 						registrations,
 						spimData.getSequenceDescription().getViewDescriptions(),
-						viewIds, FusionType.AVG, 1, bb, intensityMapping );
+						viewIds, FusionType.AVG, 1, FusionTools.defaultBlendingRange, bb, intensityMapping );
 
 		final RandomAccessibleInterval< FloatType > virtual =
 				FusionTools.fuseVirtual(
 						spimData.getSequenceDescription().getImgLoader(),
 						registrations,
 						spimData.getSequenceDescription().getViewDescriptions(),
-						viewIds, FusionType.AVG, 1, bb, null );
+						viewIds, FusionType.AVG, 1, FusionTools.defaultBlendingRange, bb, null );
 
 		//
 		// actually fuse into an image multithreaded

--- a/src/main/java/net/preibisch/mvrecon/headless/fusion/TestNonRigid.java
+++ b/src/main/java/net/preibisch/mvrecon/headless/fusion/TestNonRigid.java
@@ -154,6 +154,7 @@ public class TestNonRigid
 		labels.add( "nuclei" );
 
 		final int interpolation = 1;
+		final float blendingRange = 40;
 		final long[] controlPointDistance = new long[] { cpd, cpd, cpd };
 		final double alpha = 1.0;
 		final boolean virtualGrid = false;
@@ -192,6 +193,7 @@ public class TestNonRigid
 						alpha,
 						virtualGrid,
 						interpolation,
+						blendingRange,
 						boundingBox,
 						null,
 						service );

--- a/src/main/java/net/preibisch/mvrecon/process/boundingbox/BoundingBoxMinFilterThreshold.java
+++ b/src/main/java/net/preibisch/mvrecon/process/boundingbox/BoundingBoxMinFilterThreshold.java
@@ -122,7 +122,7 @@ public class BoundingBoxMinFilterThreshold implements BoundingBoxEstimation
 								spimData.getSequenceDescription().getImgLoader(),
 								registrations,
 								spimData.getSequenceDescription().getViewDescriptions(),
-								views, FusionType.AVG_BLEND, 1, maxBBDS, null ),
+								views, FusionType.AVG_BLEND, 1, FusionTools.defaultBlendingRange, maxBBDS, null ),
 						new ArrayImgFactory<>( new FloatType() ),
 						new FloatType(),
 						service );

--- a/src/main/java/net/preibisch/mvrecon/process/fusion/FusionTools.java
+++ b/src/main/java/net/preibisch/mvrecon/process/fusion/FusionTools.java
@@ -228,7 +228,7 @@ public class FusionTools
 			final FusionType fusionType,
 			final Interval bb )
 	{
-		return fuseVirtual( imgloader, registrations, viewDescriptions, views, fusionType, 1, bb, null );
+		return fuseVirtual( imgloader, registrations, viewDescriptions, views, fusionType, 1, FusionTools.defaultBlendingRange, bb, null );
 	}
 
 	/**
@@ -268,7 +268,7 @@ public class FusionTools
 			final Interval bb,
 			final Map< ? extends ViewId, AffineModel1D > intensityAdjustments )
 	{
-		return fuseVirtual( spimData, viewIds, fusionType, 1, bb, intensityAdjustments );
+		return fuseVirtual( spimData, viewIds, fusionType, 1, FusionTools.defaultBlendingRange, bb, intensityAdjustments );
 	}
 
 	public static RandomAccessibleInterval< FloatType > fuseVirtual(
@@ -276,6 +276,7 @@ public class FusionTools
 			final Collection< ? extends ViewId > views,
 			final FusionType fusionType,
 			final int interpolation,
+			final float blendingRange,
 			final Interval boundingBox,
 			final Map< ? extends ViewId, AffineModel1D > intensityAdjustments )
 	{
@@ -292,7 +293,7 @@ public class FusionTools
 
 		final Map< ViewId, ? extends BasicViewDescription< ? > > viewDescriptions = spimData.getSequenceDescription().getViewDescriptions();
 
-		return fuseVirtual( imgLoader, registrations, viewDescriptions, views, fusionType, interpolation, boundingBox, intensityAdjustments );
+		return fuseVirtual( imgLoader, registrations, viewDescriptions, views, fusionType, interpolation, blendingRange, boundingBox, intensityAdjustments );
 	}
 
 	/**
@@ -395,6 +396,7 @@ public class FusionTools
 			final Collection< ? extends ViewId > views,
 			final FusionType fusionType, // see FusionGUI.fusionTypes[]{"Avg", "Avg, Blending", "Avg, Content Based", "Avg, Blending & Content Based", "Max", "First Tile Wins"}
 			final int interpolation,
+			final float blendingRange,
 			final Interval boundingBox, // is already downsampled
 			//final double downsampling,
 			final Map< ? extends ViewId, AffineModel1D > intensityAdjustments )
@@ -503,7 +505,7 @@ public class FusionTools
 				// instantiate blending if necessary
 				if ( fusionType == FusionType.AVG_BLEND || fusionType == FusionType.AVG_BLEND_CONTENT )
 				{
-					final float[] blending = Util.getArrayFromValue( defaultBlendingRange, 3 );
+					final float[] blending = Util.getArrayFromValue( blendingRange, 3 );
 					final float[] border = Util.getArrayFromValue( defaultBlendingBorder, 3 );
 
 					// TODO: this is wrong, since the blending is applied to the input images

--- a/src/main/java/net/preibisch/mvrecon/process/fusion/blk/BlkAffineFusion.java
+++ b/src/main/java/net/preibisch/mvrecon/process/fusion/blk/BlkAffineFusion.java
@@ -75,6 +75,7 @@ public class BlkAffineFusion
 			final Map< ViewId, ? extends BasicViewDescription< ? > > viewDescriptions,
 			final FusionType fusionType,
 			final int interpolationMethod,
+			final float blendingRange,
 			final Map< ViewId, AffineModel1D > intensityAdjustments,
 			final Interval fusionInterval,
 			final T type,
@@ -90,7 +91,7 @@ public class BlkAffineFusion
 		if ( !supports( is2d, fusionType, intensityAdjustments ) )
 		{
 			IOFunctions.println( "BlkAffineFusion: Fusion method not supported (yet). Falling back to LazyAffineFusion." );
-			return LazyAffineFusion.init( converter, imgloader, viewIds, viewRegistrations, viewDescriptions, fusionType, interpolationMethod, intensityAdjustments, fusionInterval, type, blockSize );
+			return LazyAffineFusion.init( converter, imgloader, viewIds, viewRegistrations, viewDescriptions, fusionType, interpolationMethod, blendingRange, intensityAdjustments, fusionInterval, type, blockSize );
 		}
 
 		final HashMap< ViewId, Dimensions > viewDimensions = LazyFusionTools.assembleDimensions( viewIds, viewDescriptions );

--- a/src/main/java/net/preibisch/mvrecon/process/fusion/lazy/LazyAffineFusion.java
+++ b/src/main/java/net/preibisch/mvrecon/process/fusion/lazy/LazyAffineFusion.java
@@ -76,6 +76,7 @@ public class LazyAffineFusion<T extends RealType<T> & NativeType<T>> implements 
 
 	final FusionType fusionType;
 	final int interpolation;
+	final float blendingRange;
 	final Map< ViewId, AffineModel1D > intensityAdjustments;
 
 	/**
@@ -89,6 +90,7 @@ public class LazyAffineFusion<T extends RealType<T> & NativeType<T>> implements 
 	 * @param viewDescriptions - the viewdescriptions
 	 * @param fusionType - how to combine pixels
 	 * @param interpolation - 1==linear, 0==nearest neighbor
+	 * @param blendingRange - the pixels at the boundary across which to blend
 	 * @param intensityAdjustments - intensity adjustments, can be null
 	 * @param globalMin - the output RAI typically sits at 0,0...0 because it usually is a CachedCellImage (but the actual interval to process in many blocks sits somewhere else)
 	 * @param type - which type to fuse
@@ -101,6 +103,7 @@ public class LazyAffineFusion<T extends RealType<T> & NativeType<T>> implements 
 			final Map< ViewId, ? extends BasicViewDescription< ? > > viewDescriptions,
 			final FusionType fusionType,
 			final int interpolation,
+			final float blendingRange,
 			final Map< ViewId, AffineModel1D > intensityAdjustments,
 			final long[] globalMin,
 			final T type )
@@ -116,6 +119,7 @@ public class LazyAffineFusion<T extends RealType<T> & NativeType<T>> implements 
 		this.viewDescriptions = viewDescriptions;
 		this.fusionType = fusionType;
 		this.interpolation = interpolation;
+		this.blendingRange = blendingRange;
 		this.intensityAdjustments = intensityAdjustments;
 	}
 
@@ -136,6 +140,7 @@ public class LazyAffineFusion<T extends RealType<T> & NativeType<T>> implements 
 						viewIds,
 						fusionType,
 						interpolation, // linear interpolation
+						blendingRange,
 						targetBlock,
 						intensityAdjustments ); // intensity adjustments
 
@@ -173,6 +178,7 @@ public class LazyAffineFusion<T extends RealType<T> & NativeType<T>> implements 
 			final Map< ViewId, ? extends BasicViewDescription< ? > > viewDescriptions,
 			final FusionType fusionType,
 			final int interpolation,
+			final float blendingRange,
 			final Map< ViewId, AffineModel1D > intensityAdjustments,
 			final Interval fusionInterval,
 			final T type,
@@ -187,6 +193,7 @@ public class LazyAffineFusion<T extends RealType<T> & NativeType<T>> implements 
 						viewDescriptions,
 						fusionType,
 						interpolation,
+						blendingRange,
 						intensityAdjustments,
 						fusionInterval.minAsLongArray(),
 						type.createVariable() );
@@ -232,6 +239,7 @@ public class LazyAffineFusion<T extends RealType<T> & NativeType<T>> implements 
 				data.getSequenceDescription().getViewDescriptions(),
 				FusionType.AVG_BLEND,
 				1, // linear interpolatio
+				FusionTools.defaultBlendingRange,
 				null, // intensity adjustment
 				bb,
 				new FloatType(),

--- a/src/main/java/net/preibisch/mvrecon/process/fusion/lazy/LazyNonRigidFusion.java
+++ b/src/main/java/net/preibisch/mvrecon/process/fusion/lazy/LazyNonRigidFusion.java
@@ -85,6 +85,7 @@ public class LazyNonRigidFusion <T extends RealType<T> & NativeType<T>> implemen
 	final FusionType fusionType;
 	final boolean displayDistances;
 	final int interpolation;
+	final float blendingRange;
 	final Map< ? extends ViewId, AffineModel1D > intensityAdjustments;
 
 	final double maxDist;
@@ -108,6 +109,7 @@ public class LazyNonRigidFusion <T extends RealType<T> & NativeType<T>> implemen
 			final double alpha,
 			final boolean virtualGrid,
 			final int interpolation,
+			final float blendingRange,
 			final Map< ? extends ViewId, AffineModel1D > intensityAdjustments,
 			final ExecutorService service,
 			final Interval boundingBox,
@@ -121,6 +123,7 @@ public class LazyNonRigidFusion <T extends RealType<T> & NativeType<T>> implemen
 		this.fusionType = fusionType;
 		this.displayDistances = displayDistances;
 		this.interpolation = interpolation;
+		this.blendingRange = blendingRange;
 		this.intensityAdjustments = intensityAdjustments;
 
 		this.converter = converter;
@@ -173,6 +176,7 @@ public class LazyNonRigidFusion <T extends RealType<T> & NativeType<T>> implemen
 						fusionType,
 						displayDistances,
 						interpolation,
+						blendingRange,
 						intensityAdjustments,
 						NonRigidTools.defaultOverlapExpansion( maxDist ) );
 
@@ -210,6 +214,7 @@ public class LazyNonRigidFusion <T extends RealType<T> & NativeType<T>> implemen
 			final double alpha,
 			final boolean virtualGrid,
 			final int interpolation,
+			final float blendingRange,
 			final Map< ? extends ViewId, AffineModel1D > intensityAdjustments,
 			final ExecutorService service,
 			final Interval fusionInterval,
@@ -232,6 +237,7 @@ public class LazyNonRigidFusion <T extends RealType<T> & NativeType<T>> implemen
 						alpha,
 						virtualGrid,
 						interpolation,
+						blendingRange,
 						intensityAdjustments,
 						service,
 						fusionInterval,
@@ -263,6 +269,7 @@ public class LazyNonRigidFusion <T extends RealType<T> & NativeType<T>> implemen
 		final int cpd = Math.max( 1, (int)Math.round( 10 / ds ) );
 		final List< String > labels = Arrays.asList("nuclei"); //"beads13", "beads" 
 		final int interpolation = 1;
+		final float blendingRange = 40;
 		final long[] controlPointDistance = new long[] { cpd, cpd, cpd };
 		final double alpha = 1.0;
 		final boolean virtualGrid = false;
@@ -300,6 +307,7 @@ public class LazyNonRigidFusion <T extends RealType<T> & NativeType<T>> implemen
 				alpha,
 				virtualGrid,
 				interpolation,
+				blendingRange,
 				null,
 				service,
 				boundingBox,

--- a/src/main/java/net/preibisch/mvrecon/process/fusion/transformed/nonrigid/NonRigidTools.java
+++ b/src/main/java/net/preibisch/mvrecon/process/fusion/transformed/nonrigid/NonRigidTools.java
@@ -96,6 +96,7 @@ public class NonRigidTools
 			final double alpha,
 			final boolean virtualGrid,
 			final int interpolation,
+			final float blendingRange,
 			final Interval boundingBox1,
 			final Map< ? extends ViewId, AffineModel1D > intensityAdjustments,
 			final ExecutorService service )
@@ -134,6 +135,7 @@ public class NonRigidTools
 				alpha,
 				virtualGrid,
 				interpolation,
+				blendingRange,
 				boundingBox1,
 				intensityAdjustments,
 				service );
@@ -153,6 +155,7 @@ public class NonRigidTools
 			final double alpha,
 			final boolean virtualGrid,
 			final int interpolation,
+			final float blendingRange,
 			final Interval boundingBox,
 			final Map< ? extends ViewId, AffineModel1D > intensityAdjustments,
 			final ExecutorService service )
@@ -200,6 +203,7 @@ public class NonRigidTools
 						fusionType,
 						displayDistances,
 						interpolation,
+						blendingRange,
 						intensityAdjustments,
 						defaultOverlapExpansion( uniquePointsData.getB() ) );
 
@@ -313,6 +317,7 @@ public class NonRigidTools
 			final FusionType fusionType,
 			final boolean displayDistances,
 			final int interpolation,
+			final float blendingRange,
 			final Map< ? extends ViewId, AffineModel1D > intensityAdjustments,
 			final int overlapExpansion )
 	{
@@ -411,7 +416,7 @@ public class NonRigidTools
 				// instantiate blending if necessary
 				if ( fusionType == FusionType.AVG_BLEND || fusionType == FusionType.AVG_BLEND_CONTENT )
 				{
-					final float[] blending = Util.getArrayFromValue( FusionTools.defaultBlendingRange, 3 );
+					final float[] blending = Util.getArrayFromValue( (float) blendingRange, 3 );
 					final float[] border = Util.getArrayFromValue( FusionTools.defaultBlendingBorder, 3 );
 
 					// adjust both for z-scaling (anisotropy), downsampling, and registrations itself


### PR DESCRIPTION
By default, when fusing tiles, only `40` pixels around the border of tiles are blended together. In my case, I often have much more overlap and so blending of `40` still leaves pretty clear boundaries between tiles. So I added a parameter that controls how many pixels are blended. I typically set them to like 500-1000.

I'm attaching images below to show the difference blending 40 vs 500 or even 1000 pixels make to my fused brain.

I have tried intensity adjustment, but it is still not enough to overcome the lack of blending. The images I'm including are fused lightsheet images taken using a `488nm`, `561nm`, and `640nm` laser. And in them I try different blending values and different lambda values for intensity adjustment.

It isn't clear to me if there's a downside to simply setting the blending to a very large value, like 5000. But I figured adding it as a option is better.

[488nm images](https://github.com/user-attachments/files/18159662/488nm.zip)
[561nm images](https://github.com/user-attachments/files/18159671/561nm.zip)
[640nm images](https://github.com/user-attachments/files/18159677/640nm.zip)
