### PR TITLE
OME-ZARR support for BigStitcher fusion

### DIFF
--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/OMEZarrAttibutes.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/OMEZarrAttibutes.java
@@ -24,6 +24,7 @@ package net.preibisch.mvrecon.fiji.spimdata.imgloaders;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Arrays;
 import java.util.function.Function;
 
 import org.janelia.saalfeldlab.n5.DatasetAttributes;
@@ -38,6 +39,7 @@ import org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v04.coordinateTrans
 import org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v04.coordinateTransformations.ScaleCoordinateTransformation;
 import org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v04.coordinateTransformations.TranslationCoordinateTransformation;
 
+import mpicbg.spim.data.sequence.VoxelDimensions;
 import net.imglib2.realtransform.AffineTransform3D;
 import util.URITools;
 
@@ -126,6 +128,22 @@ public class OMEZarrAttibutes
 		meta[ 0 ] = new OmeNgffMultiScaleMetadata( n, path, name, type, "0.4", axes, datasets, childrenAttributes, coordinateTransformations, metadata );
 
 		return meta;
+	}
+
+	// TODO: this is inaccurate, we should actually estimate it from the final transformn that is applied
+	public static double[] getResolutionS0( final VoxelDimensions vx, final double anisoF, final double downsamplingF )
+	{
+		final double[] resolutionS0 = vx.dimensionsAsDoubleArray();
+
+		// not preserving anisotropy
+		if ( Double.isNaN( anisoF ) )
+			resolutionS0[ 2 ] = resolutionS0[ 0 ];
+
+		// downsampling
+		if ( !Double.isNaN( downsamplingF ) )
+			Arrays.setAll( resolutionS0, d -> resolutionS0[ d ] * downsamplingF );
+
+		return resolutionS0;
 	}
 
 	public static void loadOMEZarr( final N5Reader n5, final String dataset )

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/OMEZarrAttibutes.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/OMEZarrAttibutes.java
@@ -23,10 +23,12 @@
 package net.preibisch.mvrecon.fiji.spimdata.imgloaders;
 
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.function.Function;
 
 import org.janelia.saalfeldlab.n5.DatasetAttributes;
 import org.janelia.saalfeldlab.n5.N5Reader;
+import org.janelia.saalfeldlab.n5.universe.N5Factory;
 import org.janelia.saalfeldlab.n5.universe.N5Factory.StorageFormat;
 import org.janelia.saalfeldlab.n5.universe.metadata.axes.Axis;
 import org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v04.OmeNgffMultiScaleMetadata;
@@ -151,8 +153,19 @@ public class OMEZarrAttibutes
 		}
 	}
 
-	public static void main( String[] args )
+	public static void main( String[] args ) throws URISyntaxException
 	{
+		final URI uri2 = URITools.toURI("https://keller-data.int.janelia.org/s12a/samples_for_stitching/Live%20zebra%20fish%20stitched/Live%20zebra%20plane%206/dataset.n5");///setup0/time;t0/");
+		System.out.println( uri2.toString() );
+
+		//FileSystemKeyValueAccess kva = new FileSystemKeyValueAccess( FileSystems.getDefault() );
+		
+		String s = uri2.toString();
+		N5Factory f = new N5Factory();
+		N5Reader r = f.openFileSystemReader( s );
+		r.close();
+		System.exit( 0 );
+
 		//final URI uri = URITools.toURI( "https://storage.googleapis.com/jax-public-ngff/KOMP/adult_lacZ/ndp/Moxd1/23420_K35061_FGut.zarr/0/" );
 		//final String dataset = "/";
 

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/OMEZarrAttibutes.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/OMEZarrAttibutes.java
@@ -104,7 +104,7 @@ public class OMEZarrAttibutes
 			// if 4d and 5d, add 1's for C and T
 			for ( int d = 3; d < n; ++d )
 			{
-				translation[ d ] = 1.0;
+				translation[ d ] = 0.0;
 				scale[ d ] = 1.0;
 			}
 

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/OMEZarrAttibutes.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/OMEZarrAttibutes.java
@@ -61,7 +61,7 @@ public class OMEZarrAttibutes
 		final OmeNgffMultiScaleMetadata[] meta = new OmeNgffMultiScaleMetadata[ 1 ];
 
 		// dataset name and co
-		final String path = null;
+		final String path = "";
 		final String type = null;
 
 		// axis descriptions

--- a/src/main/java/net/preibisch/mvrecon/process/export/DisplayImage.java
+++ b/src/main/java/net/preibisch/mvrecon/process/export/DisplayImage.java
@@ -29,7 +29,7 @@ import java.util.stream.Collectors;
 import fiji.util.gui.GenericDialogPlus;
 import ij.ImagePlus;
 import ij.gui.GenericDialog;
-import mpicbg.spim.data.sequence.ViewId;
+import mpicbg.spim.data.sequence.ViewDescription;
 import net.imglib2.Interval;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.exception.ImgLibException;
@@ -90,7 +90,7 @@ public class DisplayImage implements ImgExport, Calibrateable
 			final double downsampling,
 			final double anisoF,
 			final String title,
-			final Group< ? extends ViewId > fusionGroup )
+			final Group< ? extends ViewDescription > fusionGroup )
 	{
 		// do nothing in case the image is null
 		if ( img == null )

--- a/src/main/java/net/preibisch/mvrecon/process/export/ExportLarge2DTIFF.java
+++ b/src/main/java/net/preibisch/mvrecon/process/export/ExportLarge2DTIFF.java
@@ -36,14 +36,12 @@ import bdv.viewer.SourceAndConverter;
 import ch.epfl.biop.kheops.ometiff.OMETiffPyramidizerExporter;
 import fiji.util.gui.GenericDialogPlus;
 import mpicbg.spim.data.sequence.ViewDescription;
-import mpicbg.spim.data.sequence.ViewId;
 import net.imglib2.FinalInterval;
 import net.imglib2.Interval;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.converter.ColorChannelOrder;
 import net.imglib2.converter.Converters;
 import net.imglib2.img.display.imagej.ImageJFunctions;
-import net.imglib2.multithreading.SimpleMultiThreading;
 import net.imglib2.position.FunctionRandomAccessible;
 import net.imglib2.realtransform.AffineTransform3D;
 import net.imglib2.type.NativeType;
@@ -99,7 +97,7 @@ public class ExportLarge2DTIFF implements ImgExport
 			final double downsampling,
 			final double anisoF,
 			final String title,
-			final Group<? extends ViewId> fusionGroup )
+			final Group<? extends ViewDescription> fusionGroup )
 	{
 		// hack to make the interval divisable by 16 (see https://imagesc.zulipchat.com/#narrow/stream/212929-general/topic/Writing.20large.202D.20TIFFs)
 		if ( imgInterval.dimension( 0 ) % 16 != 0 || imgInterval.dimension( 1 ) % 16 != 0 )

--- a/src/main/java/net/preibisch/mvrecon/process/export/ExportN5Api.java
+++ b/src/main/java/net/preibisch/mvrecon/process/export/ExportN5Api.java
@@ -201,6 +201,8 @@ public class ExportN5Api implements ImgExport
 			{
 				if ( storageType == StorageFormat.HDF5 )
 				{
+					IOFunctions.println( "Creating HDF5 container at '" + path + "' ... " );
+
 					final File dir = new File( URITools.fromURI( path ) ).getParentFile();
 					if ( !dir.exists() )
 						dir.mkdirs();
@@ -214,7 +216,7 @@ public class ExportN5Api implements ImgExport
 					// if we store all fused data in one container, we create the dataset here
 					if ( storageType == StorageFormat.ZARR && omeZarrOneContainer )
 					{
-						IOFunctions.println( "Creating OME-ZARR stucture & metadata ... " );
+						IOFunctions.println( "Creating OME-ZARR container & metadata '" + path + "' ... " );
 
 						final long[] dim3d = bb.dimensionsAsLongArray();
 
@@ -239,7 +241,8 @@ public class ExportN5Api implements ImgExport
 						final Function<Integer, AffineTransform3D> levelToMipmapTransform =
 								(level) -> MipmapTransforms.getMipmapTransformDefault( mrInfoZarr[level].absoluteDownsamplingDouble() );
 
-						// TODO: this is correct if preserve anisotropy was checked
+						// extract the resolution of the s0 export
+						// TODO: this is inaccurate, we should actually estimate it from the final transformn that is applied
 						final VoxelDimensions vx = fusionGroup.iterator().next().getViewSetup().getVoxelSize();
 						final double[] resolutionS0 = fusionGroup.iterator().next().getViewSetup().getVoxelSize().dimensionsAsDoubleArray();
 
@@ -249,7 +252,7 @@ public class ExportN5Api implements ImgExport
 
 						// downsampling
 						if ( !Double.isNaN( downsamplingF ) )
-							Arrays.setAll(resolutionS0, d -> resolutionS0[ d ] * downsamplingF );
+							Arrays.setAll( resolutionS0, d -> resolutionS0[ d ] * downsamplingF );
 
 						IOFunctions.println( "Resolution of s0: " + Util.printCoordinates( resolutionS0 ) + " " + vx.unit() );
 

--- a/src/main/java/net/preibisch/mvrecon/process/export/ExportN5Api.java
+++ b/src/main/java/net/preibisch/mvrecon/process/export/ExportN5Api.java
@@ -100,7 +100,7 @@ public class ExportN5Api implements ImgExport
 	public static int defaultOmeZarrDim = 2;
 	public static boolean defaultOmeZarrOneContainer = true;
 	public static boolean defaultBDV = false;
-	public static boolean defaultMultiRes = false;
+	public static boolean defaultMultiRes = true;
 	public static String defaultXMLOutURI = null;
 	public static boolean defaultManuallyAssignViewId = false;
 	public static int defaultTpId = 0;

--- a/src/main/java/net/preibisch/mvrecon/process/export/ExportN5Api.java
+++ b/src/main/java/net/preibisch/mvrecon/process/export/ExportN5Api.java
@@ -637,8 +637,9 @@ public class ExportN5Api implements ImgExport
 				final GenericDialog gdZarr1 = new GenericDialog( "OME-Zarr options" );
 
 				gdZarr1.addCheckbox( "Store channels and timepoints into a single OME-ZARR container", defaultOmeZarrOneContainer );
-				gdZarr1.addMessage( "Note: " + this.channels.size() + " channels and " + this.timepoints.size() + " timepoints selected for fusion.", GUIHelper.smallStatusFont );
-				gdZarr1.addMessage( "Note: If you do not select a single OME-ZARR, a 3D OME-ZARR will be created for each fused volume.", GUIHelper.smallStatusFont );
+				gdZarr1.addMessage(
+						"Note: " + this.channels.size() + " channels and " + this.timepoints.size() + " timepoints selected for fusion.\n" + 
+						"If you do not select a single OME-ZARR, a 3D OME-ZARR will be created for each fused volume.", GUIHelper.smallStatusFont );
 
 				gdZarr1.showDialog();
 				if ( gdZarr1.wasCanceled() )

--- a/src/main/java/net/preibisch/mvrecon/process/export/ExportN5Api.java
+++ b/src/main/java/net/preibisch/mvrecon/process/export/ExportN5Api.java
@@ -548,30 +548,43 @@ public class ExportN5Api implements ImgExport
 		//
 		if ( storageType == StorageFormat.ZARR )
 		{
-			final GenericDialog gdZarr = new GenericDialog( "OME-Zarr options" );
-
-			gdZarr.addChoice( "Preferred dimensionality of the OME-Zarr", omeZarrDimChoice, omeZarrDimChoice[ defaultOmeZarrDim ] );
-			gdZarr.addMessage( "Note: this may be overwritten by the choice to store all fusion data in a single OME-ZARR container.", GUIHelper.smallStatusFont );
-
 			if ( fusion.getSplittingType() == 0 )
 			{
 				this.channels = N5ApiTools.channels( fusion.getFusionGroups() );
 				this.timepoints = N5ApiTools.timepoints( fusion.getFusionGroups() );
 
-				gdZarr.addCheckbox( "Store channels and timepoints into a single OME-ZARR container", defaultOmeZarrOneContainer );
-				gdZarr.addMessage( "Note: " + this.channels.size() + " channels and " + this.timepoints.size() + " timepoints selected for fusion.", GUIHelper.smallStatusFont );
+				final GenericDialog gdZarr1 = new GenericDialog( "OME-Zarr options 1" );
+
+				gdZarr1.addCheckbox( "Store channels and timepoints into a single OME-ZARR container", defaultOmeZarrOneContainer );
+				gdZarr1.addMessage( "Note: " + this.channels.size() + " channels and " + this.timepoints.size() + " timepoints selected for fusion.", GUIHelper.smallStatusFont );
+
+				gdZarr1.showDialog();
+				if ( gdZarr1.wasCanceled() )
+					return false;
+
+				omeZarrOneContainer = defaultOmeZarrOneContainer = gdZarr1.getNextBoolean();
+			}
+			else
+			{
+				omeZarrOneContainer = false;
 			}
 
-			gdZarr.showDialog();
-			if ( gdZarr.wasCanceled() )
-				return false;
+			if ( !omeZarrOneContainer )
+			{
+				final GenericDialog gdZarr2 = new GenericDialog( "OME-Zarr options 2" );
 
-			omeZarrDim = defaultOmeZarrDim = gdZarr.getNextChoiceIndex();
+				gdZarr2.addChoice( "Dimensionality of (each of the) OME-Zarr(s)", omeZarrDimChoice, omeZarrDimChoice[ defaultOmeZarrDim ] );
 
-			if ( fusion.getSplittingType() == 0 )
-				omeZarrOneContainer = defaultOmeZarrOneContainer = gdZarr.getNextBoolean();
+				gdZarr2.showDialog();
+				if ( gdZarr2.wasCanceled() )
+					return false;
+
+				omeZarrDim = defaultOmeZarrDim = gdZarr2.getNextChoiceIndex();
+			}
 			else
-				omeZarrOneContainer = false;
+			{
+				omeZarrDim = 2;
+			}
 		}
 
 		//

--- a/src/main/java/net/preibisch/mvrecon/process/export/ExportN5Api.java
+++ b/src/main/java/net/preibisch/mvrecon/process/export/ExportN5Api.java
@@ -30,15 +30,12 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.EnumSet;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import javax.management.RuntimeErrorException;
 
 import org.janelia.saalfeldlab.n5.Compression;
 import org.janelia.saalfeldlab.n5.DataType;
@@ -93,7 +90,7 @@ public class ExportN5Api implements ImgExport
 	public static String defaultDatasetExtension = "/s0";
 
 	public static String[] omeZarrDimChoice = new String[] { "3D (ZYX)", "4D (CZYX)", "5D (TCZYX)" };
-	public static int defaultOmeZarrDim = 0;
+	public static int defaultOmeZarrDim = 2;
 	public static boolean defaultOmeZarrOneContainer = true;
 	public static boolean defaultBDV = false;
 	public static boolean defaultMultiRes = false;
@@ -307,13 +304,15 @@ public class ExportN5Api implements ImgExport
 					this.downsampling );
 		}
 
+		// for OME-ZARR, dimensions are 5D
 		final List<long[][]> grid = N5ApiTools.assembleJobs(
-				mrInfo[ 0 ],
+				null, // no need to go across ViewIds (for now)
+				new long[] { mrInfo[ 0 ].dimensions[ 0 ], mrInfo[ 0 ].dimensions[ 1 ], mrInfo[ 0 ].dimensions[ 2 ] },
 				new int[] {
 						blocksize()[0] * computeBlocksizeFactor()[ 0 ],
 						blocksize()[1] * computeBlocksizeFactor()[ 1 ],
-						blocksize()[2] * computeBlocksizeFactor()[ 2 ]
-				} );
+						blocksize()[2] * computeBlocksizeFactor()[ 2 ] },
+				blocksize() );
 
 		IOFunctions.println( "num blocks = " + Grid.create( bb.dimensionsAsLongArray(), blocksize() ).size() + ", size = " + bsX + "x" + bsY + "x" + bsZ );
 		IOFunctions.println( "num compute blocks = " + grid.size() + ", size = " + bsX*bsFactorX + "x" + bsY*bsFactorY + "x" + bsZ*bsFactorZ );

--- a/src/main/java/net/preibisch/mvrecon/process/export/ExportN5Api.java
+++ b/src/main/java/net/preibisch/mvrecon/process/export/ExportN5Api.java
@@ -38,9 +38,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
-import bdv.img.n5.N5ImageLoader;
-import bdv.util.MipmapTransforms;
-
 import org.janelia.saalfeldlab.n5.Compression;
 import org.janelia.saalfeldlab.n5.DataType;
 import org.janelia.saalfeldlab.n5.N5Writer;
@@ -51,6 +48,7 @@ import org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v04.OmeNgffMultiSca
 
 import bdv.export.ExportMipmapInfo;
 import bdv.export.ProposeMipmaps;
+import bdv.util.MipmapTransforms;
 import fiji.util.gui.GenericDialogPlus;
 import ij.IJ;
 import ij.gui.GenericDialog;

--- a/src/main/java/net/preibisch/mvrecon/process/export/ExportN5Api.java
+++ b/src/main/java/net/preibisch/mvrecon/process/export/ExportN5Api.java
@@ -240,14 +240,14 @@ public class ExportN5Api implements ImgExport
 						final VoxelDimensions vx = fusionGroup.iterator().next().getViewSetup().getVoxelSize();
 						final double[] resolutionS0 = OMEZarrAttibutes.getResolutionS0( vx, anisoF, downsamplingF );
 
-						IOFunctions.println( "Resolution of s0: " + Util.printCoordinates( resolutionS0 ) + " " + vx.unit() );
+						IOFunctions.println( "Resolution of s0: " + Util.printCoordinates( resolutionS0 ) + " " + "m" ); //vx.unit() might not be OME-ZARR compatiblevx.unit() );
 
 						// create metadata
 						final OmeNgffMultiScaleMetadata[] meta = OMEZarrAttibutes.createOMEZarrMetadata(
 								5, // int n
 								"/", // String name, I also saw "/"
 								resolutionS0, // double[] resolutionS0,
-								vx.unit(), // String unitXYZ, // e.g micrometer
+								"micrometer", //vx.unit() might not be OME-ZARR compatible // String unitXYZ, // e.g micrometer
 								mrInfoZarr.length, // int numResolutionLevels,
 								levelToName,
 								levelToMipmapTransform );
@@ -349,14 +349,14 @@ public class ExportN5Api implements ImgExport
 			final VoxelDimensions vx = fusionGroup.iterator().next().getViewSetup().getVoxelSize();
 			final double[] resolutionS0 = OMEZarrAttibutes.getResolutionS0( vx, anisoF, downsamplingF );
 
-			IOFunctions.println( "Resolution of s0: " + Util.printCoordinates( resolutionS0 ) + " " + vx.unit() );
+			IOFunctions.println( "Resolution of s0: " + Util.printCoordinates( resolutionS0 ) + " micrometer" );
 
 			// create metadata
 			final OmeNgffMultiScaleMetadata[] meta = OMEZarrAttibutes.createOMEZarrMetadata(
 					3, // int n
 					omeZarrSubContainer, // String name, I also saw "/"
 					resolutionS0, // double[] resolutionS0,
-					vx.unit(), // String unitXYZ, // e.g micrometer
+					"micrometer", //vx.unit() might not be OME-ZARR compatible // String unitXYZ, // e.g micrometer
 					mrInfo.length, // int numResolutionLevels,
 					(level) -> "/s" + level,
 					levelToMipmapTransform );

--- a/src/main/java/net/preibisch/mvrecon/process/export/ExportN5Api.java
+++ b/src/main/java/net/preibisch/mvrecon/process/export/ExportN5Api.java
@@ -91,8 +91,8 @@ public class ExportN5Api implements ImgExport
 	public static String defaultPathURI = null;
 	public static int defaultOption = 0;
 	public static String defaultDatasetName = "fused";
-	public static String defaultBaseDataset = "/";
-	public static String defaultDatasetExtension = "/s0";
+	//public static String defaultBaseDataset = "/";
+	//public static String defaultDatasetExtension = "/s0";
 
 	//public static String[] omeZarrDimChoice = new String[] { "3D (ZYX)", "4D (CZYX)", "5D (TCZYX)" };
 	public static int defaultOmeZarrDim = 2;
@@ -122,8 +122,8 @@ public class ExportN5Api implements ImgExport
 
 	StorageFormat storageType = StorageFormat.values()[ defaultOption ];
 	URI path = (defaultPathURI != null && defaultPathURI.trim().length() > 0 ) ? URI.create( defaultPathURI ) : null;
-	String baseDataset = defaultBaseDataset;
-	String datasetExtension = defaultDatasetExtension;
+	//String baseDataset = defaultBaseDataset;
+	//String datasetExtension = defaultDatasetExtension;
 
 	//int omeZarrDim = defaultOmeZarrDim;
 	boolean omeZarrOneContainer = defaultOmeZarrOneContainer;
@@ -319,9 +319,6 @@ public class ExportN5Api implements ImgExport
 		}
 		else if ( storageType == StorageFormat.ZARR && omeZarrOneContainer ) // OME-Zarr export into a single container
 		{
-			// TODO: timepoint in the wrong order:
-			// Prcoessing OME-ZARR sub-volume 'fused_tp_18_ch_0'. channel index=0, timepoint index=1
-			// Prcoessing OME-ZARR sub-volume 'fused_tp_30_ch_0'. channel index=0, timepoint index=0
 			currentChannelIndex = N5ApiTools.channelIndex( fusionGroup, channels );
 			currentTPIndex = N5ApiTools.timepointIndex( fusionGroup, timepoints );
 
@@ -377,17 +374,18 @@ public class ExportN5Api implements ImgExport
 		else
 		{
 			// this is the relative path to the dataset inside the N5/HDF5 container, thus using File here seems fine
-			final String dataset = new File( new File( baseDataset , title ).toString(), datasetExtension ).toString();
+			//final String dataset = new File( new File( baseDataset , title ).toString(), datasetExtension ).toString();
 
 			// e.g. in Windows this will change it to '\s0'
-			final String datasetExtensionOS = new File( datasetExtension ).toString(); 
+			//final String datasetExtensionOS = new File( datasetExtension ).toString(); 
 
-			IOFunctions.println( "datasetExtensionOS: " +datasetExtensionOS );
+			//IOFunctions.println( "datasetExtensionOS: " +datasetExtensionOS );
+			IOFunctions.println( "Creating 3D N5 sub-container '" + title + "' in '" + path + "' ... " );
 
 			// setup multi-resolution pyramid
 			mrInfo = N5ApiTools.setupMultiResolutionPyramid(
 					driverVolumeWriter,
-					(level) -> new File( dataset.substring(0, dataset.lastIndexOf( datasetExtensionOS ) ) + "/s" + level ).toString(),
+					(level) -> title + "/s" + level,
 					dataType,
 					bb.dimensionsAsLongArray(),
 					compression,
@@ -662,23 +660,6 @@ public class ExportN5Api implements ImgExport
 			{
 				omeZarrOneContainer = false;
 			}
-			/*
-			if ( !omeZarrOneContainer )
-			{
-				final GenericDialog gdZarr2 = new GenericDialog( "OME-Zarr options 2" );
-
-				gdZarr2.addChoice( "Dimensionality of (each of the) OME-Zarr(s)", omeZarrDimChoice, omeZarrDimChoice[ defaultOmeZarrDim ] );
-
-				gdZarr2.showDialog();
-				if ( gdZarr2.wasCanceled() )
-					return false;
-
-				omeZarrDim = defaultOmeZarrDim = gdZarr2.getNextChoiceIndex();
-			}
-			else
-			{
-				omeZarrDim = 2;
-			}*/
 		}
 
 		//
@@ -716,8 +697,10 @@ public class ExportN5Api implements ImgExport
 		{
 			// nothing else to ask for OME-ZARR's
 		}
-		else
+		else if ( storageType == StorageFormat.N5 )
 		{
+			// nothing else to ask for N5's
+			/*
 			gd.addStringField( name + "_base_dataset", defaultBaseDataset );
 			gd.addStringField( name + "_dataset_extension", defaultDatasetExtension );
 	
@@ -727,6 +710,7 @@ public class ExportN5Api implements ImgExport
 					+ "dataset inside the 'base dataset'. You can add a dataset extension for each volume,\n"
 					+ "e.g. /base/fused_tp0_ch2/s0, where 's0' suggests it is full resolution. If you select multi-resolution\n"
 					+ "output the dataset extension MUST end with /s0 since it will also create /s1, /s2, ...", GUIHelper.smallStatusFont, GUIHelper.neutral );
+					*/
 		}
 
 		// export type changed or undefined
@@ -836,10 +820,11 @@ public class ExportN5Api implements ImgExport
 		{
 			// nothing to get for OME-ZARR's
 		}
-		else
+		else if ( storageType == StorageFormat.N5 )
 		{
-			this.baseDataset = defaultBaseDataset  = gd.getNextString().trim();
-			this.datasetExtension = defaultDatasetExtension = gd.getNextString().trim();
+			// nothing to get for N5's
+			//this.baseDataset = defaultBaseDataset  = gd.getNextString().trim();
+			//this.datasetExtension = defaultDatasetExtension = gd.getNextString().trim();
 		}
 
 		if ( defaultAdvancedBlockSize = gd.getNextBoolean() )
@@ -899,11 +884,13 @@ public class ExportN5Api implements ImgExport
 
 		if ( multiRes )
 		{
+			/*
 			if ( !bdv && !this.datasetExtension.endsWith("/s0") )
 			{
 				IOFunctions.println( "The selected dataset extension does not end with '/s0'. Cannot continue since it is unclear how to store multi-resolution levels '/s1', '/s2', ..." );
 				return false;
 			}
+			*/
 
 			final double aniso = fusion.getAnisotropyFactor();
 			final Interval bb = fusion.getDownsampledBoundingBox();

--- a/src/main/java/net/preibisch/mvrecon/process/export/ExportN5Api.java
+++ b/src/main/java/net/preibisch/mvrecon/process/export/ExportN5Api.java
@@ -96,7 +96,7 @@ public class ExportN5Api implements ImgExport
 	public static String defaultBaseDataset = "/";
 	public static String defaultDatasetExtension = "/s0";
 
-	public static String[] omeZarrDimChoice = new String[] { "3D (ZYX)", "4D (CZYX)", "5D (TCZYX)" };
+	//public static String[] omeZarrDimChoice = new String[] { "3D (ZYX)", "4D (CZYX)", "5D (TCZYX)" };
 	public static int defaultOmeZarrDim = 2;
 	public static boolean defaultOmeZarrOneContainer = true;
 	public static boolean defaultBDV = false;
@@ -127,7 +127,7 @@ public class ExportN5Api implements ImgExport
 	String baseDataset = defaultBaseDataset;
 	String datasetExtension = defaultDatasetExtension;
 
-	int omeZarrDim = defaultOmeZarrDim;
+	//int omeZarrDim = defaultOmeZarrDim;
 	boolean omeZarrOneContainer = defaultOmeZarrOneContainer;
 
 	boolean bdv = defaultBDV;
@@ -638,10 +638,11 @@ public class ExportN5Api implements ImgExport
 				this.channels = N5ApiTools.channels( fusion.getFusionGroups() );
 				this.timepoints = N5ApiTools.timepoints( fusion.getFusionGroups() );
 
-				final GenericDialog gdZarr1 = new GenericDialog( "OME-Zarr options 1" );
+				final GenericDialog gdZarr1 = new GenericDialog( "OME-Zarr options" );
 
 				gdZarr1.addCheckbox( "Store channels and timepoints into a single OME-ZARR container", defaultOmeZarrOneContainer );
 				gdZarr1.addMessage( "Note: " + this.channels.size() + " channels and " + this.timepoints.size() + " timepoints selected for fusion.", GUIHelper.smallStatusFont );
+				gdZarr1.addMessage( "Note: If you do not select a single OME-ZARR, a 3D OME-ZARR will be created for each fused volume.", GUIHelper.smallStatusFont );
 
 				gdZarr1.showDialog();
 				if ( gdZarr1.wasCanceled() )
@@ -653,7 +654,7 @@ public class ExportN5Api implements ImgExport
 			{
 				omeZarrOneContainer = false;
 			}
-
+			/*
 			if ( !omeZarrOneContainer )
 			{
 				final GenericDialog gdZarr2 = new GenericDialog( "OME-Zarr options 2" );
@@ -669,7 +670,7 @@ public class ExportN5Api implements ImgExport
 			else
 			{
 				omeZarrDim = 2;
-			}
+			}*/
 		}
 
 		//
@@ -703,9 +704,9 @@ public class ExportN5Api implements ImgExport
 				gd.addMessage( "" );
 			}
 		}
-		else if ( storageType == StorageFormat.ZARR && omeZarrOneContainer )
+		else if ( storageType == StorageFormat.ZARR ) //&& omeZarrOneContainer )
 		{
-			// nothing else to ask
+			// nothing else to ask for OME-ZARR's
 		}
 		else
 		{
@@ -823,9 +824,9 @@ public class ExportN5Api implements ImgExport
 				// later calling getViewIdForGroup( fusionGroup, splittingType );
 			}
 		}
-		else if ( storageType == StorageFormat.ZARR && omeZarrOneContainer )
+		else if ( storageType == StorageFormat.ZARR )// && omeZarrOneContainer )
 		{
-			// nothing to get
+			// nothing to get for OME-ZARR's
 		}
 		else
 		{

--- a/src/main/java/net/preibisch/mvrecon/process/export/ExportN5Api.java
+++ b/src/main/java/net/preibisch/mvrecon/process/export/ExportN5Api.java
@@ -331,12 +331,10 @@ public class ExportN5Api implements ImgExport
 			final String omeZarrSubContainer = title + ".zarr";
 			IOFunctions.println( "Creating 3D OME-ZARR sub-container '" + omeZarrSubContainer + "' and metadata in '" + path + "' ... " );
 
-			final Function<Integer, String> levelToName = (level) -> "/s" + level;
-
 			// all is 3d
 			mrInfo = N5ApiTools.setupMultiResolutionPyramid(
 					driverVolumeWriter,
-					levelToName,
+					(level) -> omeZarrSubContainer + "/s" + level,
 					dataType,
 					bb.dimensionsAsLongArray(), //3d
 					compression,
@@ -360,7 +358,7 @@ public class ExportN5Api implements ImgExport
 					resolutionS0, // double[] resolutionS0,
 					vx.unit(), // String unitXYZ, // e.g micrometer
 					mrInfo.length, // int numResolutionLevels,
-					levelToName,
+					(level) -> "/s" + level,
 					levelToMipmapTransform );
 
 			// save metadata
@@ -372,8 +370,6 @@ public class ExportN5Api implements ImgExport
 
 			currentChannelIndex = -1;
 			currentTPIndex = -1;
-
-			throw new RuntimeException( "not implemented yet." );
 		}
 		else
 		{

--- a/src/main/java/net/preibisch/mvrecon/process/export/ExportN5Api.java
+++ b/src/main/java/net/preibisch/mvrecon/process/export/ExportN5Api.java
@@ -319,8 +319,13 @@ public class ExportN5Api implements ImgExport
 		}
 		else if ( storageType == StorageFormat.ZARR && omeZarrOneContainer ) // OME-Zarr export into a single container
 		{
+			// TODO: timepoint in the wrong order:
+			// Prcoessing OME-ZARR sub-volume 'fused_tp_18_ch_0'. channel index=0, timepoint index=1
+			// Prcoessing OME-ZARR sub-volume 'fused_tp_30_ch_0'. channel index=0, timepoint index=0
 			currentChannelIndex = N5ApiTools.channelIndex( fusionGroup, channels );
 			currentTPIndex = N5ApiTools.timepointIndex( fusionGroup, timepoints );
+
+			IOFunctions.println( "Prcoessing OME-ZARR sub-volume '" + title + "'. channel index=" + currentChannelIndex + ", timepoint index=" + currentTPIndex );
 
 			mrInfo = mrInfoZarr;
 		}
@@ -631,6 +636,14 @@ public class ExportN5Api implements ImgExport
 			{
 				this.channels = N5ApiTools.channels( fusion.getFusionGroups() );
 				this.timepoints = N5ApiTools.timepoints( fusion.getFusionGroups() );
+
+				IOFunctions.println( "Channels to be added to the OME-ZARR:" );
+				for ( final Channel c : this.channels )
+					IOFunctions.println( "\tChannel " + c.getId() + ": " + c.getName() );
+
+				IOFunctions.println( "Timepoints to be added to the OME-ZARR:" );
+				for ( final TimePoint t : this.timepoints )
+					IOFunctions.println( "\tTimepoint " + t.getId() );
 
 				final GenericDialog gdZarr1 = new GenericDialog( "OME-Zarr options" );
 

--- a/src/main/java/net/preibisch/mvrecon/process/export/ExportN5Api.java
+++ b/src/main/java/net/preibisch/mvrecon/process/export/ExportN5Api.java
@@ -236,6 +236,7 @@ public class ExportN5Api implements ImgExport
 		final RandomAccessibleInterval< T > img = Views.zeroMin( imgInterval );
 
 		final MultiResolutionLevelInfo[] mrInfo;
+		final long currentChannelIndex, currentTPIndex;
 
 		if ( bdv )
 		{
@@ -273,9 +274,15 @@ public class ExportN5Api implements ImgExport
 				IOFunctions.println( "Failed to write metadata for '"  + "': " + e );
 				return false;
 			}
+
+			currentChannelIndex = -1;
+			currentTPIndex = -1;
 		}
 		else if ( storageType == StorageFormat.ZARR && omeZarrOneContainer ) // OME-Zarr export into a single container
 		{
+			currentChannelIndex = N5ApiTools.channelIndex( fusionGroup, channels );
+			currentTPIndex = N5ApiTools.timepointIndex( fusionGroup, timepoints );
+
 			mrInfo = mrInfoZarr;
 		}
 		else if ( storageType == StorageFormat.ZARR ) // OME-Zarr export
@@ -302,6 +309,9 @@ public class ExportN5Api implements ImgExport
 					compression,
 					blocksize(),
 					this.downsampling );
+
+			currentChannelIndex = -1;
+			currentTPIndex = -1;
 		}
 
 		// for OME-ZARR, dimensions are 5D
@@ -319,19 +329,6 @@ public class ExportN5Api implements ImgExport
 
 		final AtomicInteger progress = new AtomicInteger( 0 );
 		IJ.showProgress( progress.get(), grid.size() );
-
-		final long currentChannelIndex, currentTPIndex;
-
-		if ( storageType == StorageFormat.ZARR && omeZarrOneContainer )
-		{
-			currentChannelIndex = N5ApiTools.channelIndex( fusionGroup, channels );
-			currentTPIndex = N5ApiTools.timepointIndex( fusionGroup, timepoints );
-		}
-		else
-		{
-			currentChannelIndex = -1;
-			currentTPIndex = -1;
-		}
 
 		//
 		// save full-resolution data (s0)

--- a/src/main/java/net/preibisch/mvrecon/process/export/ExportN5Api.java
+++ b/src/main/java/net/preibisch/mvrecon/process/export/ExportN5Api.java
@@ -84,7 +84,7 @@ import util.URITools;
 public class ExportN5Api implements ImgExport
 {
 	public static String defaultPathURI = null;
-	public static int defaultOption = 1;
+	public static int defaultOption = 0;
 	public static String defaultDatasetName = "fused";
 	public static String defaultBaseDataset = "/";
 	public static String defaultDatasetExtension = "/s0";
@@ -201,6 +201,7 @@ public class ExportN5Api implements ImgExport
 				{
 					driverVolumeWriter = URITools.instantiateN5Writer( storageType, path );
 
+					// OME-ZARR single container:
 					// if we store all fused data in one container, we create the dataset here
 					if ( storageType == StorageFormat.ZARR && omeZarrOneContainer )
 					{
@@ -221,10 +222,14 @@ public class ExportN5Api implements ImgExport
 								compression,
 								blockSize, //5d
 								ds ); // 5d
+
+						// TODO: save metadata
 					}
 				}
 				else
+				{
 					throw new RuntimeException( "storageType " + storageType + " not supported." );
+				}
 			}
 			catch ( Exception e )
 			{

--- a/src/main/java/net/preibisch/mvrecon/process/export/ExportN5Api.java
+++ b/src/main/java/net/preibisch/mvrecon/process/export/ExportN5Api.java
@@ -220,7 +220,7 @@ public class ExportN5Api implements ImgExport
 						for ( int d = 0; d < ds.length; ++d )
 							ds[ d ] = new int[] { this.downsampling[ d ][ 0 ], this.downsampling[ d ][ 1 ], this.downsampling[ d ][ 2 ], 1, 1 };
 
-						final Function<Integer, String> levelToName = (level) -> "/s" + level;
+						final Function<Integer, String> levelToName = (level) -> "/" + level;
 
 						// all is 5d now
 						mrInfoZarr = N5ApiTools.setupMultiResolutionPyramid(
@@ -240,7 +240,7 @@ public class ExportN5Api implements ImgExport
 						final VoxelDimensions vx = fusionGroup.iterator().next().getViewSetup().getVoxelSize();
 						final double[] resolutionS0 = OMEZarrAttibutes.getResolutionS0( vx, anisoF, downsamplingF );
 
-						IOFunctions.println( "Resolution of s0: " + Util.printCoordinates( resolutionS0 ) + " " + "m" ); //vx.unit() might not be OME-ZARR compatiblevx.unit() );
+						IOFunctions.println( "Resolution of level 0: " + Util.printCoordinates( resolutionS0 ) + " " + "m" ); //vx.unit() might not be OME-ZARR compatiblevx.unit() );
 
 						// create metadata
 						final OmeNgffMultiScaleMetadata[] meta = OMEZarrAttibutes.createOMEZarrMetadata(
@@ -334,7 +334,7 @@ public class ExportN5Api implements ImgExport
 			// all is 3d
 			mrInfo = N5ApiTools.setupMultiResolutionPyramid(
 					driverVolumeWriter,
-					(level) -> omeZarrSubContainer + "/s" + level,
+					(level) -> omeZarrSubContainer + "/" + level,
 					dataType,
 					bb.dimensionsAsLongArray(), //3d
 					compression,
@@ -349,7 +349,7 @@ public class ExportN5Api implements ImgExport
 			final VoxelDimensions vx = fusionGroup.iterator().next().getViewSetup().getVoxelSize();
 			final double[] resolutionS0 = OMEZarrAttibutes.getResolutionS0( vx, anisoF, downsamplingF );
 
-			IOFunctions.println( "Resolution of s0: " + Util.printCoordinates( resolutionS0 ) + " micrometer" );
+			IOFunctions.println( "Resolution of level 0: " + Util.printCoordinates( resolutionS0 ) + " micrometer" );
 
 			// create metadata
 			final OmeNgffMultiScaleMetadata[] meta = OMEZarrAttibutes.createOMEZarrMetadata(
@@ -358,7 +358,7 @@ public class ExportN5Api implements ImgExport
 					resolutionS0, // double[] resolutionS0,
 					"micrometer", //vx.unit() might not be OME-ZARR compatible // String unitXYZ, // e.g micrometer
 					mrInfo.length, // int numResolutionLevels,
-					(level) -> "/s" + level,
+					(level) -> "/" + level,
 					levelToMipmapTransform );
 
 			// save metadata

--- a/src/main/java/net/preibisch/mvrecon/process/export/ExportN5Api.java
+++ b/src/main/java/net/preibisch/mvrecon/process/export/ExportN5Api.java
@@ -201,8 +201,6 @@ public class ExportN5Api implements ImgExport
 			{
 				if ( storageType == StorageFormat.HDF5 )
 				{
-					IOFunctions.println( "Creating HDF5 container at '" + path + "' ... " );
-
 					final File dir = new File( URITools.fromURI( path ) ).getParentFile();
 					if ( !dir.exists() )
 						dir.mkdirs();
@@ -216,7 +214,7 @@ public class ExportN5Api implements ImgExport
 					// if we store all fused data in one container, we create the dataset here
 					if ( storageType == StorageFormat.ZARR && omeZarrOneContainer )
 					{
-						IOFunctions.println( "Creating OME-ZARR container & metadata '" + path + "' ... " );
+						IOFunctions.println( "Creating 5D OME-ZARR metadata for '" + path + "' ... " );
 
 						final long[] dim3d = bb.dimensionsAsLongArray();
 
@@ -244,7 +242,7 @@ public class ExportN5Api implements ImgExport
 						// extract the resolution of the s0 export
 						// TODO: this is inaccurate, we should actually estimate it from the final transformn that is applied
 						final VoxelDimensions vx = fusionGroup.iterator().next().getViewSetup().getVoxelSize();
-						final double[] resolutionS0 = fusionGroup.iterator().next().getViewSetup().getVoxelSize().dimensionsAsDoubleArray();
+						final double[] resolutionS0 = vx.dimensionsAsDoubleArray();
 
 						// not preserving anisotropy
 						if ( Double.isNaN( anisoF ) )
@@ -272,9 +270,6 @@ public class ExportN5Api implements ImgExport
 						// for this to work you need to register an adapter in the N5Factory class
 						// final GsonBuilder builder = new GsonBuilder().registerTypeAdapter( CoordinateTransformation.class, new CoordinateTransformationAdapter() );
 						driverVolumeWriter.setAttribute( "/", "multiscales", meta );
-						//driverVolumeWriter.getAttribute(pathName, key, class )
-						//n5.getAttribute( n5properties.getPath( setupId, timePointId ), "multiscales", OmeNgffMultiScaleMetadata[].class );
-
 					}
 				}
 				else

--- a/src/main/java/net/preibisch/mvrecon/process/export/ExportN5Api.java
+++ b/src/main/java/net/preibisch/mvrecon/process/export/ExportN5Api.java
@@ -435,18 +435,23 @@ public class ExportN5Api implements ImgExport
 							// 5D OME-ZARR CONTAINER
 							if ( storageType == StorageFormat.ZARR && omeZarrOneContainer )
 							{
-								
+								N5ApiTools.writeDownsampledBlock5dOMEZARR(
+										driverVolumeWriter,
+										mrInfo[ s ],
+										mrInfo[ s - 1 ],
+										gridBlock,
+										currentChannelIndex,
+										currentTPIndex );
 							}
 							else
 							{
-								
+								N5ApiTools.writeDownsampledBlock(
+										driverVolumeWriter,
+										mrInfo[ s ],
+										mrInfo[ s - 1 ],
+										gridBlock );
 							}
 
-							N5ApiTools.writeDownsampledBlock(
-								driverVolumeWriter,
-								mrInfo[ s ],
-								mrInfo[ s - 1 ],
-								gridBlock );
 
 							IJ.showProgress( progress.incrementAndGet(), allBlocks.size() );
 						})).get();

--- a/src/main/java/net/preibisch/mvrecon/process/export/ImgExport.java
+++ b/src/main/java/net/preibisch/mvrecon/process/export/ImgExport.java
@@ -22,7 +22,7 @@
  */
 package net.preibisch.mvrecon.process.export;
 
-import mpicbg.spim.data.sequence.ViewId;
+import mpicbg.spim.data.sequence.ViewDescription;
 import net.imglib2.Interval;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.NativeType;
@@ -64,7 +64,7 @@ public interface ImgExport
 			final double downsampling,
 			final double anisoF,
 			final String title,
-			final Group< ? extends ViewId > fusionGroup );
+			final Group< ? extends ViewDescription > fusionGroup );
 	
 	/*
 	 * Query the necessary parameters for the fusion (new dialog can be made)

--- a/src/main/java/net/preibisch/mvrecon/process/export/OpenSeaDragon.java
+++ b/src/main/java/net/preibisch/mvrecon/process/export/OpenSeaDragon.java
@@ -36,7 +36,6 @@ import gov.nist.isg.archiver.DirectoryArchiver;
 import gov.nist.isg.pyramidio.PartialImageReader;
 import gov.nist.isg.pyramidio.ScalablePyramidBuilder;
 import mpicbg.spim.data.sequence.ViewDescription;
-import mpicbg.spim.data.sequence.ViewId;
 import net.imglib2.Cursor;
 import net.imglib2.FinalInterval;
 import net.imglib2.Interval;
@@ -97,7 +96,7 @@ public class OpenSeaDragon implements ImgExport
 			final double downsampling,
 			final double anisoF,
 			final String title,
-			final Group<? extends ViewId> fusionGroup )
+			final Group<? extends ViewDescription > fusionGroup )
 	{
 		// remember all fusiongroups
 		groups.add(Views.zeroMin((RandomAccessibleInterval)(Object)imgInterval) );

--- a/src/main/java/net/preibisch/mvrecon/process/export/Save3dTIFF.java
+++ b/src/main/java/net/preibisch/mvrecon/process/export/Save3dTIFF.java
@@ -35,7 +35,7 @@ import ij.VirtualStack;
 import ij.io.FileInfo;
 import ij.io.FileSaver;
 import ij.io.TiffEncoder;
-import mpicbg.spim.data.sequence.ViewId;
+import mpicbg.spim.data.sequence.ViewDescription;
 import net.imglib2.Interval;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.NativeType;
@@ -98,7 +98,7 @@ public class Save3dTIFF implements ImgExport, Calibrateable
 			final double downsampling,
 			final double anisoF,
 			final String title,
-			final Group< ? extends ViewId > fusionGroup )
+			final Group< ? extends ViewDescription > fusionGroup )
 	{
 		// do nothing in case the image is null
 		if ( img == null )

--- a/src/main/java/net/preibisch/mvrecon/process/n5api/N5ApiTools.java
+++ b/src/main/java/net/preibisch/mvrecon/process/n5api/N5ApiTools.java
@@ -691,7 +691,7 @@ public class N5ApiTools
 		return channels;
 	}
 
-	public static int channelIndex( final Group<? extends ViewDescription> queryGroup, final ArrayList< Channel > channels )
+	public static int channelIndex( final Group<? extends ViewDescription > queryGroup, final ArrayList< Channel > channels )
 	{
 		if ( queryGroup.size() == 0 )
 			return -1;
@@ -709,7 +709,7 @@ public class N5ApiTools
 		return -1;
 	}
 
-	public static int timepointIndex( final Group<? extends ViewDescription> queryGroup, final ArrayList< TimePoint > timepoints )
+	public static int timepointIndex( final Group<? extends ViewDescription > queryGroup, final ArrayList< TimePoint > timepoints )
 	{
 		if ( queryGroup.size() == 0 )
 			return -1;

--- a/src/main/java/net/preibisch/mvrecon/process/n5api/N5ApiTools.java
+++ b/src/main/java/net/preibisch/mvrecon/process/n5api/N5ApiTools.java
@@ -450,8 +450,8 @@ public class N5ApiTools
 			final MultiResolutionLevelInfo mrInfo,
 			final MultiResolutionLevelInfo mrInfoPreviousScale,
 			final long[][] gridBlock,
-			final int currentChannelIndex,
-			final int currentTPIndex )
+			final long currentChannelIndex,
+			final long currentTPIndex )
 	{
 		final String dataset = mrInfo.dataset;
 		final String datasetPreviousScale = mrInfoPreviousScale.dataset;

--- a/src/main/java/net/preibisch/mvrecon/process/n5api/N5ApiTools.java
+++ b/src/main/java/net/preibisch/mvrecon/process/n5api/N5ApiTools.java
@@ -198,6 +198,16 @@ public class N5ApiTools
 			this.absoluteDownsampling = absoluteDownsampling;
 			this.blockSize = blockSize;
 		}
+
+		public double[] absoluteDownsamplingDouble()
+		{
+			return Arrays.stream( absoluteDownsampling ).asDoubleStream().toArray();
+		}
+
+		public int[] absoluteDownsamplingInt()
+		{
+			return absoluteDownsampling;
+		}
 	}
 
 	public static MultiResolutionLevelInfo[] setupMultiResolutionPyramid(

--- a/src/main/java/net/preibisch/mvrecon/process/n5api/N5ApiTools.java
+++ b/src/main/java/net/preibisch/mvrecon/process/n5api/N5ApiTools.java
@@ -30,6 +30,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -718,6 +719,8 @@ public class N5ApiTools
 			}
 		}
 
+		Collections.sort( tps, ( t1, t2 ) -> t1.getId() - t2.getId() );
+
 		return tps;
 	}
 
@@ -740,6 +743,8 @@ public class N5ApiTools
 					channels.add( newC );
 			}
 		}
+
+		Collections.sort( channels );
 
 		return channels;
 	}

--- a/src/main/java/net/preibisch/mvrecon/process/n5api/N5ApiTools.java
+++ b/src/main/java/net/preibisch/mvrecon/process/n5api/N5ApiTools.java
@@ -32,6 +32,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
@@ -48,7 +49,9 @@ import org.janelia.saalfeldlab.n5.universe.N5Factory.StorageFormat;
 import bdv.export.ExportMipmapInfo;
 import mpicbg.spim.data.SpimData;
 import mpicbg.spim.data.generic.AbstractSpimData;
+import mpicbg.spim.data.sequence.Channel;
 import mpicbg.spim.data.sequence.SetupImgLoader;
+import mpicbg.spim.data.sequence.TimePoint;
 import mpicbg.spim.data.sequence.ViewDescription;
 import mpicbg.spim.data.sequence.ViewId;
 import mpicbg.spim.data.sequence.ViewSetup;
@@ -616,5 +619,27 @@ public class N5ApiTools
 		viewIds.forEach( viewId -> list.add( map.get( viewId ).getViewSetup() ) );
 
 		return list;
+	}
+
+	public static int numTimepoints( final List<? extends Group<? extends ViewDescription>> fusionGroups )
+	{
+		final HashSet< TimePoint > tps = new HashSet<>();
+
+		for ( final Group<? extends ViewDescription> group : fusionGroups )
+			for ( final ViewDescription vd : group )
+				tps.add( vd.getTimePoint() );
+
+		return tps.size();
+	}
+
+	public static int numChannels( final List<? extends Group<? extends ViewDescription>> fusionGroups )
+	{
+		final HashSet< Channel > channels = new HashSet<>();
+
+		for ( final Group<? extends ViewDescription> group : fusionGroups )
+			for ( final ViewDescription vd : group )
+				channels.add( vd.getViewSetup().getChannel() );
+
+		return channels.size();
 	}
 }

--- a/src/main/java/util/URITools.java
+++ b/src/main/java/util/URITools.java
@@ -260,7 +260,7 @@ public class URITools
 			if ( format.equals( StorageFormat.N5 ))
 				return new N5FSWriter( URITools.fromURI( uri ) );
 			else if ( format.equals( StorageFormat.ZARR ))
-				return new N5ZarrWriter( URITools.fromURI( uri ), builder );
+				return new N5ZarrWriter( URITools.fromURI( uri ), builder, "/", true, true );
 			else if ( format.equals( StorageFormat.HDF5 ))
 				return new N5HDF5Writer( URITools.fromURI( uri ) );
 			else
@@ -273,7 +273,7 @@ public class URITools
 			try
 			{
 				//System.out.println( "Trying writing with credentials ..." );
-				final N5Factory factory = new N5Factory();
+				final N5Factory factory = new N5Factory().zarrDimensionSeparator( "/" );
 				factory.gsonBuilder( builder );
 				factory.s3UseCredentials();
 				n5w = factory.openWriter( format, uri );
@@ -331,6 +331,7 @@ public class URITools
 		}
 	}
 
+	/*
 	public static N5Reader instantiateGuessedN5Reader( final URI uri )
 	{
 		if ( URITools.isFile( uri ) )
@@ -392,7 +393,7 @@ public class URITools
 			try
 			{
 				//System.out.println( "Trying writing with credentials ..." );
-				final N5Factory factory = new N5Factory();
+				final N5Factory factory = new N5Factory().zarrDimensionSeparator( "/" );
 				factory.gsonBuilder( builder );
 				factory.s3UseCredentials();
 				n5w = factory.openWriter( uri.toString() );
@@ -408,6 +409,7 @@ public class URITools
 			return n5w;
 		}
 	}
+	*/
 
 	public static SpimData2 loadSpimData( final URI xmlURI, final XmlIoSpimData2 io ) throws SpimDataException
 	{

--- a/src/main/resources/plugins.config
+++ b/src/main/resources/plugins.config
@@ -48,7 +48,7 @@ Plugins>BigStitcher>Interest Points>Tools, "Remove Detections by Distance", net.
 Plugins>BigStitcher>Interest Points>Tools, "Remove Detections by relative Distance", net.preibisch.mvrecon.fiji.plugin.RelativeThinOut_Detections
 Plugins>BigStitcher>Interest Points>Tools, "Analyze Alignment Errors", net.preibisch.mvrecon.fiji.plugin.Analyze_Errors
 Plugins>BigStitcher>I/O, "Resave as HDF5 (local)", net.preibisch.mvrecon.fiji.plugin.resave.Resave_HDF5
-Plugins>BigStitcher>I/O, "Resave as N5 (local, cloud)", net.preibisch.mvrecon.fiji.plugin.resave.Resave_N5
+Plugins>BigStitcher>I/O, "Resave as N5 (local, cloud)", net.preibisch.mvrecon.fiji.plugin.resave.Resave_N5Api
 Plugins>BigStitcher>I/O, "Resave As TIFF (local)", net.preibisch.mvrecon.fiji.plugin.resave.Resave_TIFF
 Plugins>BigStitcher>I/O, "Save as ...", net.preibisch.mvrecon.fiji.plugin.XMLSaveAs
 Plugins>BigStitcher>I/O, "Resave Luxendo XML for BigStitcher", net.preibisch.mvrecon.headless.definedataset.Rewrite_LuxendoXML


### PR DESCRIPTION
Added support for OME-ZARR v2 export to BigStitcher. Tested it locally with Fiji, and in the cloud with [Neuroglancer](https://neuroglancer-demo.appspot.com/#!%7B%22dimensions%22:%7B%22z%22:%5B7.310780550106993e-7%2C%22m%22%5D%2C%22y%22:%5B7.310780550106993e-7%2C%22m%22%5D%2C%22x%22:%5B7.310780550106993e-7%2C%22m%22%5D%7D%2C%22position%22:%5B204.6210479736328%2C140%2C337%5D%2C%22crossSectionScale%22:1.514370740692048%2C%22projectionScale%22:4096%2C%22layers%22:%5B%7B%22type%22:%22image%22%2C%22source%22:%7B%22url%22:%22s3://janelia-bigstitcher-spark/IP/timeseries-5d.zarr/%7Czarr2:%22%2C%22transform%22:%7B%22outputDimensions%22:%7B%22t%27%22:%5B0.001%2C%22s%22%5D%2C%22c%27%22:%5B1%2C%22%22%5D%2C%22z%22:%5B7.310780550106993e-7%2C%22m%22%5D%2C%22y%22:%5B7.310780550106993e-7%2C%22m%22%5D%2C%22x%22:%5B7.310780550106993e-7%2C%22m%22%5D%7D%7D%7D%2C%22localDimensions%22:%7B%22c%27%22:%5B1%2C%22%22%5D%2C%22t%27%22:%5B0.001%2C%22s%22%5D%7D%2C%22localPosition%22:%5B0%2C0.5%5D%2C%22tab%22:%22source%22%2C%22name%22:%22timeseries-5d.zarr%22%7D%5D%2C%22selectedLayer%22:%7B%22size%22:348%2C%22visible%22:true%2C%22layer%22:%22timeseries-5d.zarr%22%7D%2C%22layout%22:%224panel%22%7D), [OME-NGFF-Validator](https://ome.github.io/ome-ngff-validator/?source=https://janelia-bigstitcher-spark.s3.us-east-1.amazonaws.com/Stitching/fused-5d.zarr/), and [Allen Volume Viewer](https://volumeviewer.allencell.org/viewer?url=https://janelia-bigstitcher-spark.s3.us-east-1.amazonaws.com/Stitching/fused-5d.zarr). 

@krokicki @mkitti @tpietzsch @bogovicj @yuriyzubov