### PR TITLE
fix/test: more flexible NumericalFilenamePattern matching

### DIFF
--- a/src/main/java/net/preibisch/mvrecon/fiji/datasetmanager/patterndetector/NumericalFilenamePatternDetector.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/datasetmanager/patterndetector/NumericalFilenamePatternDetector.java
@@ -238,44 +238,4 @@ public class NumericalFilenamePatternDetector implements FilenamePatternDetector
 	@Override
 	public int getNumVariables(){return variables.size();}
 	
-	public static void main(String[] args)
-	{
-		List< String > files = null;
-		try
-		{
-			Stream< Path > w = Files.list( Paths.get( "/Users/david/Desktop/Bordeaux/BIC Reconstruction/170331_EA810_Fred_MosZXY_Nocrop_12-36-22/" ));
-			
-					files = w.filter( new Predicate< Path >()
-					{
-
-						boolean res = false;
-						@Override
-						public boolean test(Path t)
-						{
-							try
-							{
-								res = Files.size( t ) > 100000;
-							}
-							catch ( IOException e )
-							{
-								// TODO Auto-generated catch block
-								e.printStackTrace();
-							}
-							return res;
-						}
-					} ).map( p -> p.toFile().getAbsolutePath()).collect( Collectors.toList() );
-		}
-		catch ( IOException e )
-		{
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		}
-		
-		System.out.println( files.get( 0 ) );
-		
-		Pair< List< String >, List< List< String > > > detectNumericPatterns = detectNumericPatterns( files );
-		
-		
-	}
-	
 }

--- a/src/test/java/net/preibisch/mvrecon/fiji/datasetmanager/patterndetector/NumericalFilenamePatternDetectorTests.java
+++ b/src/test/java/net/preibisch/mvrecon/fiji/datasetmanager/patterndetector/NumericalFilenamePatternDetectorTests.java
@@ -1,0 +1,75 @@
+package net.preibisch.mvrecon.fiji.datasetmanager.patterndetector;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class NumericalFilenamePatternDetectorTests {
+
+	@Test
+	public void testStringRepresentation() {
+
+		final NumericalFilenamePatternDetector patternDetector = new NumericalFilenamePatternDetector();
+
+		patternDetector.detectPatterns(Arrays.asList("0_t0", "1_t0"));
+		assertEquals("{0}_t{1}", patternDetector.getStringRepresentation());
+
+		patternDetector.detectPatterns(Arrays.asList("s0_t0", "s1_t0"));
+		assertEquals("s{0}_t{1}", patternDetector.getStringRepresentation());
+
+		patternDetector.detectPatterns(Arrays.asList("s0_suffix", "s1_suffix"));
+		assertEquals("s{0}_suffix", patternDetector.getStringRepresentation());
+
+		patternDetector.detectPatterns(Arrays.asList("s0_a", "s1_b"));
+		assertEquals("s{0}.*", patternDetector.getStringRepresentation());
+	}
+
+	@Test
+	public void testNumVariables() {
+
+		final List<String> prefixes = Arrays.asList("setup", "");
+		final List<String> suffixes = Arrays.asList("_t0", "");
+		final List<String> values = Arrays.asList("10", "21");
+
+		pairs(prefixes, suffixes).forEach(ps -> {
+
+			List<String> list = values.stream().map(v -> {
+				return ps[0] + v + ps[1];
+			}).collect(Collectors.toList());
+
+			final NumericalFilenamePatternDetector patternDetector = new NumericalFilenamePatternDetector();
+			patternDetector.detectPatterns(list);
+
+			int nVariables = ps[1].equals(suffixes.get(0)) ? 2 : 1;
+			assertEquals(nVariables, patternDetector.getNumVariables());
+
+			assertEquals(values.get(0), patternDetector.getValuesForVariable(0).get(0));
+			assertEquals(values.get(1), patternDetector.getValuesForVariable(0).get(1));
+
+			if( nVariables == 2) {
+				assertEquals("0", patternDetector.getValuesForVariable(1).get(0));
+				assertEquals("0", patternDetector.getValuesForVariable(1).get(1));
+			}
+
+		});
+
+	}
+
+	private static List<String[]> pairs( List<String> prefix, List<String> suffix) {
+
+		return prefix.stream().flatMap( p -> {
+			return suffix.stream().map(s -> {
+				return new String[] {p, s};
+			});
+		}).collect(Collectors.toList());
+	}
+
+}


### PR DESCRIPTION
* strings that start with a number are now supported
* strings that start end a number are now supported
* strings containing numbers that are constant now matched as numbers
* add a test

The provided test shows what I'd expect the behavior of the matcher to be, and this differs from the current behavior, especially for strings that start or end with a numerical pattern.

In particular, I have these expectations
| Strings  | Pattern |
| ----------- | ----------- |
| `[ "0_s", "1_s"]` |  `{0}_s` |
| `[ "0_s", "1_t"]` |  `{0}.*` |
| `[ "0_s0", "1_s0"]` |  `{0}_s{1}` |
| `[ "t0_s0", "t1_s0"]` |  `t{0}_s{1}` |
 
I marked some methods `@Deprecated`, these are no longer used and could be deleted (but that would break API).