### PR TITLE
Modernize lazy flatfield correction code

### DIFF
--- a/data/dataset.xml
+++ b/data/dataset.xml
@@ -1,0 +1,506 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SpimData version="0.2">
+  <BasePath type="relative">.</BasePath>
+  <SequenceDescription>
+    <ImageLoader format="bdv.n5" version="1.1">
+      <n5 type="relative">dataset.n5/</n5>
+    </ImageLoader>
+    <ViewSetups>
+      <ViewSetup>
+        <id>0</id>
+        <name>0</name>
+        <size>512 320 825</size>
+        <voxelSize>
+          <unit>pixels</unit>
+          <size>1.0 1.0 3.0</size>
+        </voxelSize>
+        <attributes>
+          <illumination>0</illumination>
+          <channel>0</channel>
+          <tile>187</tile>
+          <angle>0</angle>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>1</id>
+        <name>1</name>
+        <size>512 320 825</size>
+        <voxelSize>
+          <unit>pixels</unit>
+          <size>1.0 1.0 3.0</size>
+        </voxelSize>
+        <attributes>
+          <illumination>0</illumination>
+          <channel>0</channel>
+          <tile>188</tile>
+          <angle>0</angle>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>2</id>
+        <name>2</name>
+        <size>512 320 825</size>
+        <voxelSize>
+          <unit>pixels</unit>
+          <size>1.0 1.0 3.0</size>
+        </voxelSize>
+        <attributes>
+          <illumination>0</illumination>
+          <channel>0</channel>
+          <tile>189</tile>
+          <angle>0</angle>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>3</id>
+        <name>3</name>
+        <size>512 320 825</size>
+        <voxelSize>
+          <unit>pixels</unit>
+          <size>1.0 1.0 3.0</size>
+        </voxelSize>
+        <attributes>
+          <illumination>0</illumination>
+          <channel>0</channel>
+          <tile>200</tile>
+          <angle>0</angle>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>4</id>
+        <name>4</name>
+        <size>512 320 825</size>
+        <voxelSize>
+          <unit>pixels</unit>
+          <size>1.0 1.0 3.0</size>
+        </voxelSize>
+        <attributes>
+          <illumination>0</illumination>
+          <channel>0</channel>
+          <tile>201</tile>
+          <angle>0</angle>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>5</id>
+        <name>5</name>
+        <size>512 320 825</size>
+        <voxelSize>
+          <unit>pixels</unit>
+          <size>1.0 1.0 3.0</size>
+        </voxelSize>
+        <attributes>
+          <illumination>0</illumination>
+          <channel>0</channel>
+          <tile>202</tile>
+          <angle>0</angle>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>6</id>
+        <name>6</name>
+        <size>512 320 825</size>
+        <voxelSize>
+          <unit>pixels</unit>
+          <size>1.0 1.0 3.0</size>
+        </voxelSize>
+        <attributes>
+          <illumination>0</illumination>
+          <channel>0</channel>
+          <tile>213</tile>
+          <angle>0</angle>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>7</id>
+        <name>7</name>
+        <size>512 320 825</size>
+        <voxelSize>
+          <unit>pixels</unit>
+          <size>1.0 1.0 3.0</size>
+        </voxelSize>
+        <attributes>
+          <illumination>0</illumination>
+          <channel>0</channel>
+          <tile>214</tile>
+          <angle>0</angle>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>8</id>
+        <name>8</name>
+        <size>512 320 825</size>
+        <voxelSize>
+          <unit>pixels</unit>
+          <size>1.0 1.0 3.0</size>
+        </voxelSize>
+        <attributes>
+          <illumination>0</illumination>
+          <channel>0</channel>
+          <tile>215</tile>
+          <angle>0</angle>
+        </attributes>
+      </ViewSetup>
+      <Attributes name="illumination">
+        <Illumination>
+          <id>0</id>
+          <name>0</name>
+        </Illumination>
+      </Attributes>
+      <Attributes name="channel">
+        <Channel>
+          <id>0</id>
+          <name>0</name>
+        </Channel>
+      </Attributes>
+      <Attributes name="tile">
+        <Tile>
+          <id>187</id>
+          <name>187</name>
+        </Tile>
+        <Tile>
+          <id>188</id>
+          <name>188</name>
+        </Tile>
+        <Tile>
+          <id>189</id>
+          <name>189</name>
+        </Tile>
+        <Tile>
+          <id>200</id>
+          <name>200</name>
+        </Tile>
+        <Tile>
+          <id>201</id>
+          <name>201</name>
+        </Tile>
+        <Tile>
+          <id>202</id>
+          <name>202</name>
+        </Tile>
+        <Tile>
+          <id>213</id>
+          <name>213</name>
+        </Tile>
+        <Tile>
+          <id>214</id>
+          <name>214</name>
+        </Tile>
+        <Tile>
+          <id>215</id>
+          <name>215</name>
+        </Tile>
+      </Attributes>
+      <Attributes name="angle">
+        <Angle>
+          <id>0</id>
+          <name>0</name>
+        </Angle>
+      </Attributes>
+    </ViewSetups>
+    <Timepoints type="pattern">
+      <integerpattern>0</integerpattern>
+    </Timepoints>
+    <MissingViews />
+  </SequenceDescription>
+  <ViewRegistrations>
+    <ViewRegistration timepoint="0" setup="0">
+      <ViewTransform type="affine">
+        <Name>AffineModel3D regularized with an RigidModel3D, lambda = 0.1</Name>
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>Stitching Transform</Name>
+        <affine>1.0 0.0 0.0 0.4554158176323426 0.0 1.0 0.0 -0.13328548693164066 0.0 0.0 1.0 1.039028825990859</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>Translation to Regular Grid</Name>
+        <affine>1.0 0.0 0.0 199.68 0.0 1.0 0.0 102.40000000000003 0.0 0.0 1.0 -1236.0</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>calibration</Name>
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 3.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="1">
+      <ViewTransform type="affine">
+        <Name>AffineModel3D regularized with an RigidModel3D, lambda = 0.1</Name>
+        <affine>0.9996881730582423 1.0178764373025146E-4 9.91613051380682E-5 0.296854107149204 -0.0014206520238486176 1.000352820575225 5.493263412035365E-5 0.4978096475705985 -4.038421786319725E-4 1.2989941922307108E-4 1.0000050536353644 0.012322662821996552</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>Stitching Transform</Name>
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>Translation to Regular Grid</Name>
+        <affine>1.0 0.0 0.0 -256.0 0.0 1.0 0.0 102.40000000000003 0.0 0.0 1.0 -1236.0</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>calibration</Name>
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 3.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="2">
+      <ViewTransform type="affine">
+        <Name>AffineModel3D regularized with an RigidModel3D, lambda = 0.1</Name>
+        <affine>0.9999774841758134 -2.0323268523581142E-4 5.914840097558037E-5 0.41302203806414345 -6.595441757221898E-4 1.0005468325585005 1.0422412713430604E-4 0.86847428183128 -3.8743282755243446E-4 6.197381562939316E-4 0.9999038186675331 -0.1051593717912322</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>Stitching Transform</Name>
+        <affine>1.0 0.0 0.0 -0.2804882451294475 0.0 1.0 0.0 0.15177465825263425 0.0 0.0 1.0 -0.8673431810167168</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>Translation to Regular Grid</Name>
+        <affine>1.0 0.0 0.0 -711.6800000000001 0.0 1.0 0.0 102.40000000000003 0.0 0.0 1.0 -1236.0</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>calibration</Name>
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 3.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="3">
+      <ViewTransform type="affine">
+        <Name>AffineModel3D regularized with an RigidModel3D, lambda = 0.1</Name>
+        <affine>0.9996509004376033 0.0011789057647756168 6.625470971101606E-5 -0.4380062409126003 -5.886838131605057E-6 0.9993980714516947 8.378533632140301E-4 0.21066285389381184 1.1914663433102846E-4 -0.0017577181435329034 0.9993905308006584 -0.10732512771106033</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>Stitching Transform</Name>
+        <affine>1.0 0.0 0.0 -0.8442948117588571 0.0 1.0 0.0 7.4417831077170336 0.0 0.0 1.0 -8.789096260073075</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>Translation to Regular Grid</Name>
+        <affine>1.0 0.0 0.0 199.68 0.0 1.0 0.0 -160.0 0.0 0.0 1.0 -1236.0</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>calibration</Name>
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 3.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="4">
+      <ViewTransform type="affine">
+        <Name>AffineModel3D regularized with an RigidModel3D, lambda = 0.1</Name>
+        <affine>0.9993691627809789 6.213286683890014E-4 9.303551548369867E-5 -0.5698358880199796 -0.0012153705700172891 0.9994415380582407 8.680618674785683E-4 0.916909696194346 -1.5083252038943456E-4 -0.0011408852434367028 0.9994660587646744 0.2820529225572497</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>Stitching Transform</Name>
+        <affine>1.0 0.0 0.0 -0.9089191675130128 0.0 1.0 0.0 7.4256749717825095 0.0 0.0 1.0 -10.328335265676746</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>Translation to Regular Grid</Name>
+        <affine>1.0 0.0 0.0 -256.0 0.0 1.0 0.0 -160.0 0.0 0.0 1.0 -1236.0</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>calibration</Name>
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 3.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="5">
+      <ViewTransform type="affine">
+        <Name>AffineModel3D regularized with an RigidModel3D, lambda = 0.1</Name>
+        <affine>0.9995958883424029 1.1960194298687558E-4 1.3045003320240472E-4 -0.5288425017288729 -4.5021629309568165E-4 0.9995801176422028 9.375713906809582E-4 1.7071573589623064 -2.5232116962087617E-4 -5.217759052761294E-4 0.9995631970154002 0.266678832277585</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>Stitching Transform</Name>
+        <affine>1.0 0.0 0.0 -1.1369886493304193 0.0 1.0 0.0 7.212246076053502 0.0 0.0 1.0 -11.06907324837572</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>Translation to Regular Grid</Name>
+        <affine>1.0 0.0 0.0 -711.6800000000001 0.0 1.0 0.0 -160.0 0.0 0.0 1.0 -1236.0</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>calibration</Name>
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 3.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="6">
+      <ViewTransform type="affine">
+        <Name>AffineModel3D regularized with an RigidModel3D, lambda = 0.1</Name>
+        <affine>1.001169864797628 0.00527491302811622 1.4584877195363756E-4 -0.15773640915627343 -0.004686469222584484 0.9996923176367982 -0.002087984887367355 1.2420606082221906 -6.295077531490363E-4 0.005598468303174577 1.0011602899054004 1.9104004620529875</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>Stitching Transform</Name>
+        <affine>1.0 0.0 0.0 -0.2626855827553527 0.0 1.0 0.0 -6.7600081391679225 0.0 0.0 1.0 12.896136661870298</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>Translation to Regular Grid</Name>
+        <affine>1.0 0.0 0.0 199.68 0.0 1.0 0.0 -422.40000000000003 0.0 0.0 1.0 -1236.0</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>calibration</Name>
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 3.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="7">
+      <ViewTransform type="affine">
+        <Name>AffineModel3D regularized with an RigidModel3D, lambda = 0.1</Name>
+        <affine>1.0009007956899272 0.0053216640997549155 1.371415077664928E-4 0.31426019006657296 -0.005800996293005373 0.9993339550765709 -0.0019903541975732236 0.5557333216408067 -4.823233633192067E-4 0.003500523337610362 1.0009341748352047 1.2744275908022205</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>Stitching Transform</Name>
+        <affine>1.0 0.0 0.0 -0.7700626936842326 0.0 1.0 0.0 -7.432744962459225 0.0 0.0 1.0 11.579421273826847</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>Translation to Regular Grid</Name>
+        <affine>1.0 0.0 0.0 -256.0 0.0 1.0 0.0 -422.40000000000003 0.0 0.0 1.0 -1236.0</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>calibration</Name>
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 3.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="8">
+      <ViewTransform type="affine">
+        <Name>AffineModel3D regularized with an RigidModel3D, lambda = 0.1</Name>
+        <affine>1.0012387020759832 0.005337931651988534 5.916593012930141E-5 0.6833023552548335 -0.0048548568558627265 0.9989044018136208 -0.0019280609543394106 -0.26569722464665557 -3.915489271687177E-4 0.0016823628452441262 1.0009459560649534 0.679636329046033</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>Stitching Transform</Name>
+        <affine>1.0 0.0 0.0 -1.2414564955437868 0.0 1.0 0.0 -8.130736624699523 0.0 0.0 1.0 10.981609779561097</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>Translation to Regular Grid</Name>
+        <affine>1.0 0.0 0.0 -711.6800000000001 0.0 1.0 0.0 -422.40000000000003 0.0 0.0 1.0 -1236.0</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>calibration</Name>
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 3.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+  </ViewRegistrations>
+  <ViewInterestPoints>
+    <ViewInterestPointsFile timepoint="0" setup="0" label="beads" params="DOG s=1.7999999523162842 t=0.00800000037997961 min=false max=true imageSigmaX=0.5 imageSigmaY=0.5 imageSigmaZ=0.5 downsampleXYIndex=0 downsampleZ=1 minIntensity=193.0 maxIntensity=1923.0">tpId_0_viewSetupId_0/beads</ViewInterestPointsFile>
+    <ViewInterestPointsFile timepoint="0" setup="1" label="beads" params="DOG s=1.7999999523162842 t=0.00800000037997961 min=false max=true imageSigmaX=0.5 imageSigmaY=0.5 imageSigmaZ=0.5 downsampleXYIndex=0 downsampleZ=1 minIntensity=193.0 maxIntensity=1923.0">tpId_0_viewSetupId_1/beads</ViewInterestPointsFile>
+    <ViewInterestPointsFile timepoint="0" setup="2" label="beads" params="DOG s=1.7999999523162842 t=0.00800000037997961 min=false max=true imageSigmaX=0.5 imageSigmaY=0.5 imageSigmaZ=0.5 downsampleXYIndex=0 downsampleZ=1 minIntensity=193.0 maxIntensity=1923.0">tpId_0_viewSetupId_2/beads</ViewInterestPointsFile>
+    <ViewInterestPointsFile timepoint="0" setup="3" label="beads" params="DOG s=1.7999999523162842 t=0.00800000037997961 min=false max=true imageSigmaX=0.5 imageSigmaY=0.5 imageSigmaZ=0.5 downsampleXYIndex=0 downsampleZ=1 minIntensity=193.0 maxIntensity=1923.0">tpId_0_viewSetupId_3/beads</ViewInterestPointsFile>
+    <ViewInterestPointsFile timepoint="0" setup="4" label="beads" params="DOG s=1.7999999523162842 t=0.00800000037997961 min=false max=true imageSigmaX=0.5 imageSigmaY=0.5 imageSigmaZ=0.5 downsampleXYIndex=0 downsampleZ=1 minIntensity=193.0 maxIntensity=1923.0">tpId_0_viewSetupId_4/beads</ViewInterestPointsFile>
+    <ViewInterestPointsFile timepoint="0" setup="5" label="beads" params="DOG s=1.7999999523162842 t=0.00800000037997961 min=false max=true imageSigmaX=0.5 imageSigmaY=0.5 imageSigmaZ=0.5 downsampleXYIndex=0 downsampleZ=1 minIntensity=193.0 maxIntensity=1923.0">tpId_0_viewSetupId_5/beads</ViewInterestPointsFile>
+    <ViewInterestPointsFile timepoint="0" setup="6" label="beads" params="DOG s=1.7999999523162842 t=0.00800000037997961 min=false max=true imageSigmaX=0.5 imageSigmaY=0.5 imageSigmaZ=0.5 downsampleXYIndex=0 downsampleZ=1 minIntensity=193.0 maxIntensity=1923.0">tpId_0_viewSetupId_6/beads</ViewInterestPointsFile>
+    <ViewInterestPointsFile timepoint="0" setup="7" label="beads" params="DOG s=1.7999999523162842 t=0.00800000037997961 min=false max=true imageSigmaX=0.5 imageSigmaY=0.5 imageSigmaZ=0.5 downsampleXYIndex=0 downsampleZ=1 minIntensity=193.0 maxIntensity=1923.0">tpId_0_viewSetupId_7/beads</ViewInterestPointsFile>
+    <ViewInterestPointsFile timepoint="0" setup="8" label="beads" params="DOG s=1.7999999523162842 t=0.00800000037997961 min=false max=true imageSigmaX=0.5 imageSigmaY=0.5 imageSigmaZ=0.5 downsampleXYIndex=0 downsampleZ=1 minIntensity=193.0 maxIntensity=1923.0">tpId_0_viewSetupId_8/beads</ViewInterestPointsFile>
+  </ViewInterestPoints>
+  <BoundingBoxes />
+  <PointSpreadFunctions />
+  <StitchingResults>
+    <PairwiseResult view_setup_a="2" view_setup_b="1" tp_a="0" tp_b="0">
+      <shift>1.0 0.0 0.0 0.32830997041742194 0.0 1.0 0.0 -0.2780143304040763 0.0 0.0 1.0 0.8627255545425214</shift>
+      <correlation>0.9872797935430719</correlation>
+      <hash>-19840.08</hash>
+      <overlap_boundingbox>-256.0 102.0 -1236.0 -200.0 422.0 1236.0</overlap_boundingbox>
+    </PairwiseResult>
+    <PairwiseResult view_setup_a="1" view_setup_b="0" tp_a="0" tp_b="0">
+      <shift>1.0 0.0 0.0 0.31408745860667864 0.0 1.0 0.0 -0.21794513304740804 0.0 0.0 1.0 1.0669536191755924</shift>
+      <correlation>0.9890595837012269</correlation>
+      <hash>-13460.56</hash>
+      <overlap_boundingbox>199.0 102.0 -1236.0 255.0 422.0 1236.0</overlap_boundingbox>
+    </PairwiseResult>
+    <PairwiseResult view_setup_a="5" view_setup_b="4" tp_a="0" tp_b="0">
+      <shift>1.0 0.0 0.0 0.3219589445005795 0.0 1.0 0.0 -0.2912676156699092 0.0 0.0 1.0 0.7868782074069713</shift>
+      <correlation>0.989534384651222</correlation>
+      <hash>-23513.68</hash>
+      <overlap_boundingbox>-256.0 -160.0 -1236.0 -200.0 159.0 1236.0</overlap_boundingbox>
+    </PairwiseResult>
+    <PairwiseResult view_setup_a="4" view_setup_b="3" tp_a="0" tp_b="0">
+      <shift>1.0 0.0 0.0 0.32849982720156845 0.0 1.0 0.0 -0.299139087662013 0.0 0.0 1.0 1.1721464806346376</shift>
+      <correlation>0.9875872479386237</correlation>
+      <hash>-17134.16</hash>
+      <overlap_boundingbox>199.0 -160.0 -1236.0 255.0 159.0 1236.0</overlap_boundingbox>
+    </PairwiseResult>
+    <PairwiseResult view_setup_a="8" view_setup_b="7" tp_a="0" tp_b="0">
+      <shift>1.0 0.0 0.0 0.2950324994815787 0.0 1.0 0.0 1.3873944732041537 0.0 0.0 1.0 0.8156317724537985</shift>
+      <correlation>0.9350710728845969</correlation>
+      <hash>-27187.28</hash>
+      <overlap_boundingbox>-256.0 -423.0 -1236.0 -200.0 -103.0 1236.0</overlap_boundingbox>
+    </PairwiseResult>
+    <PairwiseResult view_setup_a="7" view_setup_b="6" tp_a="0" tp_b="0">
+      <shift>1.0 0.0 0.0 0.28614119325933984 0.0 1.0 0.0 1.3775777622511782 0.0 0.0 1.0 1.3157733733060013</shift>
+      <correlation>0.9339835065140643</correlation>
+      <hash>-20807.760000000002</hash>
+      <overlap_boundingbox>199.0 -423.0 -1236.0 255.0 -103.0 1236.0</overlap_boundingbox>
+    </PairwiseResult>
+    <PairwiseResult view_setup_a="2" view_setup_b="4" tp_a="0" tp_b="0">
+      <shift>1.0 0.0 0.0 -0.022274627811640357 0.0 1.0 0.0 7.064784613790181 0.0 0.0 1.0 -9.66095411700826</shift>
+      <correlation>0.9267757024498638</correlation>
+      <hash>-23251.28</hash>
+      <overlap_boundingbox>-256.0 102.0 -1236.0 -200.0 159.0 1236.0</overlap_boundingbox>
+    </PairwiseResult>
+    <PairwiseResult view_setup_a="1" view_setup_b="3" tp_a="0" tp_b="0">
+      <shift>1.0 0.0 0.0 -0.09643953149634399 0.0 1.0 0.0 7.007672103883749 0.0 0.0 1.0 -9.036354555841172</shift>
+      <correlation>0.9321167659568985</correlation>
+      <hash>-16871.76</hash>
+      <overlap_boundingbox>199.0 102.0 -1236.0 255.0 159.0 1236.0</overlap_boundingbox>
+    </PairwiseResult>
+    <PairwiseResult view_setup_a="5" view_setup_b="7" tp_a="0" tp_b="0">
+      <shift>1.0 0.0 0.0 0.31868072554544824 0.0 1.0 0.0 -14.060647711779382 0.0 0.0 1.0 22.925437346686294</shift>
+      <correlation>0.9354709581463394</correlation>
+      <hash>-26924.88</hash>
+      <overlap_boundingbox>-256.0 -160.0 -1236.0 -200.0 -103.0 1236.0</overlap_boundingbox>
+    </PairwiseResult>
+    <PairwiseResult view_setup_a="4" view_setup_b="6" tp_a="0" tp_b="0">
+      <shift>1.0 0.0 0.0 0.42744418243105997 0.0 1.0 0.0 -14.049728759960828 0.0 0.0 1.0 23.294215724982678</shift>
+      <correlation>0.9410862556623087</correlation>
+      <hash>-20545.36</hash>
+      <overlap_boundingbox>199.0 -160.0 -1236.0 255.0 -103.0 1236.0</overlap_boundingbox>
+    </PairwiseResult>
+    <PairwiseResult view_setup_a="2" view_setup_b="5" tp_a="0" tp_b="0">
+      <shift>1.0 0.0 0.0 -1.5104784240610343 0.0 1.0 0.0 7.395826789692137 0.0 0.0 1.0 -9.997150408536527</shift>
+      <correlation>0.9162468747756625</correlation>
+      <hash>-29175.120000000003</hash>
+      <overlap_boundingbox>-712.0 102.0 -1236.0 -200.0 159.0 1236.0</overlap_boundingbox>
+    </PairwiseResult>
+    <PairwiseResult view_setup_a="1" view_setup_b="4" tp_a="0" tp_b="0">
+      <shift>1.0 0.0 0.0 -1.9429844985963882 0.0 1.0 0.0 7.478610381875683 0.0 0.0 1.0 -9.992593031616707</shift>
+      <correlation>0.9304678530064963</correlation>
+      <hash>-22795.6</hash>
+      <overlap_boundingbox>-256.0 102.0 -1236.0 255.0 159.0 1236.0</overlap_boundingbox>
+    </PairwiseResult>
+    <PairwiseResult view_setup_a="0" view_setup_b="3" tp_a="0" tp_b="0">
+      <shift>1.0 0.0 0.0 -2.0782351526913487 0.0 1.0 0.0 7.41086456502083 0.0 0.0 1.0 -9.69656279859555</shift>
+      <correlation>0.9357936880330161</correlation>
+      <hash>-16416.08</hash>
+      <overlap_boundingbox>199.0 102.0 -1236.0 711.0 159.0 1236.0</overlap_boundingbox>
+    </PairwiseResult>
+    <PairwiseResult view_setup_a="5" view_setup_b="8" tp_a="0" tp_b="0">
+      <shift>1.0 0.0 0.0 -0.3287299635215959 0.0 1.0 0.0 -14.747678576491978 0.0 0.0 1.0 21.81115327961561</shift>
+      <correlation>0.9138108463084885</correlation>
+      <hash>-32848.72</hash>
+      <overlap_boundingbox>-712.0 -160.0 -1236.0 -200.0 -103.0 1236.0</overlap_boundingbox>
+    </PairwiseResult>
+    <PairwiseResult view_setup_a="4" view_setup_b="7" tp_a="0" tp_b="0">
+      <shift>1.0 0.0 0.0 0.34904618022437717 0.0 1.0 0.0 -15.354558165871083 0.0 0.0 1.0 21.82603817266454</shift>
+      <correlation>0.8990291118916934</correlation>
+      <hash>-26469.2</hash>
+      <overlap_boundingbox>-256.0 -160.0 -1236.0 255.0 -103.0 1236.0</overlap_boundingbox>
+    </PairwiseResult>
+    <PairwiseResult view_setup_a="3" view_setup_b="6" tp_a="0" tp_b="0">
+      <shift>1.0 0.0 0.0 1.0216345489996854 0.0 1.0 0.0 -15.042586536834278 0.0 0.0 1.0 21.61643113924515</shift>
+      <correlation>0.8887321660239942</correlation>
+      <hash>-20089.68</hash>
+      <overlap_boundingbox>199.0 -160.0 -1236.0 711.0 -103.0 1236.0</overlap_boundingbox>
+    </PairwiseResult>
+    <PairwiseResult view_setup_a="1" view_setup_b="5" tp_a="0" tp_b="0">
+      <shift>1.0 0.0 0.0 -0.6616285141958542 0.0 1.0 0.0 7.55184164375774 0.0 0.0 1.0 -11.190099606327976</shift>
+      <correlation>0.9526419402381631</correlation>
+      <hash>-28719.440000000002</hash>
+      <overlap_boundingbox>-256.0 102.0 -1236.0 -200.0 159.0 1236.0</overlap_boundingbox>
+    </PairwiseResult>
+    <PairwiseResult view_setup_a="0" view_setup_b="4" tp_a="0" tp_b="0">
+      <shift>1.0 0.0 0.0 -0.7271388208706355 0.0 1.0 0.0 7.638504842226183 0.0 0.0 1.0 -11.471001585951399</shift>
+      <correlation>0.9439136410878279</correlation>
+      <hash>-22339.92</hash>
+      <overlap_boundingbox>199.0 102.0 -1236.0 255.0 159.0 1236.0</overlap_boundingbox>
+    </PairwiseResult>
+    <PairwiseResult view_setup_a="4" view_setup_b="8" tp_a="0" tp_b="0">
+      <shift>1.0 0.0 0.0 -0.284636513100736 0.0 1.0 0.0 -15.462312909779143 0.0 0.0 1.0 21.767295071746958</shift>
+      <correlation>0.9233340706532531</correlation>
+      <hash>-32393.04</hash>
+      <overlap_boundingbox>-256.0 -160.0 -1236.0 -200.0 -103.0 1236.0</overlap_boundingbox>
+    </PairwiseResult>
+    <PairwiseResult view_setup_a="3" view_setup_b="7" tp_a="0" tp_b="0">
+      <shift>1.0 0.0 0.0 -0.13258697351179194 0.0 1.0 0.0 -14.947295037284562 0.0 0.0 1.0 19.954530783329574</shift>
+      <correlation>0.9243536847543689</correlation>
+      <hash>-26013.52</hash>
+      <overlap_boundingbox>199.0 -160.0 -1236.0 255.0 -103.0 1236.0</overlap_boundingbox>
+    </PairwiseResult>
+  </StitchingResults>
+  <IntensityAdjustments />
+</SpimData>

--- a/data/dataset_corrected.xml
+++ b/data/dataset_corrected.xml
@@ -1,0 +1,417 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SpimData version="0.2">
+  <BasePath type="relative">.</BasePath>
+  <SequenceDescription>
+    <ImageLoader format="spimreconstruction.wrapped.flatfield.multiresolution" Active="true" Cached="true">
+      <WrappedImgLoader>
+        <ImageLoader format="bdv.n5" version="1.1">
+          <n5 type="relative">dataset.n5/</n5>
+        </ImageLoader>
+      </WrappedImgLoader>
+      <FlatFields>
+        <FlatField Timepoint="0" ViewSetup="0">
+          <BrightImg>dark_and_flatfields/setup187-flatfield (fixed by mirroring).tif</BrightImg>
+          <DarkImg>dark_and_flatfields/setup187-AVG_darkfield-fromdata.tif</DarkImg>
+        </FlatField>
+        <FlatField Timepoint="0" ViewSetup="1">
+          <BrightImg>dark_and_flatfields/setup188-flatfield (fixed by mirroring).tif</BrightImg>
+          <DarkImg>dark_and_flatfields/setup188-AVG_darkfield-fromdata.tif</DarkImg>
+        </FlatField>
+        <FlatField Timepoint="0" ViewSetup="2">
+          <BrightImg>dark_and_flatfields/setup189-flatfield.tif</BrightImg>
+          <DarkImg>dark_and_flatfields/setup189-AVG_darkfield-fromdata.tif</DarkImg>
+        </FlatField>
+        <FlatField Timepoint="0" ViewSetup="3">
+          <BrightImg>dark_and_flatfields/setup200-flatfield (fixed by mirroring).tif</BrightImg>
+          <DarkImg>dark_and_flatfields/setup200-AVG_darkfield-fromdata.tif</DarkImg>
+        </FlatField>
+        <FlatField Timepoint="0" ViewSetup="4">
+          <BrightImg>dark_and_flatfields/setup201-flatfield (fixed by mirroring).tif</BrightImg>
+          <DarkImg>dark_and_flatfields/setup201-AVG_darkfield-fromdata.tif</DarkImg>
+        </FlatField>
+        <FlatField Timepoint="0" ViewSetup="5">
+          <BrightImg>dark_and_flatfields/setup202-flatfield.tif</BrightImg>
+          <DarkImg>dark_and_flatfields/setup202-AVG_darkfield-fromdata.tif</DarkImg>
+        </FlatField>
+        <FlatField Timepoint="0" ViewSetup="6">
+          <BrightImg>dark_and_flatfields/setup213-flatfield (fixed by mirroring).tif</BrightImg>
+          <DarkImg>dark_and_flatfields/setup213-AVG_darkfield-fromdata.tif</DarkImg>
+        </FlatField>
+        <FlatField Timepoint="0" ViewSetup="7">
+          <BrightImg>dark_and_flatfields/setup214-flatfield.tif</BrightImg>
+          <DarkImg>dark_and_flatfields/setup214-AVG_darkfield-fromdata.tif</DarkImg>
+        </FlatField>
+        <FlatField Timepoint="0" ViewSetup="8">
+          <BrightImg>dark_and_flatfields/setup215-flatfield.tif</BrightImg>
+          <DarkImg>dark_and_flatfields/setup215-AVG_darkfield-fromdata.tif</DarkImg>
+        </FlatField>
+      </FlatFields>
+    </ImageLoader>
+    <ViewSetups>
+      <ViewSetup>
+        <id>0</id>
+        <name>0</name>
+        <size>512 320 825</size>
+        <voxelSize>
+          <unit>pixels</unit>
+          <size>1.0 1.0 3.0</size>
+        </voxelSize>
+        <attributes>
+          <illumination>0</illumination>
+          <channel>0</channel>
+          <tile>187</tile>
+          <angle>0</angle>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>1</id>
+        <name>1</name>
+        <size>512 320 825</size>
+        <voxelSize>
+          <unit>pixels</unit>
+          <size>1.0 1.0 3.0</size>
+        </voxelSize>
+        <attributes>
+          <illumination>0</illumination>
+          <channel>0</channel>
+          <tile>188</tile>
+          <angle>0</angle>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>2</id>
+        <name>2</name>
+        <size>512 320 825</size>
+        <voxelSize>
+          <unit>pixels</unit>
+          <size>1.0 1.0 3.0</size>
+        </voxelSize>
+        <attributes>
+          <illumination>0</illumination>
+          <channel>0</channel>
+          <tile>189</tile>
+          <angle>0</angle>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>3</id>
+        <name>3</name>
+        <size>512 320 825</size>
+        <voxelSize>
+          <unit>pixels</unit>
+          <size>1.0 1.0 3.0</size>
+        </voxelSize>
+        <attributes>
+          <illumination>0</illumination>
+          <channel>0</channel>
+          <tile>200</tile>
+          <angle>0</angle>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>4</id>
+        <name>4</name>
+        <size>512 320 825</size>
+        <voxelSize>
+          <unit>pixels</unit>
+          <size>1.0 1.0 3.0</size>
+        </voxelSize>
+        <attributes>
+          <illumination>0</illumination>
+          <channel>0</channel>
+          <tile>201</tile>
+          <angle>0</angle>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>5</id>
+        <name>5</name>
+        <size>512 320 825</size>
+        <voxelSize>
+          <unit>pixels</unit>
+          <size>1.0 1.0 3.0</size>
+        </voxelSize>
+        <attributes>
+          <illumination>0</illumination>
+          <channel>0</channel>
+          <tile>202</tile>
+          <angle>0</angle>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>6</id>
+        <name>6</name>
+        <size>512 320 825</size>
+        <voxelSize>
+          <unit>pixels</unit>
+          <size>1.0 1.0 3.0</size>
+        </voxelSize>
+        <attributes>
+          <illumination>0</illumination>
+          <channel>0</channel>
+          <tile>213</tile>
+          <angle>0</angle>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>7</id>
+        <name>7</name>
+        <size>512 320 825</size>
+        <voxelSize>
+          <unit>pixels</unit>
+          <size>1.0 1.0 3.0</size>
+        </voxelSize>
+        <attributes>
+          <illumination>0</illumination>
+          <channel>0</channel>
+          <tile>214</tile>
+          <angle>0</angle>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>8</id>
+        <name>8</name>
+        <size>512 320 825</size>
+        <voxelSize>
+          <unit>pixels</unit>
+          <size>1.0 1.0 3.0</size>
+        </voxelSize>
+        <attributes>
+          <illumination>0</illumination>
+          <channel>0</channel>
+          <tile>215</tile>
+          <angle>0</angle>
+        </attributes>
+      </ViewSetup>
+      <Attributes name="illumination">
+        <Illumination>
+          <id>0</id>
+          <name>0</name>
+        </Illumination>
+      </Attributes>
+      <Attributes name="channel">
+        <Channel>
+          <id>0</id>
+          <name>0</name>
+        </Channel>
+      </Attributes>
+      <Attributes name="tile">
+        <Tile>
+          <id>187</id>
+          <name>187</name>
+        </Tile>
+        <Tile>
+          <id>188</id>
+          <name>188</name>
+        </Tile>
+        <Tile>
+          <id>189</id>
+          <name>189</name>
+        </Tile>
+        <Tile>
+          <id>200</id>
+          <name>200</name>
+        </Tile>
+        <Tile>
+          <id>201</id>
+          <name>201</name>
+        </Tile>
+        <Tile>
+          <id>202</id>
+          <name>202</name>
+        </Tile>
+        <Tile>
+          <id>213</id>
+          <name>213</name>
+        </Tile>
+        <Tile>
+          <id>214</id>
+          <name>214</name>
+        </Tile>
+        <Tile>
+          <id>215</id>
+          <name>215</name>
+        </Tile>
+      </Attributes>
+      <Attributes name="angle">
+        <Angle>
+          <id>0</id>
+          <name>0</name>
+        </Angle>
+      </Attributes>
+    </ViewSetups>
+    <Timepoints type="pattern">
+      <integerpattern>0</integerpattern>
+    </Timepoints>
+    <MissingViews />
+  </SequenceDescription>
+  <ViewRegistrations>
+    <ViewRegistration timepoint="0" setup="0">
+      <ViewTransform type="affine">
+        <Name>AffineModel3D regularized with an RigidModel3D, lambda = 0.1</Name>
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>Stitching Transform</Name>
+        <affine>1.0 0.0 0.0 0.4554158176323426 0.0 1.0 0.0 -0.13328548693164066 0.0 0.0 1.0 1.039028825990859</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>Translation to Regular Grid</Name>
+        <affine>1.0 0.0 0.0 199.68 0.0 1.0 0.0 102.40000000000003 0.0 0.0 1.0 -1236.0</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>calibration</Name>
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 3.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="1">
+      <ViewTransform type="affine">
+        <Name>AffineModel3D regularized with an RigidModel3D, lambda = 0.1</Name>
+        <affine>0.9996881730582423 1.0178764373025146E-4 9.91613051380682E-5 0.296854107149204 -0.0014206520238486176 1.000352820575225 5.493263412035365E-5 0.4978096475705985 -4.038421786319725E-4 1.2989941922307108E-4 1.0000050536353644 0.012322662821996552</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>Stitching Transform</Name>
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>Translation to Regular Grid</Name>
+        <affine>1.0 0.0 0.0 -256.0 0.0 1.0 0.0 102.40000000000003 0.0 0.0 1.0 -1236.0</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>calibration</Name>
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 3.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="2">
+      <ViewTransform type="affine">
+        <Name>AffineModel3D regularized with an RigidModel3D, lambda = 0.1</Name>
+        <affine>0.9999774841758134 -2.0323268523581142E-4 5.914840097558037E-5 0.41302203806414345 -6.595441757221898E-4 1.0005468325585005 1.0422412713430604E-4 0.86847428183128 -3.8743282755243446E-4 6.197381562939316E-4 0.9999038186675331 -0.1051593717912322</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>Stitching Transform</Name>
+        <affine>1.0 0.0 0.0 -0.2804882451294475 0.0 1.0 0.0 0.15177465825263425 0.0 0.0 1.0 -0.8673431810167168</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>Translation to Regular Grid</Name>
+        <affine>1.0 0.0 0.0 -711.6800000000001 0.0 1.0 0.0 102.40000000000003 0.0 0.0 1.0 -1236.0</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>calibration</Name>
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 3.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="3">
+      <ViewTransform type="affine">
+        <Name>AffineModel3D regularized with an RigidModel3D, lambda = 0.1</Name>
+        <affine>0.9996509004376033 0.0011789057647756168 6.625470971101606E-5 -0.4380062409126003 -5.886838131605057E-6 0.9993980714516947 8.378533632140301E-4 0.21066285389381184 1.1914663433102846E-4 -0.0017577181435329034 0.9993905308006584 -0.10732512771106033</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>Stitching Transform</Name>
+        <affine>1.0 0.0 0.0 -0.8442948117588571 0.0 1.0 0.0 7.4417831077170336 0.0 0.0 1.0 -8.789096260073075</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>Translation to Regular Grid</Name>
+        <affine>1.0 0.0 0.0 199.68 0.0 1.0 0.0 -160.0 0.0 0.0 1.0 -1236.0</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>calibration</Name>
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 3.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="4">
+      <ViewTransform type="affine">
+        <Name>AffineModel3D regularized with an RigidModel3D, lambda = 0.1</Name>
+        <affine>0.9993691627809789 6.213286683890014E-4 9.303551548369867E-5 -0.5698358880199796 -0.0012153705700172891 0.9994415380582407 8.680618674785683E-4 0.916909696194346 -1.5083252038943456E-4 -0.0011408852434367028 0.9994660587646744 0.2820529225572497</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>Stitching Transform</Name>
+        <affine>1.0 0.0 0.0 -0.9089191675130128 0.0 1.0 0.0 7.4256749717825095 0.0 0.0 1.0 -10.328335265676746</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>Translation to Regular Grid</Name>
+        <affine>1.0 0.0 0.0 -256.0 0.0 1.0 0.0 -160.0 0.0 0.0 1.0 -1236.0</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>calibration</Name>
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 3.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="5">
+      <ViewTransform type="affine">
+        <Name>AffineModel3D regularized with an RigidModel3D, lambda = 0.1</Name>
+        <affine>0.9995958883424029 1.1960194298687558E-4 1.3045003320240472E-4 -0.5288425017288729 -4.5021629309568165E-4 0.9995801176422028 9.375713906809582E-4 1.7071573589623064 -2.5232116962087617E-4 -5.217759052761294E-4 0.9995631970154002 0.266678832277585</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>Stitching Transform</Name>
+        <affine>1.0 0.0 0.0 -1.1369886493304193 0.0 1.0 0.0 7.212246076053502 0.0 0.0 1.0 -11.06907324837572</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>Translation to Regular Grid</Name>
+        <affine>1.0 0.0 0.0 -711.6800000000001 0.0 1.0 0.0 -160.0 0.0 0.0 1.0 -1236.0</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>calibration</Name>
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 3.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="6">
+      <ViewTransform type="affine">
+        <Name>AffineModel3D regularized with an RigidModel3D, lambda = 0.1</Name>
+        <affine>1.001169864797628 0.00527491302811622 1.4584877195363756E-4 -0.15773640915627343 -0.004686469222584484 0.9996923176367982 -0.002087984887367355 1.2420606082221906 -6.295077531490363E-4 0.005598468303174577 1.0011602899054004 1.9104004620529875</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>Stitching Transform</Name>
+        <affine>1.0 0.0 0.0 -0.2626855827553527 0.0 1.0 0.0 -6.7600081391679225 0.0 0.0 1.0 12.896136661870298</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>Translation to Regular Grid</Name>
+        <affine>1.0 0.0 0.0 199.68 0.0 1.0 0.0 -422.40000000000003 0.0 0.0 1.0 -1236.0</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>calibration</Name>
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 3.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="7">
+      <ViewTransform type="affine">
+        <Name>AffineModel3D regularized with an RigidModel3D, lambda = 0.1</Name>
+        <affine>1.0009007956899272 0.0053216640997549155 1.371415077664928E-4 0.31426019006657296 -0.005800996293005373 0.9993339550765709 -0.0019903541975732236 0.5557333216408067 -4.823233633192067E-4 0.003500523337610362 1.0009341748352047 1.2744275908022205</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>Stitching Transform</Name>
+        <affine>1.0 0.0 0.0 -0.7700626936842326 0.0 1.0 0.0 -7.432744962459225 0.0 0.0 1.0 11.579421273826847</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>Translation to Regular Grid</Name>
+        <affine>1.0 0.0 0.0 -256.0 0.0 1.0 0.0 -422.40000000000003 0.0 0.0 1.0 -1236.0</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>calibration</Name>
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 3.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="8">
+      <ViewTransform type="affine">
+        <Name>AffineModel3D regularized with an RigidModel3D, lambda = 0.1</Name>
+        <affine>1.0012387020759832 0.005337931651988534 5.916593012930141E-5 0.6833023552548335 -0.0048548568558627265 0.9989044018136208 -0.0019280609543394106 -0.26569722464665557 -3.915489271687177E-4 0.0016823628452441262 1.0009459560649534 0.679636329046033</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>Stitching Transform</Name>
+        <affine>1.0 0.0 0.0 -1.2414564955437868 0.0 1.0 0.0 -8.130736624699523 0.0 0.0 1.0 10.981609779561097</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>Translation to Regular Grid</Name>
+        <affine>1.0 0.0 0.0 -711.6800000000001 0.0 1.0 0.0 -422.40000000000003 0.0 0.0 1.0 -1236.0</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>calibration</Name>
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 3.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+  </ViewRegistrations>
+  <ViewInterestPoints />
+  <BoundingBoxes />
+  <PointSpreadFunctions />
+  <StitchingResults />
+  <IntensityAdjustments />
+</SpimData>

--- a/data/dataset_corrected.xml
+++ b/data/dataset_corrected.xml
@@ -10,40 +10,40 @@
       </WrappedImgLoader>
       <FlatFields>
         <FlatField Timepoint="0" ViewSetup="0">
-          <BrightImg>dark_and_flatfields/setup187-flatfield (fixed by mirroring).tif</BrightImg>
-          <DarkImg>dark_and_flatfields/setup187-AVG_darkfield-fromdata.tif</DarkImg>
+          <BrightImg format="tif">dark_and_flatfields/setup187-flatfield (fixed by mirroring).tif</BrightImg>
+          <DarkImg format="tif">dark_and_flatfields/setup187-AVG_darkfield-fromdata.tif</DarkImg>
         </FlatField>
         <FlatField Timepoint="0" ViewSetup="1">
-          <BrightImg>dark_and_flatfields/setup188-flatfield (fixed by mirroring).tif</BrightImg>
-          <DarkImg>dark_and_flatfields/setup188-AVG_darkfield-fromdata.tif</DarkImg>
+          <BrightImg format="tif">dark_and_flatfields/setup188-flatfield (fixed by mirroring).tif</BrightImg>
+          <DarkImg format="tif">dark_and_flatfields/setup188-AVG_darkfield-fromdata.tif</DarkImg>
         </FlatField>
         <FlatField Timepoint="0" ViewSetup="2">
-          <BrightImg>dark_and_flatfields/setup189-flatfield.tif</BrightImg>
-          <DarkImg>dark_and_flatfields/setup189-AVG_darkfield-fromdata.tif</DarkImg>
+          <BrightImg format="tif">dark_and_flatfields/setup189-flatfield.tif</BrightImg>
+          <DarkImg format="tif">dark_and_flatfields/setup189-AVG_darkfield-fromdata.tif</DarkImg>
         </FlatField>
         <FlatField Timepoint="0" ViewSetup="3">
-          <BrightImg>dark_and_flatfields/setup200-flatfield (fixed by mirroring).tif</BrightImg>
-          <DarkImg>dark_and_flatfields/setup200-AVG_darkfield-fromdata.tif</DarkImg>
+          <BrightImg format="tif">dark_and_flatfields/setup200-flatfield (fixed by mirroring).tif</BrightImg>
+          <DarkImg format="tif">dark_and_flatfields/setup200-AVG_darkfield-fromdata.tif</DarkImg>
         </FlatField>
         <FlatField Timepoint="0" ViewSetup="4">
-          <BrightImg>dark_and_flatfields/setup201-flatfield (fixed by mirroring).tif</BrightImg>
-          <DarkImg>dark_and_flatfields/setup201-AVG_darkfield-fromdata.tif</DarkImg>
+          <BrightImg format="tif">dark_and_flatfields/setup201-flatfield (fixed by mirroring).tif</BrightImg>
+          <DarkImg format="tif">dark_and_flatfields/setup201-AVG_darkfield-fromdata.tif</DarkImg>
         </FlatField>
         <FlatField Timepoint="0" ViewSetup="5">
-          <BrightImg>dark_and_flatfields/setup202-flatfield.tif</BrightImg>
-          <DarkImg>dark_and_flatfields/setup202-AVG_darkfield-fromdata.tif</DarkImg>
+          <BrightImg format="tif">dark_and_flatfields/setup202-flatfield.tif</BrightImg>
+          <DarkImg format="tif">dark_and_flatfields/setup202-AVG_darkfield-fromdata.tif</DarkImg>
         </FlatField>
         <FlatField Timepoint="0" ViewSetup="6">
-          <BrightImg>dark_and_flatfields/setup213-flatfield (fixed by mirroring).tif</BrightImg>
-          <DarkImg>dark_and_flatfields/setup213-AVG_darkfield-fromdata.tif</DarkImg>
+          <BrightImg format="tif">dark_and_flatfields/setup213-flatfield (fixed by mirroring).tif</BrightImg>
+          <DarkImg format="tif">dark_and_flatfields/setup213-AVG_darkfield-fromdata.tif</DarkImg>
         </FlatField>
         <FlatField Timepoint="0" ViewSetup="7">
-          <BrightImg>dark_and_flatfields/setup214-flatfield.tif</BrightImg>
-          <DarkImg>dark_and_flatfields/setup214-AVG_darkfield-fromdata.tif</DarkImg>
+          <BrightImg format="tif">dark_and_flatfields/setup214-flatfield.tif</BrightImg>
+          <DarkImg format="tif">dark_and_flatfields/setup214-AVG_darkfield-fromdata.tif</DarkImg>
         </FlatField>
         <FlatField Timepoint="0" ViewSetup="8">
-          <BrightImg>dark_and_flatfields/setup215-flatfield.tif</BrightImg>
-          <DarkImg>dark_and_flatfields/setup215-AVG_darkfield-fromdata.tif</DarkImg>
+          <BrightImg format="tif">dark_and_flatfields/setup215-flatfield.tif</BrightImg>
+          <DarkImg format="tif">dark_and_flatfields/setup215-AVG_darkfield-fromdata.tif</DarkImg>
         </FlatField>
       </FlatFields>
     </ImageLoader>

--- a/data/dataset_corrected_viewer.xml
+++ b/data/dataset_corrected_viewer.xml
@@ -1,0 +1,417 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SpimData version="0.2">
+  <BasePath type="relative">.</BasePath>
+  <SequenceDescription>
+    <ImageLoader format="spimreconstruction.wrapped.flatfield.viewer" Active="true" Cached="true">
+      <WrappedImgLoader>
+        <ImageLoader format="bdv.n5" version="1.1">
+          <n5 type="relative">dataset.n5/</n5>
+        </ImageLoader>
+      </WrappedImgLoader>
+      <FlatFields>
+        <FlatField Timepoint="0" ViewSetup="0">
+          <BrightImg>dark_and_flatfields/setup187-flatfield (fixed by mirroring).tif</BrightImg>
+          <DarkImg>dark_and_flatfields/setup187-AVG_darkfield-fromdata.tif</DarkImg>
+        </FlatField>
+        <FlatField Timepoint="0" ViewSetup="1">
+          <BrightImg>dark_and_flatfields/setup188-flatfield (fixed by mirroring).tif</BrightImg>
+          <DarkImg>dark_and_flatfields/setup188-AVG_darkfield-fromdata.tif</DarkImg>
+        </FlatField>
+        <FlatField Timepoint="0" ViewSetup="2">
+          <BrightImg>dark_and_flatfields/setup189-flatfield.tif</BrightImg>
+          <DarkImg>dark_and_flatfields/setup189-AVG_darkfield-fromdata.tif</DarkImg>
+        </FlatField>
+        <FlatField Timepoint="0" ViewSetup="3">
+          <BrightImg>dark_and_flatfields/setup200-flatfield (fixed by mirroring).tif</BrightImg>
+          <DarkImg>dark_and_flatfields/setup200-AVG_darkfield-fromdata.tif</DarkImg>
+        </FlatField>
+        <FlatField Timepoint="0" ViewSetup="4">
+          <BrightImg>dark_and_flatfields/setup201-flatfield (fixed by mirroring).tif</BrightImg>
+          <DarkImg>dark_and_flatfields/setup201-AVG_darkfield-fromdata.tif</DarkImg>
+        </FlatField>
+        <FlatField Timepoint="0" ViewSetup="5">
+          <BrightImg>dark_and_flatfields/setup202-flatfield.tif</BrightImg>
+          <DarkImg>dark_and_flatfields/setup202-AVG_darkfield-fromdata.tif</DarkImg>
+        </FlatField>
+        <FlatField Timepoint="0" ViewSetup="6">
+          <BrightImg>dark_and_flatfields/setup213-flatfield (fixed by mirroring).tif</BrightImg>
+          <DarkImg>dark_and_flatfields/setup213-AVG_darkfield-fromdata.tif</DarkImg>
+        </FlatField>
+        <FlatField Timepoint="0" ViewSetup="7">
+          <BrightImg>dark_and_flatfields/setup214-flatfield.tif</BrightImg>
+          <DarkImg>dark_and_flatfields/setup214-AVG_darkfield-fromdata.tif</DarkImg>
+        </FlatField>
+        <FlatField Timepoint="0" ViewSetup="8">
+          <BrightImg>dark_and_flatfields/setup215-flatfield.tif</BrightImg>
+          <DarkImg>dark_and_flatfields/setup215-AVG_darkfield-fromdata.tif</DarkImg>
+        </FlatField>
+      </FlatFields>
+    </ImageLoader>
+    <ViewSetups>
+      <ViewSetup>
+        <id>0</id>
+        <name>0</name>
+        <size>512 320 825</size>
+        <voxelSize>
+          <unit>pixels</unit>
+          <size>1.0 1.0 3.0</size>
+        </voxelSize>
+        <attributes>
+          <illumination>0</illumination>
+          <channel>0</channel>
+          <tile>187</tile>
+          <angle>0</angle>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>1</id>
+        <name>1</name>
+        <size>512 320 825</size>
+        <voxelSize>
+          <unit>pixels</unit>
+          <size>1.0 1.0 3.0</size>
+        </voxelSize>
+        <attributes>
+          <illumination>0</illumination>
+          <channel>0</channel>
+          <tile>188</tile>
+          <angle>0</angle>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>2</id>
+        <name>2</name>
+        <size>512 320 825</size>
+        <voxelSize>
+          <unit>pixels</unit>
+          <size>1.0 1.0 3.0</size>
+        </voxelSize>
+        <attributes>
+          <illumination>0</illumination>
+          <channel>0</channel>
+          <tile>189</tile>
+          <angle>0</angle>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>3</id>
+        <name>3</name>
+        <size>512 320 825</size>
+        <voxelSize>
+          <unit>pixels</unit>
+          <size>1.0 1.0 3.0</size>
+        </voxelSize>
+        <attributes>
+          <illumination>0</illumination>
+          <channel>0</channel>
+          <tile>200</tile>
+          <angle>0</angle>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>4</id>
+        <name>4</name>
+        <size>512 320 825</size>
+        <voxelSize>
+          <unit>pixels</unit>
+          <size>1.0 1.0 3.0</size>
+        </voxelSize>
+        <attributes>
+          <illumination>0</illumination>
+          <channel>0</channel>
+          <tile>201</tile>
+          <angle>0</angle>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>5</id>
+        <name>5</name>
+        <size>512 320 825</size>
+        <voxelSize>
+          <unit>pixels</unit>
+          <size>1.0 1.0 3.0</size>
+        </voxelSize>
+        <attributes>
+          <illumination>0</illumination>
+          <channel>0</channel>
+          <tile>202</tile>
+          <angle>0</angle>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>6</id>
+        <name>6</name>
+        <size>512 320 825</size>
+        <voxelSize>
+          <unit>pixels</unit>
+          <size>1.0 1.0 3.0</size>
+        </voxelSize>
+        <attributes>
+          <illumination>0</illumination>
+          <channel>0</channel>
+          <tile>213</tile>
+          <angle>0</angle>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>7</id>
+        <name>7</name>
+        <size>512 320 825</size>
+        <voxelSize>
+          <unit>pixels</unit>
+          <size>1.0 1.0 3.0</size>
+        </voxelSize>
+        <attributes>
+          <illumination>0</illumination>
+          <channel>0</channel>
+          <tile>214</tile>
+          <angle>0</angle>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>8</id>
+        <name>8</name>
+        <size>512 320 825</size>
+        <voxelSize>
+          <unit>pixels</unit>
+          <size>1.0 1.0 3.0</size>
+        </voxelSize>
+        <attributes>
+          <illumination>0</illumination>
+          <channel>0</channel>
+          <tile>215</tile>
+          <angle>0</angle>
+        </attributes>
+      </ViewSetup>
+      <Attributes name="illumination">
+        <Illumination>
+          <id>0</id>
+          <name>0</name>
+        </Illumination>
+      </Attributes>
+      <Attributes name="channel">
+        <Channel>
+          <id>0</id>
+          <name>0</name>
+        </Channel>
+      </Attributes>
+      <Attributes name="tile">
+        <Tile>
+          <id>187</id>
+          <name>187</name>
+        </Tile>
+        <Tile>
+          <id>188</id>
+          <name>188</name>
+        </Tile>
+        <Tile>
+          <id>189</id>
+          <name>189</name>
+        </Tile>
+        <Tile>
+          <id>200</id>
+          <name>200</name>
+        </Tile>
+        <Tile>
+          <id>201</id>
+          <name>201</name>
+        </Tile>
+        <Tile>
+          <id>202</id>
+          <name>202</name>
+        </Tile>
+        <Tile>
+          <id>213</id>
+          <name>213</name>
+        </Tile>
+        <Tile>
+          <id>214</id>
+          <name>214</name>
+        </Tile>
+        <Tile>
+          <id>215</id>
+          <name>215</name>
+        </Tile>
+      </Attributes>
+      <Attributes name="angle">
+        <Angle>
+          <id>0</id>
+          <name>0</name>
+        </Angle>
+      </Attributes>
+    </ViewSetups>
+    <Timepoints type="pattern">
+      <integerpattern>0</integerpattern>
+    </Timepoints>
+    <MissingViews />
+  </SequenceDescription>
+  <ViewRegistrations>
+    <ViewRegistration timepoint="0" setup="0">
+      <ViewTransform type="affine">
+        <Name>AffineModel3D regularized with an RigidModel3D, lambda = 0.1</Name>
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>Stitching Transform</Name>
+        <affine>1.0 0.0 0.0 0.4554158176323426 0.0 1.0 0.0 -0.13328548693164066 0.0 0.0 1.0 1.039028825990859</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>Translation to Regular Grid</Name>
+        <affine>1.0 0.0 0.0 199.68 0.0 1.0 0.0 102.40000000000003 0.0 0.0 1.0 -1236.0</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>calibration</Name>
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 3.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="1">
+      <ViewTransform type="affine">
+        <Name>AffineModel3D regularized with an RigidModel3D, lambda = 0.1</Name>
+        <affine>0.9996881730582423 1.0178764373025146E-4 9.91613051380682E-5 0.296854107149204 -0.0014206520238486176 1.000352820575225 5.493263412035365E-5 0.4978096475705985 -4.038421786319725E-4 1.2989941922307108E-4 1.0000050536353644 0.012322662821996552</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>Stitching Transform</Name>
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>Translation to Regular Grid</Name>
+        <affine>1.0 0.0 0.0 -256.0 0.0 1.0 0.0 102.40000000000003 0.0 0.0 1.0 -1236.0</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>calibration</Name>
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 3.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="2">
+      <ViewTransform type="affine">
+        <Name>AffineModel3D regularized with an RigidModel3D, lambda = 0.1</Name>
+        <affine>0.9999774841758134 -2.0323268523581142E-4 5.914840097558037E-5 0.41302203806414345 -6.595441757221898E-4 1.0005468325585005 1.0422412713430604E-4 0.86847428183128 -3.8743282755243446E-4 6.197381562939316E-4 0.9999038186675331 -0.1051593717912322</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>Stitching Transform</Name>
+        <affine>1.0 0.0 0.0 -0.2804882451294475 0.0 1.0 0.0 0.15177465825263425 0.0 0.0 1.0 -0.8673431810167168</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>Translation to Regular Grid</Name>
+        <affine>1.0 0.0 0.0 -711.6800000000001 0.0 1.0 0.0 102.40000000000003 0.0 0.0 1.0 -1236.0</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>calibration</Name>
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 3.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="3">
+      <ViewTransform type="affine">
+        <Name>AffineModel3D regularized with an RigidModel3D, lambda = 0.1</Name>
+        <affine>0.9996509004376033 0.0011789057647756168 6.625470971101606E-5 -0.4380062409126003 -5.886838131605057E-6 0.9993980714516947 8.378533632140301E-4 0.21066285389381184 1.1914663433102846E-4 -0.0017577181435329034 0.9993905308006584 -0.10732512771106033</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>Stitching Transform</Name>
+        <affine>1.0 0.0 0.0 -0.8442948117588571 0.0 1.0 0.0 7.4417831077170336 0.0 0.0 1.0 -8.789096260073075</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>Translation to Regular Grid</Name>
+        <affine>1.0 0.0 0.0 199.68 0.0 1.0 0.0 -160.0 0.0 0.0 1.0 -1236.0</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>calibration</Name>
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 3.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="4">
+      <ViewTransform type="affine">
+        <Name>AffineModel3D regularized with an RigidModel3D, lambda = 0.1</Name>
+        <affine>0.9993691627809789 6.213286683890014E-4 9.303551548369867E-5 -0.5698358880199796 -0.0012153705700172891 0.9994415380582407 8.680618674785683E-4 0.916909696194346 -1.5083252038943456E-4 -0.0011408852434367028 0.9994660587646744 0.2820529225572497</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>Stitching Transform</Name>
+        <affine>1.0 0.0 0.0 -0.9089191675130128 0.0 1.0 0.0 7.4256749717825095 0.0 0.0 1.0 -10.328335265676746</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>Translation to Regular Grid</Name>
+        <affine>1.0 0.0 0.0 -256.0 0.0 1.0 0.0 -160.0 0.0 0.0 1.0 -1236.0</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>calibration</Name>
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 3.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="5">
+      <ViewTransform type="affine">
+        <Name>AffineModel3D regularized with an RigidModel3D, lambda = 0.1</Name>
+        <affine>0.9995958883424029 1.1960194298687558E-4 1.3045003320240472E-4 -0.5288425017288729 -4.5021629309568165E-4 0.9995801176422028 9.375713906809582E-4 1.7071573589623064 -2.5232116962087617E-4 -5.217759052761294E-4 0.9995631970154002 0.266678832277585</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>Stitching Transform</Name>
+        <affine>1.0 0.0 0.0 -1.1369886493304193 0.0 1.0 0.0 7.212246076053502 0.0 0.0 1.0 -11.06907324837572</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>Translation to Regular Grid</Name>
+        <affine>1.0 0.0 0.0 -711.6800000000001 0.0 1.0 0.0 -160.0 0.0 0.0 1.0 -1236.0</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>calibration</Name>
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 3.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="6">
+      <ViewTransform type="affine">
+        <Name>AffineModel3D regularized with an RigidModel3D, lambda = 0.1</Name>
+        <affine>1.001169864797628 0.00527491302811622 1.4584877195363756E-4 -0.15773640915627343 -0.004686469222584484 0.9996923176367982 -0.002087984887367355 1.2420606082221906 -6.295077531490363E-4 0.005598468303174577 1.0011602899054004 1.9104004620529875</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>Stitching Transform</Name>
+        <affine>1.0 0.0 0.0 -0.2626855827553527 0.0 1.0 0.0 -6.7600081391679225 0.0 0.0 1.0 12.896136661870298</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>Translation to Regular Grid</Name>
+        <affine>1.0 0.0 0.0 199.68 0.0 1.0 0.0 -422.40000000000003 0.0 0.0 1.0 -1236.0</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>calibration</Name>
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 3.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="7">
+      <ViewTransform type="affine">
+        <Name>AffineModel3D regularized with an RigidModel3D, lambda = 0.1</Name>
+        <affine>1.0009007956899272 0.0053216640997549155 1.371415077664928E-4 0.31426019006657296 -0.005800996293005373 0.9993339550765709 -0.0019903541975732236 0.5557333216408067 -4.823233633192067E-4 0.003500523337610362 1.0009341748352047 1.2744275908022205</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>Stitching Transform</Name>
+        <affine>1.0 0.0 0.0 -0.7700626936842326 0.0 1.0 0.0 -7.432744962459225 0.0 0.0 1.0 11.579421273826847</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>Translation to Regular Grid</Name>
+        <affine>1.0 0.0 0.0 -256.0 0.0 1.0 0.0 -422.40000000000003 0.0 0.0 1.0 -1236.0</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>calibration</Name>
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 3.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="8">
+      <ViewTransform type="affine">
+        <Name>AffineModel3D regularized with an RigidModel3D, lambda = 0.1</Name>
+        <affine>1.0012387020759832 0.005337931651988534 5.916593012930141E-5 0.6833023552548335 -0.0048548568558627265 0.9989044018136208 -0.0019280609543394106 -0.26569722464665557 -3.915489271687177E-4 0.0016823628452441262 1.0009459560649534 0.679636329046033</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>Stitching Transform</Name>
+        <affine>1.0 0.0 0.0 -1.2414564955437868 0.0 1.0 0.0 -8.130736624699523 0.0 0.0 1.0 10.981609779561097</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>Translation to Regular Grid</Name>
+        <affine>1.0 0.0 0.0 -711.6800000000001 0.0 1.0 0.0 -422.40000000000003 0.0 0.0 1.0 -1236.0</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>calibration</Name>
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 3.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+  </ViewRegistrations>
+  <ViewInterestPoints />
+  <BoundingBoxes />
+  <PointSpreadFunctions />
+  <StitchingResults />
+  <IntensityAdjustments />
+</SpimData>

--- a/data/dataset_corrected_viewer.xml
+++ b/data/dataset_corrected_viewer.xml
@@ -10,40 +10,40 @@
       </WrappedImgLoader>
       <FlatFields>
         <FlatField Timepoint="0" ViewSetup="0">
-          <BrightImg>dark_and_flatfields/setup187-flatfield (fixed by mirroring).tif</BrightImg>
-          <DarkImg>dark_and_flatfields/setup187-AVG_darkfield-fromdata.tif</DarkImg>
+          <BrightImg format="tif">dark_and_flatfields/setup187-flatfield (fixed by mirroring).tif</BrightImg>
+          <DarkImg format="tif">dark_and_flatfields/setup187-AVG_darkfield-fromdata.tif</DarkImg>
         </FlatField>
         <FlatField Timepoint="0" ViewSetup="1">
-          <BrightImg>dark_and_flatfields/setup188-flatfield (fixed by mirroring).tif</BrightImg>
-          <DarkImg>dark_and_flatfields/setup188-AVG_darkfield-fromdata.tif</DarkImg>
+          <BrightImg format="tif">dark_and_flatfields/setup188-flatfield (fixed by mirroring).tif</BrightImg>
+          <DarkImg format="tif">dark_and_flatfields/setup188-AVG_darkfield-fromdata.tif</DarkImg>
         </FlatField>
         <FlatField Timepoint="0" ViewSetup="2">
-          <BrightImg>dark_and_flatfields/setup189-flatfield.tif</BrightImg>
-          <DarkImg>dark_and_flatfields/setup189-AVG_darkfield-fromdata.tif</DarkImg>
+          <BrightImg format="tif">dark_and_flatfields/setup189-flatfield.tif</BrightImg>
+          <DarkImg format="tif">dark_and_flatfields/setup189-AVG_darkfield-fromdata.tif</DarkImg>
         </FlatField>
         <FlatField Timepoint="0" ViewSetup="3">
-          <BrightImg>dark_and_flatfields/setup200-flatfield (fixed by mirroring).tif</BrightImg>
-          <DarkImg>dark_and_flatfields/setup200-AVG_darkfield-fromdata.tif</DarkImg>
+          <BrightImg format="tif">dark_and_flatfields/setup200-flatfield (fixed by mirroring).tif</BrightImg>
+          <DarkImg format="tif">dark_and_flatfields/setup200-AVG_darkfield-fromdata.tif</DarkImg>
         </FlatField>
         <FlatField Timepoint="0" ViewSetup="4">
-          <BrightImg>dark_and_flatfields/setup201-flatfield (fixed by mirroring).tif</BrightImg>
-          <DarkImg>dark_and_flatfields/setup201-AVG_darkfield-fromdata.tif</DarkImg>
+          <BrightImg format="tif">dark_and_flatfields/setup201-flatfield (fixed by mirroring).tif</BrightImg>
+          <DarkImg format="tif">dark_and_flatfields/setup201-AVG_darkfield-fromdata.tif</DarkImg>
         </FlatField>
         <FlatField Timepoint="0" ViewSetup="5">
-          <BrightImg>dark_and_flatfields/setup202-flatfield.tif</BrightImg>
-          <DarkImg>dark_and_flatfields/setup202-AVG_darkfield-fromdata.tif</DarkImg>
+          <BrightImg format="tif">dark_and_flatfields/setup202-flatfield.tif</BrightImg>
+          <DarkImg format="tif">dark_and_flatfields/setup202-AVG_darkfield-fromdata.tif</DarkImg>
         </FlatField>
         <FlatField Timepoint="0" ViewSetup="6">
-          <BrightImg>dark_and_flatfields/setup213-flatfield (fixed by mirroring).tif</BrightImg>
-          <DarkImg>dark_and_flatfields/setup213-AVG_darkfield-fromdata.tif</DarkImg>
+          <BrightImg format="tif">dark_and_flatfields/setup213-flatfield (fixed by mirroring).tif</BrightImg>
+          <DarkImg format="tif">dark_and_flatfields/setup213-AVG_darkfield-fromdata.tif</DarkImg>
         </FlatField>
         <FlatField Timepoint="0" ViewSetup="7">
-          <BrightImg>dark_and_flatfields/setup214-flatfield.tif</BrightImg>
-          <DarkImg>dark_and_flatfields/setup214-AVG_darkfield-fromdata.tif</DarkImg>
+          <BrightImg format="tif">dark_and_flatfields/setup214-flatfield.tif</BrightImg>
+          <DarkImg format="tif">dark_and_flatfields/setup214-AVG_darkfield-fromdata.tif</DarkImg>
         </FlatField>
         <FlatField Timepoint="0" ViewSetup="8">
-          <BrightImg>dark_and_flatfields/setup215-flatfield.tif</BrightImg>
-          <DarkImg>dark_and_flatfields/setup215-AVG_darkfield-fromdata.tif</DarkImg>
+          <BrightImg format="tif">dark_and_flatfields/setup215-flatfield.tif</BrightImg>
+          <DarkImg format="tif">dark_and_flatfields/setup215-AVG_darkfield-fromdata.tif</DarkImg>
         </FlatField>
       </FlatFields>
     </ImageLoader>

--- a/data/dataset_corrected_viewer_s3.xml
+++ b/data/dataset_corrected_viewer_s3.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SpimData version="0.2">
+  <BasePath type="relative">.</BasePath>
+  <SequenceDescription>
+    <ImageLoader format="spimreconstruction.wrapped.flatfield.viewer" Active="true" Cached="true">
+      <WrappedImgLoader>
+        <ImageLoader format="bdv.n5" version="1.1">
+          <n5 type="relative">https://s3.janelia.org/keller-lab/s12a/samples_for_stitching/fly_brain_3/basic_corrected/dataset.n5</n5>
+        </ImageLoader>
+      </WrappedImgLoader>
+      <FlatFields>
+        <FlatField Timepoint="0" ViewSetup="0">
+		  <BrightImg format="n5">https://s3.janelia.org/keller-lab/s12a/samples_for_stitching/fly_brain_3/kittisopikulm/camera1/dark_field/s0/</BrightImg>
+		  <DarkImg format="n5" >https://s3.janelia.org/keller-lab/s12a/samples_for_stitching/fly_brain_3/kittisopikulm/camera1/flat_field/s0/</DarkImg>
+        </FlatField>
+      </FlatFields>
+    </ImageLoader>
+    <ViewSetups>
+      <ViewSetup>
+        <id>0</id>
+        <name>0</name>
+        <size>512 320 825</size>
+        <voxelSize>
+          <unit>pixels</unit>
+          <size>1.0 1.0 3.0</size>
+        </voxelSize>
+        <attributes>
+          <illumination>0</illumination>
+          <channel>0</channel>
+          <tile>187</tile>
+          <angle>0</angle>
+        </attributes>
+      </ViewSetup>
+      <Attributes name="illumination">
+        <Illumination>
+          <id>0</id>
+          <name>0</name>
+        </Illumination>
+      </Attributes>
+      <Attributes name="channel">
+        <Channel>
+          <id>0</id>
+          <name>0</name>
+        </Channel>
+      </Attributes>
+      <Attributes name="tile">
+        <Tile>
+          <id>187</id>
+          <name>187</name>
+        </Tile>
+        <Tile>
+          <id>188</id>
+          <name>188</name>
+        </Tile>
+        <Tile>
+          <id>189</id>
+          <name>189</name>
+        </Tile>
+        <Tile>
+          <id>200</id>
+          <name>200</name>
+        </Tile>
+        <Tile>
+          <id>201</id>
+          <name>201</name>
+        </Tile>
+        <Tile>
+          <id>202</id>
+          <name>202</name>
+        </Tile>
+        <Tile>
+          <id>213</id>
+          <name>213</name>
+        </Tile>
+        <Tile>
+          <id>214</id>
+          <name>214</name>
+        </Tile>
+        <Tile>
+          <id>215</id>
+          <name>215</name>
+        </Tile>
+      </Attributes>
+      <Attributes name="angle">
+        <Angle>
+          <id>0</id>
+          <name>0</name>
+        </Angle>
+      </Attributes>
+    </ViewSetups>
+    <Timepoints type="pattern">
+      <integerpattern>0</integerpattern>
+    </Timepoints>
+    <MissingViews />
+  </SequenceDescription>
+  <ViewRegistrations>
+    <ViewRegistration timepoint="0" setup="0">
+      <ViewTransform type="affine">
+        <Name>AffineModel3D regularized with an RigidModel3D, lambda = 0.1</Name>
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>Stitching Transform</Name>
+        <affine>1.0 0.0 0.0 0.4554158176323426 0.0 1.0 0.0 -0.13328548693164066 0.0 0.0 1.0 1.039028825990859</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>Translation to Regular Grid</Name>
+        <affine>1.0 0.0 0.0 199.68 0.0 1.0 0.0 102.40000000000003 0.0 0.0 1.0 -1236.0</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>calibration</Name>
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 3.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+  </ViewRegistrations>
+  <ViewInterestPoints />
+  <BoundingBoxes />
+  <PointSpreadFunctions />
+  <StitchingResults />
+  <IntensityAdjustments />
+</SpimData>

--- a/pom.xml
+++ b/pom.xml
@@ -113,12 +113,13 @@ like Selective Plane Illumination Microscopy (SPIM) Data.</description>
 
 		<!-- N5 alpha versions for Zarr v3 shard support -->
 		<!-- See: https://imglib.github.io/imglib2-blog/posts/2025-12-22-n5-shard-dev/ -->
-		<n5.version>4.0.0-alpha-6</n5.version>
-		<n5-imglib2.version>7.1.0-alpha-6</n5-imglib2.version>
+		<n5.version>4.0.0-alpha-7</n5.version>
+		<n5-imglib2.version>7.1.0-alpha-7</n5-imglib2.version>
 		<n5-universe.version>2.4.0-alpha-6</n5-universe.version>
 		<n5-zarr.version>2.0.0-alpha-4</n5-zarr.version>
 		<n5-zstandard.version>2.0.0-alpha-4</n5-zstandard.version>
 		<n5-blosc.version>2.0.0-alpha-4</n5-blosc.version>
+		<n5-aws-s3.version>4.4.0-alpha-5</n5-aws-s3.version>
 	</properties>
 
 	<repositories>

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/FlatFieldCorrectionPopup.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/FlatFieldCorrectionPopup.java
@@ -27,7 +27,6 @@ import java.awt.Point;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.File;
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
@@ -46,6 +45,7 @@ import net.preibisch.mvrecon.fiji.spimdata.SpimData2;
 import net.preibisch.mvrecon.fiji.spimdata.explorer.ExplorerWindow;
 import net.preibisch.mvrecon.fiji.spimdata.imgloaders.flatfield.DefaultFlatfieldCorrectionWrappedImgLoader;
 import net.preibisch.mvrecon.fiji.spimdata.imgloaders.flatfield.FlatfieldCorrectionWrappedImgLoader;
+import net.preibisch.mvrecon.fiji.spimdata.imgloaders.flatfield.FlatfieldImageInfo;
 import net.preibisch.mvrecon.fiji.spimdata.imgloaders.flatfield.LazyLoadingFlatFieldCorrectionMap;
 import net.preibisch.mvrecon.fiji.spimdata.imgloaders.flatfield.MultiResolutionFlatfieldCorrectionWrappedImgLoader;
 
@@ -102,10 +102,10 @@ public class FlatFieldCorrectionPopup extends JMenuItem implements ExplorerWindo
 								.isCached()
 						: true );
 
-				Map<ViewId, Pair<URI, URI>> uriMap = null;
+				Map<ViewId, Pair<FlatfieldImageInfo, FlatfieldImageInfo>> infoMap = null;
 				if ( alreadyFF )
-					uriMap = ((LazyLoadingFlatFieldCorrectionMap<ImgLoader>) data.getSequenceDescription()
-							.getImgLoader()).getUriMap();
+					infoMap = ((LazyLoadingFlatFieldCorrectionMap<ImgLoader>) data.getSequenceDescription()
+							.getImgLoader()).getInfoMap();
 
 				for ( Channel c : channels )
 					for ( Illumination ill : illums )
@@ -121,12 +121,12 @@ public class FlatFieldCorrectionPopup extends JMenuItem implements ExplorerWindo
 									} ).findAny().orElseGet( null );
 
 							if ( anyViewId != null )
-								if (uriMap.containsKey(anyViewId)) {
-									Pair<URI, URI> uris = uriMap.get(anyViewId);
-									if (uris.getA() != null)
-										bright = new File(uris.getA()).getAbsolutePath();
-									if (uris.getB() != null)
-										dark = new File(uris.getB()).getAbsolutePath();
+								if (infoMap.containsKey(anyViewId)) {
+									Pair<FlatfieldImageInfo, FlatfieldImageInfo> infos = infoMap.get(anyViewId);
+									if (infos.getA() != null)
+										bright = new File(infos.getA().getUri()).getAbsolutePath();
+									if (infos.getB() != null)
+										dark = new File(infos.getB().getUri()).getAbsolutePath();
 								}
 						}
 						gdp.addMessage( "Channel: " + c.getName() + ", Illumination: " + ill.getName() + ":" );
@@ -160,12 +160,16 @@ public class FlatFieldCorrectionPopup extends JMenuItem implements ExplorerWindo
 						File lightFile = !lightPath.equals( "" ) ? new File( lightPath ) : null;
 						File darkFile = !darkPath.equals( "" ) ? new File( darkPath ) : null;
 
+						final File finalLightFile = lightFile;
+						final File finalDarkFile = darkFile;
 						data.getSequenceDescription().getViewDescriptions().entrySet().forEach( el -> {
 							if ( el.getValue().getViewSetup().getChannel() == c
 									&& el.getValue().getViewSetup().getIllumination() == ill )
 							{
-								ffIL.setBrightImage( el.getKey(), lightFile );
-								ffIL.setDarkImage( el.getKey(), darkFile );
+								if (finalLightFile != null)
+									ffIL.setBrightImage( el.getKey(), new FlatfieldImageInfo(finalLightFile.toURI(), null) );
+								if (finalDarkFile != null)
+									ffIL.setDarkImage( el.getKey(), new FlatfieldImageInfo(finalDarkFile.toURI(), null) );
 							}
 						} );
 					}

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/FlatFieldCorrectionPopup.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/explorer/popup/FlatFieldCorrectionPopup.java
@@ -27,6 +27,7 @@ import java.awt.Point;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.File;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
@@ -101,10 +102,10 @@ public class FlatFieldCorrectionPopup extends JMenuItem implements ExplorerWindo
 								.isCached()
 						: true );
 
-				Map< ViewId, Pair< File, File > > fileMap = null;
+				Map<ViewId, Pair<URI, URI>> uriMap = null;
 				if ( alreadyFF )
-					fileMap = ( (LazyLoadingFlatFieldCorrectionMap< ImgLoader >) data.getSequenceDescription()
-							.getImgLoader() ).getFileMap();
+					uriMap = ((LazyLoadingFlatFieldCorrectionMap<ImgLoader>) data.getSequenceDescription()
+							.getImgLoader()).getUriMap();
 
 				for ( Channel c : channels )
 					for ( Illumination ill : illums )
@@ -120,13 +121,12 @@ public class FlatFieldCorrectionPopup extends JMenuItem implements ExplorerWindo
 									} ).findAny().orElseGet( null );
 
 							if ( anyViewId != null )
-								if ( fileMap.containsKey( anyViewId ) )
-								{
-									Pair< File, File > files = fileMap.get( anyViewId );
-									if ( files.getA() != null )
-										bright = files.getA().getAbsolutePath();
-									if ( files.getB() != null )
-										dark = files.getB().getAbsolutePath();
+								if (uriMap.containsKey(anyViewId)) {
+									Pair<URI, URI> uris = uriMap.get(anyViewId);
+									if (uris.getA() != null)
+										bright = new File(uris.getA()).getAbsolutePath();
+									if (uris.getB() != null)
+										dark = new File(uris.getB()).getAbsolutePath();
 								}
 						}
 						gdp.addMessage( "Channel: " + c.getName() + ", Illumination: " + ill.getName() + ":" );

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/ConvertFlatfieldsToZarr.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/ConvertFlatfieldsToZarr.java
@@ -33,7 +33,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.janelia.saalfeldlab.n5.Compression;
-import org.janelia.saalfeldlab.n5.GzipCompression;
+import org.janelia.saalfeldlab.n5.DataType;
 import org.janelia.saalfeldlab.n5.N5Writer;
 import org.janelia.saalfeldlab.n5.imglib2.N5Utils;
 import org.janelia.saalfeldlab.n5.universe.StorageFormat;
@@ -43,6 +43,7 @@ import ij.ImagePlus;
 import net.imglib2.img.Img;
 import net.imglib2.img.display.imagej.ImageJFunctions;
 import net.imglib2.type.numeric.real.FloatType;
+import org.janelia.scicomp.n5.zstandard.ZstandardCompression;
 import util.URITools;
 
 /**
@@ -80,9 +81,11 @@ public class ConvertFlatfieldsToZarr {
 		for (int d = 0; d < img.numDimensions(); d++)
 			blockSize[d] = (int) img.dimension(d);
 
-		// Save (N5Utils.save creates the dataset internally)
-		final Compression compression = new GzipCompression();
-		N5Utils.save(img, writer, "/", blockSize, compression);
+		// Save at root (empty string for Zarr v3)
+		// Save a block manually to work around a N5Utils.save issue for now
+		final Compression compression = new ZstandardCompression();
+		writer.createDataset("/", img.dimensionsAsLongArray(), blockSize, DataType.FLOAT32, compression);
+		N5Utils.saveBlock(img, writer, "", new long[]{0, 0});
 
 		writer.close();
 		System.out.println("  Created: " + outputZarr.getAbsolutePath());

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/ConvertFlatfieldsToZarr.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/ConvertFlatfieldsToZarr.java
@@ -1,0 +1,303 @@
+/*-
+ * #%L
+ * Software for the reconstruction of multi-view microscopic acquisitions
+ * like Selective Plane Illumination Microscopy (SPIM) Data.
+ * %%
+ * Copyright (C) 2012 - 2025 Multiview Reconstruction developers.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+package net.preibisch.mvrecon.fiji.spimdata.imgloaders.flatfield;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.janelia.saalfeldlab.n5.Compression;
+import org.janelia.saalfeldlab.n5.GzipCompression;
+import org.janelia.saalfeldlab.n5.N5Writer;
+import org.janelia.saalfeldlab.n5.imglib2.N5Utils;
+import org.janelia.saalfeldlab.n5.universe.StorageFormat;
+
+import ij.IJ;
+import ij.ImagePlus;
+import mpicbg.spim.data.SpimDataException;
+import mpicbg.spim.data.sequence.ViewSetup;
+import net.imglib2.img.Img;
+import net.imglib2.img.display.imagej.ImageJFunctions;
+import net.imglib2.type.numeric.real.FloatType;
+import net.preibisch.mvrecon.fiji.spimdata.SpimData2;
+import net.preibisch.mvrecon.fiji.spimdata.XmlIoSpimData2;
+import util.URITools;
+
+/**
+ * Utility to convert TIFF-based flatfield images to Zarr v3 format.
+ *
+ * This creates single-shard Zarr containers for each flatfield image,
+ * suitable for cloud storage or local chunked access.
+ *
+ * Also generates a test XML file with the Zarr paths configured.
+ */
+public class ConvertFlatfieldsToZarr {
+
+	/**
+	 * Convert a single TIFF image to Zarr v3 format.
+	 *
+	 * @param inputTiff  path to input TIFF file
+	 * @param outputZarr path for output .zarr container
+	 * @throws IOException if writing fails
+	 */
+	public static void convertTiffToZarr(final File inputTiff, final File outputZarr) throws IOException {
+		System.out.println("Converting: " + inputTiff.getName() + " -> " + outputZarr.getName());
+
+		// Load TIFF via ImageJ
+		final ImagePlus imp = IJ.openImage(inputTiff.getAbsolutePath());
+		if (imp == null)
+			throw new IOException("Failed to load TIFF: " + inputTiff);
+
+		final Img<FloatType> img = ImageJFunctions.convertFloat(imp);
+
+		// Create Zarr v3 writer
+		final N5Writer writer = URITools.instantiateN5Writer(StorageFormat.ZARR, outputZarr.toURI());
+
+		// Use a single block/shard for the entire image (flatfields are typically small)
+		final int[] blockSize = new int[img.numDimensions()];
+		for (int d = 0; d < img.numDimensions(); d++)
+			blockSize[d] = (int) img.dimension(d);
+
+		// Save (N5Utils.save creates the dataset internally)
+		final Compression compression = new GzipCompression();
+		N5Utils.save(img, writer, "/", blockSize, compression);
+
+		writer.close();
+		System.out.println("  Created: " + outputZarr.getAbsolutePath());
+	}
+
+	/**
+	 * Convert all flatfield TIFFs in a directory to Zarr format.
+	 *
+	 * @param inputDir  directory containing TIFF files
+	 * @param outputDir directory for output .zarr containers
+	 * @return map of original filename (without extension) to output Zarr file
+	 * @throws IOException if conversion fails
+	 */
+	public static Map<String, File> convertDirectory(final File inputDir, final File outputDir) throws IOException {
+		if (!outputDir.exists())
+			outputDir.mkdirs();
+
+		final Map<String, File> converted = new HashMap<>();
+
+		final File[] tiffFiles = inputDir.listFiles((dir, name) ->
+			name.toLowerCase().endsWith(".tif") || name.toLowerCase().endsWith(".tiff"));
+
+		if (tiffFiles == null || tiffFiles.length == 0) {
+			System.out.println("No TIFF files found in: " + inputDir);
+			return converted;
+		}
+
+		for (final File tiff : tiffFiles) {
+			final String baseName = tiff.getName().replaceAll("\\.(tif|tiff)$", "");
+			final File zarrOut = new File(outputDir, baseName + ".zarr");
+
+			convertTiffToZarr(tiff, zarrOut);
+			converted.put(baseName, zarrOut);
+		}
+
+		return converted;
+	}
+
+	/**
+	 * Generate a test XML file with Zarr-based flatfield correction.
+	 *
+	 * @param baseXmlPath     path to the original dataset XML
+	 * @param outputXmlPath   path for the new XML with flatfield correction
+	 * @param flatfieldDir    directory containing .zarr flatfield files
+	 * @param brightPattern   pattern for bright image names (e.g., "flatfield_tile%d")
+	 * @param darkPattern     pattern for dark image names (e.g., "darkfield_tile%d")
+	 * @throws SpimDataException if XML loading fails
+	 * @throws IOException       if XML writing fails
+	 */
+	public static void generateTestXml(
+			final String baseXmlPath,
+			final String outputXmlPath,
+			final File flatfieldDir,
+			final String brightPattern,
+			final String darkPattern) throws SpimDataException, IOException {
+
+		System.out.println("\n=== Generating Test XML ===");
+		System.out.println("Base XML: " + baseXmlPath);
+		System.out.println("Output XML: " + outputXmlPath);
+
+		// Load original dataset to get view setup info
+		final SpimData2 data = new XmlIoSpimData2().load(baseXmlPath);
+
+		// Build XML content manually to wrap the original loader with flatfield correction
+		final StringBuilder xml = new StringBuilder();
+		xml.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+		xml.append("<SpimData version=\"0.2\">\n");
+		xml.append("  <BasePath type=\"relative\">.</BasePath>\n");
+		xml.append("  <SequenceDescription>\n");
+
+		// ImageLoader section with flatfield wrapper
+		xml.append("    <ImageLoader format=\"spimreconstruction.wrapped.flatfield.default\" ");
+		xml.append("Active=\"true\" Cached=\"true\">\n");
+
+		// Reference the original loader - read from original XML
+		xml.append("      <WrappedImgLoader>\n");
+		xml.append("        <!-- Original loader from base dataset -->\n");
+		xml.append("        <ImageLoader format=\"bdv.n5\" version=\"1.0\">\n");
+		xml.append("          <n5 type=\"relative\">dataset.n5</n5>\n");
+		xml.append("        </ImageLoader>\n");
+		xml.append("      </WrappedImgLoader>\n");
+
+		// Flatfield configuration for each view setup
+		xml.append("      <FlatFields>\n");
+
+		for (final ViewSetup vs : data.getSequenceDescription().getViewSetupsOrdered()) {
+			final int setupId = vs.getId();
+			final int tileId = vs.getTile().getId();
+
+			// Construct Zarr file names based on patterns
+			final String brightName = String.format(brightPattern, tileId) + ".zarr";
+			final String darkName = String.format(darkPattern, tileId) + ".zarr";
+
+			final File brightFile = new File(flatfieldDir, brightName);
+			final File darkFile = new File(flatfieldDir, darkName);
+
+			// Only include if files exist
+			final boolean hasBright = brightFile.exists();
+			final boolean hasDark = darkFile.exists();
+
+			if (hasBright || hasDark) {
+				xml.append("        <FlatField timepoint=\"0\" setup=\"").append(setupId).append("\">\n");
+				if (hasBright)
+					xml.append("          <BrightImg>").append(brightFile.getName()).append("</BrightImg>\n");
+				if (hasDark)
+					xml.append("          <DarkImg>").append(darkFile.getName()).append("</DarkImg>\n");
+				xml.append("        </FlatField>\n");
+
+				System.out.println("  Setup " + setupId + " (tile " + tileId + "): " +
+						(hasBright ? "bright=" + brightName : "") +
+						(hasDark ? " dark=" + darkName : ""));
+			}
+		}
+
+		xml.append("      </FlatFields>\n");
+		xml.append("    </ImageLoader>\n");
+
+		// Copy ViewSetups from original
+		xml.append("    <!-- ViewSetups copied from original dataset -->\n");
+		xml.append("    <ViewSetups>\n");
+		for (final ViewSetup vs : data.getSequenceDescription().getViewSetupsOrdered()) {
+			xml.append("      <ViewSetup>\n");
+			xml.append("        <id>").append(vs.getId()).append("</id>\n");
+			xml.append("        <name>").append(vs.getName()).append("</name>\n");
+			xml.append("        <size>").append(vs.getSize().dimension(0)).append(" ")
+					.append(vs.getSize().dimension(1)).append(" ")
+					.append(vs.getSize().dimension(2)).append("</size>\n");
+			xml.append("        <voxelSize>\n");
+			xml.append("          <unit>").append(vs.getVoxelSize().unit()).append("</unit>\n");
+			xml.append("          <size>").append(vs.getVoxelSize().dimension(0)).append(" ")
+					.append(vs.getVoxelSize().dimension(1)).append(" ")
+					.append(vs.getVoxelSize().dimension(2)).append("</size>\n");
+			xml.append("        </voxelSize>\n");
+			xml.append("        <attributes>\n");
+			xml.append("          <channel>").append(vs.getChannel().getId()).append("</channel>\n");
+			xml.append("          <tile>").append(vs.getTile().getId()).append("</tile>\n");
+			xml.append("          <illumination>").append(vs.getIllumination().getId()).append("</illumination>\n");
+			xml.append("          <angle>").append(vs.getAngle().getId()).append("</angle>\n");
+			xml.append("        </attributes>\n");
+			xml.append("      </ViewSetup>\n");
+		}
+		xml.append("    </ViewSetups>\n");
+
+		// Timepoints
+		xml.append("    <Timepoints type=\"range\">\n");
+		xml.append("      <first>0</first>\n");
+		xml.append("      <last>0</last>\n");
+		xml.append("    </Timepoints>\n");
+
+		xml.append("  </SequenceDescription>\n");
+
+		// ViewRegistrations (identity transforms)
+		xml.append("  <ViewRegistrations>\n");
+		for (final ViewSetup vs : data.getSequenceDescription().getViewSetupsOrdered()) {
+			xml.append("    <ViewRegistration timepoint=\"0\" setup=\"").append(vs.getId()).append("\">\n");
+			xml.append("      <ViewTransform type=\"affine\">\n");
+			xml.append("        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>\n");
+			xml.append("      </ViewTransform>\n");
+			xml.append("    </ViewRegistration>\n");
+		}
+		xml.append("  </ViewRegistrations>\n");
+
+		xml.append("</SpimData>\n");
+
+		// Write XML file
+		try (FileWriter writer = new FileWriter(outputXmlPath)) {
+			writer.write(xml.toString());
+		}
+
+		System.out.println("\nCreated: " + outputXmlPath);
+	}
+
+	/**
+	 * Example main method demonstrating conversion and XML generation.
+	 */
+	public static void main(String[] args) throws Exception {
+		// Configuration - adjust these paths for your setup
+		final String basePath = "/Users/innerbergerm/Projects/janelia/multiview-reconstruction/";
+		final String dataPath = basePath + "data/";
+
+		// Input: directory with TIFF flatfields
+		final File tiffDir = new File(basePath, "dark_and_flatfields");
+
+		// Output: directory for Zarr flatfields
+		final File zarrDir = new File(basePath, "dark_and_flatfields_zarr");
+
+		// Step 1: Convert all TIFFs to Zarr
+		System.out.println("=== Step 1: Converting TIFFs to Zarr v3 ===\n");
+
+		if (tiffDir.exists()) {
+			convertDirectory(tiffDir, zarrDir);
+		} else {
+			throw new IOException("Input TIFF directory does not exist: " + tiffDir.getAbsolutePath());
+		}
+
+		// Step 2: Generate test XML
+		System.out.println("\n=== Step 2: Generating Test XML ===\n");
+
+		final String baseXml = dataPath + "dataset.xml";
+		final String outputXml = dataPath + "dataset_corrected_zarr.xml";
+
+		if (new File(baseXml).exists()) {
+			generateTestXml(
+					baseXml,
+					outputXml,
+					zarrDir,
+					"flatfield_tile%d",  // pattern for bright images
+					"darkfield_tile%d"   // pattern for dark images
+			);
+		} else {
+			System.out.println("Base XML not found: " + baseXml);
+			System.out.println("Skipping XML generation.");
+		}
+
+		System.out.println("\n=== Done! ===");
+		System.out.println("To test, load: " + outputXml);
+	}
+}

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/ConvertFlatfieldsToZarr.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/ConvertFlatfieldsToZarr.java
@@ -22,11 +22,15 @@
  */
 package net.preibisch.mvrecon.fiji.spimdata.imgloaders.flatfield;
 
+import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.janelia.saalfeldlab.n5.Compression;
 import org.janelia.saalfeldlab.n5.GzipCompression;
@@ -36,13 +40,9 @@ import org.janelia.saalfeldlab.n5.universe.StorageFormat;
 
 import ij.IJ;
 import ij.ImagePlus;
-import mpicbg.spim.data.SpimDataException;
-import mpicbg.spim.data.sequence.ViewSetup;
 import net.imglib2.img.Img;
 import net.imglib2.img.display.imagej.ImageJFunctions;
 import net.imglib2.type.numeric.real.FloatType;
-import net.preibisch.mvrecon.fiji.spimdata.SpimData2;
-import net.preibisch.mvrecon.fiji.spimdata.XmlIoSpimData2;
 import util.URITools;
 
 /**
@@ -122,137 +122,88 @@ public class ConvertFlatfieldsToZarr {
 	}
 
 	/**
-	 * Generate a test XML file with Zarr-based flatfield correction.
+	 * Generate a test XML file with Zarr-based flatfield correction by copying
+	 * an existing working XML and updating the flatfield paths to point to Zarr files.
 	 *
-	 * @param baseXmlPath     path to the original dataset XML
-	 * @param outputXmlPath   path for the new XML with flatfield correction
-	 * @param flatfieldDir    directory containing .zarr flatfield files
-	 * @param brightPattern   pattern for bright image names (e.g., "flatfield_tile%d")
-	 * @param darkPattern     pattern for dark image names (e.g., "darkfield_tile%d")
-	 * @throws SpimDataException if XML loading fails
-	 * @throws IOException       if XML writing fails
+	 * @param sourceXmlPath   path to a working flatfield-corrected XML (with TIFF paths)
+	 * @param outputXmlPath   path for the new XML with Zarr flatfield paths
+	 * @param zarrDir         directory containing .zarr flatfield files
+	 * @param convertedFiles  map of base names to Zarr files from conversion
+	 * @throws IOException if reading/writing fails
 	 */
 	public static void generateTestXml(
-			final String baseXmlPath,
+			final String sourceXmlPath,
 			final String outputXmlPath,
-			final File flatfieldDir,
-			final String brightPattern,
-			final String darkPattern) throws SpimDataException, IOException {
+			final File zarrDir,
+			final Map<String, File> convertedFiles) throws IOException {
 
 		System.out.println("\n=== Generating Test XML ===");
-		System.out.println("Base XML: " + baseXmlPath);
+		System.out.println("Source XML: " + sourceXmlPath);
 		System.out.println("Output XML: " + outputXmlPath);
 
-		// Load original dataset to get view setup info
-		final SpimData2 data = new XmlIoSpimData2().load(baseXmlPath);
-
-		// Build XML content manually to wrap the original loader with flatfield correction
-		final StringBuilder xml = new StringBuilder();
-		xml.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
-		xml.append("<SpimData version=\"0.2\">\n");
-		xml.append("  <BasePath type=\"relative\">.</BasePath>\n");
-		xml.append("  <SequenceDescription>\n");
-
-		// ImageLoader section with flatfield wrapper
-		xml.append("    <ImageLoader format=\"spimreconstruction.wrapped.flatfield.default\" ");
-		xml.append("Active=\"true\" Cached=\"true\">\n");
-
-		// Reference the original loader - read from original XML
-		xml.append("      <WrappedImgLoader>\n");
-		xml.append("        <!-- Original loader from base dataset -->\n");
-		xml.append("        <ImageLoader format=\"bdv.n5\" version=\"1.0\">\n");
-		xml.append("          <n5 type=\"relative\">dataset.n5</n5>\n");
-		xml.append("        </ImageLoader>\n");
-		xml.append("      </WrappedImgLoader>\n");
-
-		// Flatfield configuration for each view setup
-		xml.append("      <FlatFields>\n");
-
-		for (final ViewSetup vs : data.getSequenceDescription().getViewSetupsOrdered()) {
-			final int setupId = vs.getId();
-			final int tileId = vs.getTile().getId();
-
-			// Construct Zarr file names based on patterns
-			final String brightName = String.format(brightPattern, tileId) + ".zarr";
-			final String darkName = String.format(darkPattern, tileId) + ".zarr";
-
-			final File brightFile = new File(flatfieldDir, brightName);
-			final File darkFile = new File(flatfieldDir, darkName);
-
-			// Only include if files exist
-			final boolean hasBright = brightFile.exists();
-			final boolean hasDark = darkFile.exists();
-
-			if (hasBright || hasDark) {
-				xml.append("        <FlatField timepoint=\"0\" setup=\"").append(setupId).append("\">\n");
-				if (hasBright)
-					xml.append("          <BrightImg>").append(brightFile.getName()).append("</BrightImg>\n");
-				if (hasDark)
-					xml.append("          <DarkImg>").append(darkFile.getName()).append("</DarkImg>\n");
-				xml.append("        </FlatField>\n");
-
-				System.out.println("  Setup " + setupId + " (tile " + tileId + "): " +
-						(hasBright ? "bright=" + brightName : "") +
-						(hasDark ? " dark=" + darkName : ""));
+		// Read the source XML
+		final StringBuilder content = new StringBuilder();
+		try (BufferedReader reader = new BufferedReader(new FileReader(sourceXmlPath))) {
+			String line;
+			while ((line = reader.readLine()) != null) {
+				content.append(line).append("\n");
 			}
 		}
 
-		xml.append("      </FlatFields>\n");
-		xml.append("    </ImageLoader>\n");
+		String xml = content.toString();
 
-		// Copy ViewSetups from original
-		xml.append("    <!-- ViewSetups copied from original dataset -->\n");
-		xml.append("    <ViewSetups>\n");
-		for (final ViewSetup vs : data.getSequenceDescription().getViewSetupsOrdered()) {
-			xml.append("      <ViewSetup>\n");
-			xml.append("        <id>").append(vs.getId()).append("</id>\n");
-			xml.append("        <name>").append(vs.getName()).append("</name>\n");
-			xml.append("        <size>").append(vs.getSize().dimension(0)).append(" ")
-					.append(vs.getSize().dimension(1)).append(" ")
-					.append(vs.getSize().dimension(2)).append("</size>\n");
-			xml.append("        <voxelSize>\n");
-			xml.append("          <unit>").append(vs.getVoxelSize().unit()).append("</unit>\n");
-			xml.append("          <size>").append(vs.getVoxelSize().dimension(0)).append(" ")
-					.append(vs.getVoxelSize().dimension(1)).append(" ")
-					.append(vs.getVoxelSize().dimension(2)).append("</size>\n");
-			xml.append("        </voxelSize>\n");
-			xml.append("        <attributes>\n");
-			xml.append("          <channel>").append(vs.getChannel().getId()).append("</channel>\n");
-			xml.append("          <tile>").append(vs.getTile().getId()).append("</tile>\n");
-			xml.append("          <illumination>").append(vs.getIllumination().getId()).append("</illumination>\n");
-			xml.append("          <angle>").append(vs.getAngle().getId()).append("</angle>\n");
-			xml.append("        </attributes>\n");
-			xml.append("      </ViewSetup>\n");
-		}
-		xml.append("    </ViewSetups>\n");
+		// Pattern to match BrightImg and DarkImg paths
+		final Pattern brightPattern = Pattern.compile("(<BrightImg>)([^<]+)(</BrightImg>)");
+		final Pattern darkPattern = Pattern.compile("(<DarkImg>)([^<]+)(</DarkImg>)");
 
-		// Timepoints
-		xml.append("    <Timepoints type=\"range\">\n");
-		xml.append("      <first>0</first>\n");
-		xml.append("      <last>0</last>\n");
-		xml.append("    </Timepoints>\n");
+		// Replace TIFF paths with Zarr paths
+		xml = replaceFlatfieldPaths(xml, brightPattern, zarrDir, convertedFiles);
+		xml = replaceFlatfieldPaths(xml, darkPattern, zarrDir, convertedFiles);
 
-		xml.append("  </SequenceDescription>\n");
-
-		// ViewRegistrations (identity transforms)
-		xml.append("  <ViewRegistrations>\n");
-		for (final ViewSetup vs : data.getSequenceDescription().getViewSetupsOrdered()) {
-			xml.append("    <ViewRegistration timepoint=\"0\" setup=\"").append(vs.getId()).append("\">\n");
-			xml.append("      <ViewTransform type=\"affine\">\n");
-			xml.append("        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>\n");
-			xml.append("      </ViewTransform>\n");
-			xml.append("    </ViewRegistration>\n");
-		}
-		xml.append("  </ViewRegistrations>\n");
-
-		xml.append("</SpimData>\n");
-
-		// Write XML file
+		// Write output XML
 		try (FileWriter writer = new FileWriter(outputXmlPath)) {
-			writer.write(xml.toString());
+			writer.write(xml);
 		}
 
-		System.out.println("\nCreated: " + outputXmlPath);
+		System.out.println("Created: " + outputXmlPath);
+	}
+
+	/**
+	 * Replace flatfield TIFF paths with Zarr paths in XML content.
+	 */
+	private static String replaceFlatfieldPaths(
+			String xml,
+			final Pattern pattern,
+			final File zarrDir,
+			final Map<String, File> convertedFiles) {
+
+		final Matcher matcher = pattern.matcher(xml);
+		final StringBuffer result = new StringBuffer();
+
+		while (matcher.find()) {
+			final String openTag = matcher.group(1);
+			final String oldPath = matcher.group(2);
+			final String closeTag = matcher.group(3);
+
+			// Extract base name from old path (remove directory and extension)
+			String baseName = new File(oldPath).getName();
+			baseName = baseName.replaceAll("\\.(tif|tiff)$", "");
+
+			// Find corresponding Zarr file
+			String newPath = oldPath;  // default: keep original if not found
+			if (convertedFiles.containsKey(baseName)) {
+				// Use relative path from zarrDir
+				newPath = zarrDir.getName() + "/" + convertedFiles.get(baseName).getName();
+				System.out.println("  " + oldPath + " -> " + newPath);
+			} else {
+				System.out.println("  WARNING: No Zarr found for: " + baseName);
+			}
+
+			matcher.appendReplacement(result, Matcher.quoteReplacement(openTag + newPath + closeTag));
+		}
+		matcher.appendTail(result);
+
+		return result.toString();
 	}
 
 	/**
@@ -266,34 +217,35 @@ public class ConvertFlatfieldsToZarr {
 		// Input: directory with TIFF flatfields
 		final File tiffDir = new File(basePath, "dark_and_flatfields");
 
-		// Output: directory for Zarr flatfields
+		// Output: directory for Zarr flatfields (in data folder, next to other data)
 		final File zarrDir = new File(basePath, "dark_and_flatfields_zarr");
 
 		// Step 1: Convert all TIFFs to Zarr
 		System.out.println("=== Step 1: Converting TIFFs to Zarr v3 ===\n");
 
+		Map<String, File> convertedFiles;
 		if (tiffDir.exists()) {
-			convertDirectory(tiffDir, zarrDir);
+			convertedFiles = convertDirectory(tiffDir, zarrDir);
 		} else {
 			throw new IOException("Input TIFF directory does not exist: " + tiffDir.getAbsolutePath());
 		}
 
-		// Step 2: Generate test XML
+		// Step 2: Generate test XML by copying from working TIFF-based XML
 		System.out.println("\n=== Step 2: Generating Test XML ===\n");
 
-		final String baseXml = dataPath + "dataset.xml";
+		// Use the working flatfield-corrected XML as source
+		final String sourceXml = dataPath + "dataset_corrected_viewer.xml";
 		final String outputXml = dataPath + "dataset_corrected_zarr.xml";
 
-		if (new File(baseXml).exists()) {
+		if (new File(sourceXml).exists()) {
 			generateTestXml(
-					baseXml,
+					sourceXml,
 					outputXml,
 					zarrDir,
-					"flatfield_tile%d",  // pattern for bright images
-					"darkfield_tile%d"   // pattern for dark images
+					convertedFiles
 			);
 		} else {
-			System.out.println("Base XML not found: " + baseXml);
+			System.out.println("Source XML not found: " + sourceXml);
 			System.out.println("Skipping XML generation.");
 		}
 

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/DefaultFlatfieldCorrectionWrappedImgLoader.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/DefaultFlatfieldCorrectionWrappedImgLoader.java
@@ -33,7 +33,6 @@ import mpicbg.spim.data.sequence.SetupImgLoader;
 import mpicbg.spim.data.sequence.ViewId;
 import mpicbg.spim.data.sequence.VoxelDimensions;
 import net.imglib2.Dimensions;
-import net.imglib2.RandomAccessible;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.converter.RealTypeConverters;
 import net.imglib2.img.Img;
@@ -47,14 +46,13 @@ import net.imglib2.type.numeric.real.FloatType;
 import net.imglib2.view.Views;
 import net.preibisch.mvrecon.fiji.plugin.queryXML.LoadParseQueryXML;
 import net.preibisch.mvrecon.fiji.spimdata.SpimData2;
-import net.preibisch.mvrecon.fiji.spimdata.imgloaders.filemap2.FileMapImgLoaderLOCI2;
 import net.preibisch.mvrecon.process.fusion.FusionTools;
 
 
 public class DefaultFlatfieldCorrectionWrappedImgLoader extends LazyLoadingFlatFieldCorrectionMap< ImgLoader >
 		implements ImgLoader
 {
-	private ImgLoader wrappedImgLoader;
+	private final ImgLoader wrappedImgLoader;
 	private boolean active;
 	private boolean cacheResult;
 
@@ -106,23 +104,27 @@ public class DefaultFlatfieldCorrectionWrappedImgLoader extends LazyLoadingFlatF
 		}
 
 		@Override
-		public RandomAccessibleInterval< T > getImage(int timepointId, ImgLoaderHint... hints)
-		{
-			if (!active)
-				return (RandomAccessibleInterval< T >) wrappedImgLoader.getSetupImgLoader( setupId ).getImage( timepointId,
-						hints );
+		public RandomAccessibleInterval< T > getImage(int timepointId, ImgLoaderHint... hints) {
+			if (!active) {
+				@SuppressWarnings("unchecked") final RandomAccessibleInterval<T> img =
+						(RandomAccessibleInterval<T>) wrappedImgLoader.getSetupImgLoader(setupId).getImage(timepointId, hints);
+				return img;
+			}
 
 			@SuppressWarnings("unchecked")
-			RandomAccessibleInterval< T > rai = FlatFieldCorrectedRandomAccessibleIntervals.create(
-					(RandomAccessibleInterval< T >) wrappedImgLoader.getSetupImgLoader( setupId ).getImage( timepointId,
-							hints ),
-					getBrightImg( new ViewId( timepointId, setupId ) ),
-					getDarkImg( new ViewId( timepointId, setupId ) ) );
+			RandomAccessibleInterval<T> rai = FlatFieldCorrectedRandomAccessibleIntervals.create(
+					(RandomAccessibleInterval<T>) wrappedImgLoader.getSetupImgLoader(setupId).getImage(timepointId,
+																									   hints),
+					getBrightImg(new ViewId(timepointId, setupId)),
+					getDarkImg(new ViewId(timepointId, setupId)));
 
 			boolean loadCompletelyRequested = false;
-			for (ImgLoaderHint hint : hints)
-				if (hint == ImgLoaderHints.LOAD_COMPLETELY)
+			for (ImgLoaderHint hint : hints) {
+				if (hint == ImgLoaderHints.LOAD_COMPLETELY) {
 					loadCompletelyRequested = true;
+					break;
+				}
+			}
 
 			if (loadCompletelyRequested)
 			{
@@ -131,12 +133,13 @@ public class DefaultFlatfieldCorrectionWrappedImgLoader extends LazyLoadingFlatF
 					numPx *= rai.dimension( d );
 
 				final ImgFactory< T > imgFactory;
-				if (Math.log(numPx) / Math.log( 2 ) < 31)
-					imgFactory = new ArrayImgFactory<T>();
-				else
-					imgFactory = new CellImgFactory<T>();
+				if (Math.log(numPx) / Math.log(2) < 31) {
+					imgFactory = new ArrayImgFactory<>(getImageType());
+				} else {
+					imgFactory = new CellImgFactory<>(getImageType());
+				}
 
-				Img< T > loadedImg = imgFactory.create( rai, getImageType() );
+				Img<T> loadedImg = imgFactory.create(rai);
 				RealTypeConverters.copyFromTo( Views.extendZero( rai ), loadedImg );
 
 				rai = loadedImg;
@@ -148,8 +151,8 @@ public class DefaultFlatfieldCorrectionWrappedImgLoader extends LazyLoadingFlatF
 				Arrays.fill( cellSize, 1 );
 				for ( int d = 0; d < rai.numDimensions() - 1; d++ )
 					cellSize[d] = (int) rai.dimension( d );
-				rai = FusionTools.cacheRandomAccessibleInterval( rai, Long.MAX_VALUE,
-						Views.iterable( rai ).firstElement().createVariable(), cellSize );
+				rai = FusionTools.cacheRandomAccessibleInterval(
+						rai, Long.MAX_VALUE, rai.firstElement().createVariable(), cellSize);
 			}
 
 			return rai;
@@ -161,8 +164,7 @@ public class DefaultFlatfieldCorrectionWrappedImgLoader extends LazyLoadingFlatF
 				ImgLoaderHint... hints)
 		{
 			if (!active)
-				return (RandomAccessibleInterval< FloatType >) wrappedImgLoader.getSetupImgLoader( setupId ).getFloatImage( timepointId,
-						false, hints );
+				return wrappedImgLoader.getSetupImgLoader(setupId).getFloatImage(timepointId, false, hints);
 
 			@SuppressWarnings("unchecked")
 			RandomAccessibleInterval< FloatType > rai = FlatFieldCorrectedRandomAccessibleIntervals.create(
@@ -176,9 +178,12 @@ public class DefaultFlatfieldCorrectionWrappedImgLoader extends LazyLoadingFlatF
 				RandomAccessibleInterval< FloatType > raiNormalized = new VirtuallyNormalizedRandomAccessibleInterval<>(
 						rai );
 				boolean loadCompletelyRequested = false;
-				for (ImgLoaderHint hint : hints)
-					if (hint == ImgLoaderHints.LOAD_COMPLETELY)
+				for (ImgLoaderHint hint : hints) {
+					if (hint == ImgLoaderHints.LOAD_COMPLETELY) {
 						loadCompletelyRequested = true;
+						break;
+					}
+				}
 
 				if (loadCompletelyRequested)
 				{
@@ -187,13 +192,14 @@ public class DefaultFlatfieldCorrectionWrappedImgLoader extends LazyLoadingFlatF
 						numPx *= raiNormalized.dimension( d );
 
 					final ImgFactory< FloatType > imgFactory;
-					if (Math.log(numPx) / Math.log( 2 ) < 31)
-						imgFactory = new ArrayImgFactory<FloatType>();
-					else
-						imgFactory = new CellImgFactory<FloatType>();
+					if (Math.log(numPx) / Math.log(2) < 31) {
+						imgFactory = new ArrayImgFactory<>(new FloatType());
+					} else {
+						imgFactory = new CellImgFactory<>(new FloatType());
+					}
 
-					Img< FloatType > loadedImg = imgFactory.create( raiNormalized, new FloatType() );
-					FileMapImgLoaderLOCI2.copy(Views.extendZero( raiNormalized ), loadedImg);
+					Img<FloatType> loadedImg = imgFactory.create(raiNormalized);
+					RealTypeConverters.copyFromTo(Views.extendZero(raiNormalized), loadedImg);
 
 					raiNormalized = loadedImg;
 				}
@@ -203,17 +209,20 @@ public class DefaultFlatfieldCorrectionWrappedImgLoader extends LazyLoadingFlatF
 					Arrays.fill( cellSize, 1 );
 					for ( int d = 0; d < raiNormalized.numDimensions() - 1; d++ )
 						cellSize[d] = (int) raiNormalized.dimension( d );
-					raiNormalized = FusionTools.cacheRandomAccessibleInterval( raiNormalized, Long.MAX_VALUE,
-							Views.iterable( rai ).firstElement().createVariable(), cellSize );
+					raiNormalized = FusionTools.cacheRandomAccessibleInterval(
+							raiNormalized, Long.MAX_VALUE, rai.firstElement().createVariable(), cellSize);
 				}
 				rai = raiNormalized;
 			}
 			else
 			{
 				boolean loadCompletelyRequested = false;
-				for (ImgLoaderHint hint : hints)
-					if (hint == ImgLoaderHints.LOAD_COMPLETELY)
+				for (ImgLoaderHint hint : hints) {
+					if (hint == ImgLoaderHints.LOAD_COMPLETELY) {
 						loadCompletelyRequested = true;
+						break;
+					}
+				}
 
 				if (loadCompletelyRequested)
 				{
@@ -222,13 +231,14 @@ public class DefaultFlatfieldCorrectionWrappedImgLoader extends LazyLoadingFlatF
 						numPx *= rai.dimension( d );
 
 					final ImgFactory< FloatType > imgFactory;
-					if (Math.log(numPx) / Math.log( 2 ) < 31)
-						imgFactory = new ArrayImgFactory<FloatType>();
-					else
-						imgFactory = new CellImgFactory<FloatType>();
+					if (Math.log(numPx) / Math.log(2) < 31) {
+						imgFactory = new ArrayImgFactory<>(new FloatType());
+					} else {
+						imgFactory = new CellImgFactory<>(new FloatType());
+					}
 
-					Img< FloatType > loadedImg = imgFactory.create( rai, new FloatType() );
-					FileMapImgLoaderLOCI2.copy(Views.extendZero( rai ), loadedImg);
+					Img< FloatType > loadedImg = imgFactory.create(rai);
+					RealTypeConverters.copyFromTo(Views.extendZero(rai), loadedImg);
 
 					rai = loadedImg;
 				}
@@ -238,8 +248,8 @@ public class DefaultFlatfieldCorrectionWrappedImgLoader extends LazyLoadingFlatF
 					Arrays.fill( cellSize, 1 );
 					for ( int d = 0; d < rai.numDimensions() - 1; d++ )
 						cellSize[d] = (int) rai.dimension( d );
-					rai = FusionTools.cacheRandomAccessibleInterval( rai, Long.MAX_VALUE,
-							Views.iterable( rai ).firstElement().createVariable(), cellSize );
+					rai = FusionTools.cacheRandomAccessibleInterval(
+							rai, Long.MAX_VALUE, rai.firstElement().createVariable(), cellSize);
 				}
 
 			}

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/DefaultFlatfieldCorrectionWrappedImgLoader.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/DefaultFlatfieldCorrectionWrappedImgLoader.java
@@ -285,7 +285,7 @@ public class DefaultFlatfieldCorrectionWrappedImgLoader extends LazyLoadingFlatF
 
 		ImgLoader il = data.getSequenceDescription().getImgLoader();
 		DefaultFlatfieldCorrectionWrappedImgLoader ffcil = new DefaultFlatfieldCorrectionWrappedImgLoader( il );
-		ffcil.setDarkImage( new ViewId( 0, 0 ), new File( "/Users/david/desktop/ff.tif" ) );
+		ffcil.setDarkImage(new ViewId(0, 0), new FlatfieldImageInfo(new File("/Users/david/desktop/ff.tif").toURI()));
 
 		data.getSequenceDescription().setImgLoader( ffcil );
 

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/FlatFieldCorrectedRandomAccessibleInterval.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/FlatFieldCorrectedRandomAccessibleInterval.java
@@ -55,6 +55,9 @@ public class FlatFieldCorrectedRandomAccessibleInterval <O extends RealType< O >
 		this.brightImg = brightImg;
 		this.darkImg = darkImg;
 
+		if (brightImg.numDimensions() > sourceImg.numDimensions() || darkImg.numDimensions() > sourceImg.numDimensions())
+			throw new IllegalArgumentException("Bright-/darkfield images have more dimensions than source image!");
+
 		meanBrightCorrected = getMeanCorrected( brightImg, darkImg );
 		type = outputType;
 	}
@@ -105,20 +108,15 @@ public class FlatFieldCorrectedRandomAccessibleInterval <O extends RealType< O >
 		@Override
 		public O get()
 		{
-			// NB: the flat field images seem to be 3D with 1 z slice
-			// if they were truly 2D, we would use position.length - 1
-			final long[] positionBright = new long[ nDimBright ];
-			final long[] positionDark = new long[ nDimDark ];
-			// only copy position of n-1 dimensions
-			System.arraycopy( position, 0, positionBright, 0, nDimBright );
-			System.arraycopy( position, 0, positionDark, 0, nDimDark );
+			// Use the fact that bright and dark must be of dimensionality <= source,
+			// and that coordinates outside the dimensionality are ignored
+			sourceRA.setPosition(position);
+			brightRA.setPosition(position);
+			darkRA.setPosition(position);
 
-			sourceRA.setPosition( position );
-			brightRA.setPosition( positionBright );
-			darkRA.setPosition( positionDark );
-
-			final double corrBright = brightRA.get().getRealDouble() - darkRA.get().getRealDouble();
-			final double corrImg = sourceRA.get().getRealDouble() - darkRA.get().getRealDouble();
+			final double darkValue = darkRA.get().getRealDouble();
+			final double corrBright = brightRA.get().getRealDouble() - darkValue;
+			final double corrImg = sourceRA.get().getRealDouble() - darkValue;
 
 			if (corrBright == 0)
 				value.setReal( 0.0 );

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/FlatFieldCorrectedRandomAccessibleInterval.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/FlatFieldCorrectedRandomAccessibleInterval.java
@@ -25,6 +25,7 @@ package net.preibisch.mvrecon.fiji.spimdata.imgloaders.flatfield;
 import net.imglib2.AbstractInterval;
 import net.imglib2.Cursor;
 import net.imglib2.Interval;
+import net.imglib2.Localizable;
 import net.imglib2.Point;
 import net.imglib2.RandomAccess;
 import net.imglib2.RandomAccessibleInterval;
@@ -80,15 +81,11 @@ public class FlatFieldCorrectedRandomAccessibleInterval <O extends RealType< O >
 		return type;
 	}
 
-	private class FlatFieldCorrectedRandomAccess extends Point implements RandomAccess< O >
+	private class FlatFieldCorrectedRandomAccess extends Point implements RandomAccess<O>
 	{
-		/*
-		 * TODO: manually implement move methods
-		 */
-		
-		private final RandomAccess< T > sourceRA;
-		private final RandomAccess< S > brightRA;
-		private final RandomAccess< R > darkRA;
+		private final RandomAccess<T> sourceRA;
+		private final RandomAccess<S> brightRA;
+		private final RandomAccess<R> darkRA;
 		private final O value;
 
 		private final int nDimBright;
@@ -96,7 +93,7 @@ public class FlatFieldCorrectedRandomAccessibleInterval <O extends RealType< O >
 
 		public FlatFieldCorrectedRandomAccess()
 		{
-			super( sourceImg.numDimensions() );
+			super(sourceImg.numDimensions());
 			sourceRA = sourceImg.randomAccess();
 			brightRA = brightImg.randomAccess();
 			darkRA = darkImg.randomAccess();
@@ -108,35 +105,153 @@ public class FlatFieldCorrectedRandomAccessibleInterval <O extends RealType< O >
 		@Override
 		public O get()
 		{
-			// Use the fact that bright and dark must be of dimensionality <= source,
-			// and that coordinates outside the dimensionality are ignored
-			sourceRA.setPosition(position);
-			brightRA.setPosition(position);
-			darkRA.setPosition(position);
-
 			final double darkValue = darkRA.get().getRealDouble();
 			final double corrBright = brightRA.get().getRealDouble() - darkValue;
 			final double corrImg = sourceRA.get().getRealDouble() - darkValue;
 
 			if (corrBright == 0)
-				value.setReal( 0.0 );
+				value.setReal(0.0);
 			else
 			{
-				final double corr = Math.min( Math.max( corrImg * meanBrightCorrected / corrBright, value.getMinValue() ), value.getMaxValue() );
-				value.setReal( corr );
+				final double corr = Math.min(Math.max(corrImg * meanBrightCorrected / corrBright, value.getMinValue()), value.getMaxValue());
+				value.setReal(corr);
 			}
 
 			return value;
 		}
 
 		@Override
-		public RandomAccess< O > copy()
+		public void fwd(int d)
 		{
-			final FlatFieldCorrectedRandomAccessibleInterval<O, T, S, R >.FlatFieldCorrectedRandomAccess copy = new FlatFieldCorrectedRandomAccess();
-			copy.setPosition( this );
+			position[d]++;
+			sourceRA.fwd(d);
+			if (d < nDimBright) brightRA.fwd(d);
+			if (d < nDimDark) darkRA.fwd(d);
+		}
+
+		@Override
+		public void bck(int d)
+		{
+			position[d]--;
+			sourceRA.bck(d);
+			if (d < nDimBright) brightRA.bck(d);
+			if (d < nDimDark) darkRA.bck(d);
+		}
+
+		@Override
+		public void move(int distance, int d)
+		{
+			position[d] += distance;
+			sourceRA.move(distance, d);
+			if (d < nDimBright) brightRA.move(distance, d);
+			if (d < nDimDark) darkRA.move(distance, d);
+		}
+
+		@Override
+		public void move(long distance, int d)
+		{
+			position[d] += distance;
+			sourceRA.move(distance, d);
+			if (d < nDimBright) brightRA.move(distance, d);
+			if (d < nDimDark) darkRA.move(distance, d);
+		}
+
+		@Override
+		public void move(Localizable distance)
+		{
+			for (int d = 0; d < n; d++)
+				position[d] += distance.getLongPosition(d);
+			sourceRA.move(distance);
+			for (int d = 0; d < nDimBright; d++)
+				brightRA.move(distance.getLongPosition(d), d);
+			for (int d = 0; d < nDimDark; d++)
+				darkRA.move(distance.getLongPosition(d), d);
+		}
+
+		@Override
+		public void move(int[] distance)
+		{
+			for (int d = 0; d < n; d++)
+				position[d] += distance[d];
+			sourceRA.move(distance);
+			for (int d = 0; d < nDimBright; d++)
+				brightRA.move(distance[d], d);
+			for (int d = 0; d < nDimDark; d++)
+				darkRA.move(distance[d], d);
+		}
+
+		@Override
+		public void move(long[] distance)
+		{
+			for (int d = 0; d < n; d++)
+				position[d] += distance[d];
+			sourceRA.move(distance);
+			for (int d = 0; d < nDimBright; d++)
+				brightRA.move(distance[d], d);
+			for (int d = 0; d < nDimDark; d++)
+				darkRA.move(distance[d], d);
+		}
+
+		@Override
+		public void setPosition(Localizable position)
+		{
+			for (int d = 0; d < n; d++)
+				this.position[d] = position.getLongPosition(d);
+			sourceRA.setPosition(position);
+			for (int d = 0; d < nDimBright; d++)
+				brightRA.setPosition(position.getLongPosition(d), d);
+			for (int d = 0; d < nDimDark; d++)
+				darkRA.setPosition(position.getLongPosition(d), d);
+		}
+
+		@Override
+		public void setPosition(int[] position)
+		{
+			for (int d = 0; d < n; d++)
+				this.position[d] = position[d];
+			sourceRA.setPosition(position);
+			for (int d = 0; d < nDimBright; d++)
+				brightRA.setPosition(position[d], d);
+			for (int d = 0; d < nDimDark; d++)
+				darkRA.setPosition(position[d], d);
+		}
+
+		@Override
+		public void setPosition(long[] position)
+		{
+			for (int d = 0; d < n; d++)
+				this.position[d] = position[d];
+			sourceRA.setPosition(position);
+			for (int d = 0; d < nDimBright; d++)
+				brightRA.setPosition(position[d], d);
+			for (int d = 0; d < nDimDark; d++)
+				darkRA.setPosition(position[d], d);
+		}
+
+		@Override
+		public void setPosition(int position, int d)
+		{
+			this.position[d] = position;
+			sourceRA.setPosition(position, d);
+			if (d < nDimBright) brightRA.setPosition(position, d);
+			if (d < nDimDark) darkRA.setPosition(position, d);
+		}
+
+		@Override
+		public void setPosition(long position, int d)
+		{
+			this.position[d] = position;
+			sourceRA.setPosition(position, d);
+			if (d < nDimBright) brightRA.setPosition(position, d);
+			if (d < nDimDark) darkRA.setPosition(position, d);
+		}
+
+		@Override
+		public RandomAccess<O> copy() {
+			final FlatFieldCorrectedRandomAccessibleInterval<O, T, S, R>.FlatFieldCorrectedRandomAccess copy = new FlatFieldCorrectedRandomAccess();
+			copy.setPosition(this);
 			return copy;
 		}
-		
 	}
 	
 	public static <P extends RealType< P >, Q extends RealType< Q >> double getMeanCorrected(RandomAccessibleInterval< P > brightImg, RandomAccessibleInterval< Q > darkImg)

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/FlatFieldCorrectedRandomAccessibleInterval.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/FlatFieldCorrectedRandomAccessibleInterval.java
@@ -28,12 +28,10 @@ import net.imglib2.Interval;
 import net.imglib2.Point;
 import net.imglib2.RandomAccess;
 import net.imglib2.RandomAccessibleInterval;
-import net.imglib2.Sampler;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.util.Pair;
 import net.imglib2.util.RealSum;
 import net.imglib2.util.ValuePair;
-import net.imglib2.view.Views;
 
 /*
  * 
@@ -148,7 +146,7 @@ public class FlatFieldCorrectedRandomAccessibleInterval <O extends RealType< O >
 		final RealSum sum = new RealSum();
 		long count = 0;
 		
-		final Cursor< P > brightCursor = Views.iterable( brightImg ).cursor();
+		final Cursor< P > brightCursor = brightImg.cursor();
 		final RandomAccess< Q > darkRA = darkImg.randomAccess();
 		
 		while (brightCursor.hasNext())
@@ -172,7 +170,7 @@ public class FlatFieldCorrectedRandomAccessibleInterval <O extends RealType< O >
 		double min = Double.MAX_VALUE;
 		double max = - Double.MAX_VALUE;
 
-		for (final P pixel : Views.iterable( img ))
+		for (final P pixel : img)
 		{
 			double value = pixel.getRealDouble();
 			
@@ -183,7 +181,7 @@ public class FlatFieldCorrectedRandomAccessibleInterval <O extends RealType< O >
 				min = value;
 		}
 		
-		return new ValuePair< Double, Double >( min, max );
+		return new ValuePair<>( min, max );
 	}
 
 }

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/FlatFieldCorrectedRandomAccessibleInterval.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/FlatFieldCorrectedRandomAccessibleInterval.java
@@ -26,7 +26,6 @@ import net.imglib2.AbstractInterval;
 import net.imglib2.Cursor;
 import net.imglib2.Interval;
 import net.imglib2.Localizable;
-import net.imglib2.Point;
 import net.imglib2.RandomAccess;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.RealType;
@@ -81,25 +80,32 @@ public class FlatFieldCorrectedRandomAccessibleInterval <O extends RealType< O >
 		return type;
 	}
 
-	private class FlatFieldCorrectedRandomAccess extends Point implements RandomAccess<O>
+	private class FlatFieldCorrectedRandomAccess implements RandomAccess<O>
 	{
 		private final RandomAccess<T> sourceRA;
 		private final RandomAccess<S> brightRA;
 		private final RandomAccess<R> darkRA;
 		private final O value;
 
+		private final int nDimSource;
 		private final int nDimBright;
 		private final int nDimDark;
 
+		// Cached min/max values to avoid virtual method calls in get()
+		private final double minValue;
+		private final double maxValue;
+
 		public FlatFieldCorrectedRandomAccess()
 		{
-			super(sourceImg.numDimensions());
 			sourceRA = sourceImg.randomAccess();
 			brightRA = brightImg.randomAccess();
 			darkRA = darkImg.randomAccess();
 			value = type.createVariable();
+			nDimSource = sourceImg.numDimensions();
 			nDimBright = brightImg.numDimensions();
 			nDimDark = darkImg.numDimensions();
+			minValue = value.getMinValue();
+			maxValue = value.getMaxValue();
 		}
 
 		@Override
@@ -113,7 +119,7 @@ public class FlatFieldCorrectedRandomAccessibleInterval <O extends RealType< O >
 				value.setReal(0.0);
 			else
 			{
-				final double corr = Math.min(Math.max(corrImg * meanBrightCorrected / corrBright, value.getMinValue()), value.getMaxValue());
+				final double corr = Math.min(Math.max(corrImg * meanBrightCorrected / corrBright, minValue), maxValue);
 				value.setReal(corr);
 			}
 
@@ -123,7 +129,6 @@ public class FlatFieldCorrectedRandomAccessibleInterval <O extends RealType< O >
 		@Override
 		public void fwd(int d)
 		{
-			position[d]++;
 			sourceRA.fwd(d);
 			if (d < nDimBright) brightRA.fwd(d);
 			if (d < nDimDark) darkRA.fwd(d);
@@ -132,7 +137,6 @@ public class FlatFieldCorrectedRandomAccessibleInterval <O extends RealType< O >
 		@Override
 		public void bck(int d)
 		{
-			position[d]--;
 			sourceRA.bck(d);
 			if (d < nDimBright) brightRA.bck(d);
 			if (d < nDimDark) darkRA.bck(d);
@@ -141,7 +145,6 @@ public class FlatFieldCorrectedRandomAccessibleInterval <O extends RealType< O >
 		@Override
 		public void move(int distance, int d)
 		{
-			position[d] += distance;
 			sourceRA.move(distance, d);
 			if (d < nDimBright) brightRA.move(distance, d);
 			if (d < nDimDark) darkRA.move(distance, d);
@@ -150,7 +153,6 @@ public class FlatFieldCorrectedRandomAccessibleInterval <O extends RealType< O >
 		@Override
 		public void move(long distance, int d)
 		{
-			position[d] += distance;
 			sourceRA.move(distance, d);
 			if (d < nDimBright) brightRA.move(distance, d);
 			if (d < nDimDark) darkRA.move(distance, d);
@@ -159,8 +161,6 @@ public class FlatFieldCorrectedRandomAccessibleInterval <O extends RealType< O >
 		@Override
 		public void move(Localizable distance)
 		{
-			for (int d = 0; d < n; d++)
-				position[d] += distance.getLongPosition(d);
 			sourceRA.move(distance);
 			for (int d = 0; d < nDimBright; d++)
 				brightRA.move(distance.getLongPosition(d), d);
@@ -171,8 +171,6 @@ public class FlatFieldCorrectedRandomAccessibleInterval <O extends RealType< O >
 		@Override
 		public void move(int[] distance)
 		{
-			for (int d = 0; d < n; d++)
-				position[d] += distance[d];
 			sourceRA.move(distance);
 			for (int d = 0; d < nDimBright; d++)
 				brightRA.move(distance[d], d);
@@ -183,8 +181,6 @@ public class FlatFieldCorrectedRandomAccessibleInterval <O extends RealType< O >
 		@Override
 		public void move(long[] distance)
 		{
-			for (int d = 0; d < n; d++)
-				position[d] += distance[d];
 			sourceRA.move(distance);
 			for (int d = 0; d < nDimBright; d++)
 				brightRA.move(distance[d], d);
@@ -195,8 +191,6 @@ public class FlatFieldCorrectedRandomAccessibleInterval <O extends RealType< O >
 		@Override
 		public void setPosition(Localizable position)
 		{
-			for (int d = 0; d < n; d++)
-				this.position[d] = position.getLongPosition(d);
 			sourceRA.setPosition(position);
 			for (int d = 0; d < nDimBright; d++)
 				brightRA.setPosition(position.getLongPosition(d), d);
@@ -207,8 +201,6 @@ public class FlatFieldCorrectedRandomAccessibleInterval <O extends RealType< O >
 		@Override
 		public void setPosition(int[] position)
 		{
-			for (int d = 0; d < n; d++)
-				this.position[d] = position[d];
 			sourceRA.setPosition(position);
 			for (int d = 0; d < nDimBright; d++)
 				brightRA.setPosition(position[d], d);
@@ -219,8 +211,6 @@ public class FlatFieldCorrectedRandomAccessibleInterval <O extends RealType< O >
 		@Override
 		public void setPosition(long[] position)
 		{
-			for (int d = 0; d < n; d++)
-				this.position[d] = position[d];
 			sourceRA.setPosition(position);
 			for (int d = 0; d < nDimBright; d++)
 				brightRA.setPosition(position[d], d);
@@ -231,7 +221,6 @@ public class FlatFieldCorrectedRandomAccessibleInterval <O extends RealType< O >
 		@Override
 		public void setPosition(int position, int d)
 		{
-			this.position[d] = position;
 			sourceRA.setPosition(position, d);
 			if (d < nDimBright) brightRA.setPosition(position, d);
 			if (d < nDimDark) darkRA.setPosition(position, d);
@@ -240,16 +229,72 @@ public class FlatFieldCorrectedRandomAccessibleInterval <O extends RealType< O >
 		@Override
 		public void setPosition(long position, int d)
 		{
-			this.position[d] = position;
 			sourceRA.setPosition(position, d);
 			if (d < nDimBright) brightRA.setPosition(position, d);
 			if (d < nDimDark) darkRA.setPosition(position, d);
 		}
 
+		// Localizable - delegate to sourceRA
+
 		@Override
-		public RandomAccess<O> copy() {
+		public int numDimensions()
+		{
+			return nDimSource;
+		}
+
+		@Override
+		public void localize(int[] position)
+		{
+			sourceRA.localize(position);
+		}
+
+		@Override
+		public void localize(long[] position)
+		{
+			sourceRA.localize(position);
+		}
+
+		@Override
+		public int getIntPosition(int d)
+		{
+			return sourceRA.getIntPosition(d);
+		}
+
+		@Override
+		public long getLongPosition(int d)
+		{
+			return sourceRA.getLongPosition(d);
+		}
+
+		@Override
+		public void localize(float[] position)
+		{
+			sourceRA.localize(position);
+		}
+
+		@Override
+		public void localize(double[] position)
+		{
+			sourceRA.localize(position);
+		}
+
+		@Override
+		public float getFloatPosition(int d)
+		{
+			return sourceRA.getFloatPosition(d);
+		}
+
+		@Override
+		public double getDoublePosition(int d)
+		{
+			return sourceRA.getDoublePosition(d);
+		}
+
+		@Override
+		public RandomAccess<O> copy()
+		{
 			final FlatFieldCorrectedRandomAccessibleInterval<O, T, S, R>.FlatFieldCorrectedRandomAccess copy = new FlatFieldCorrectedRandomAccess();
-			copy.setPosition(this);
+			copy.setPosition(sourceRA);
 			return copy;
 		}
 	}

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/FlatFieldCorrectedRandomAccessibleIntervals.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/FlatFieldCorrectedRandomAccessibleIntervals.java
@@ -25,7 +25,6 @@ package net.preibisch.mvrecon.fiji.spimdata.imgloaders.flatfield;
 import java.util.Arrays;
 
 import bdv.util.ConstantRandomAccessible;
-import bdv.viewer.overlay.SourceInfoOverlayRenderer;
 import net.imglib2.FinalInterval;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.RealType;
@@ -39,7 +38,7 @@ public class FlatFieldCorrectedRandomAccessibleIntervals
 			RandomAccessibleInterval< S > brightImg,
 			RandomAccessibleInterval< T > darkImg )
 	{
-		R type = Views.iterable( sourceImg ).firstElement().createVariable();
+		R type = sourceImg.firstElement().createVariable();
 		return create( sourceImg, brightImg, darkImg, type );
 	}
 	public static <O extends RealType< O >, R extends RealType< R >, S extends RealType< S >, T extends RealType< T >> RandomAccessibleInterval< O > create(
@@ -85,20 +84,20 @@ public class FlatFieldCorrectedRandomAccessibleIntervals
 		{
 			// assume bright and dark images constant -> should return original
 			// TODO: 'optimize' by really returning sourceImg?
-			final ConstantRandomAccessible< FloatType > constantBright = new ConstantRandomAccessible<FloatType>( new FloatType(1.0f), sourceImg.numDimensions() );
-			final ConstantRandomAccessible< FloatType > constantDark = new ConstantRandomAccessible<FloatType>( new FloatType(0.0f), sourceImg.numDimensions() );
+			final ConstantRandomAccessible< FloatType > constantBright = new ConstantRandomAccessible<>( new FloatType(1.0f), sourceImg.numDimensions() );
+			final ConstantRandomAccessible< FloatType > constantDark = new ConstantRandomAccessible<>( new FloatType(0.0f), sourceImg.numDimensions() );
 			return new FlatFieldCorrectedRandomAccessibleInterval<>(outputType, sourceImg, Views.interval( constantBright, sourceImg ), Views.interval( constantDark, sourceImg ) );
 		}
 		else if (brightImg == null)
 		{
 			// assume bright image == constant
-			final ConstantRandomAccessible< FloatType > constantBright = new ConstantRandomAccessible<FloatType>( new FloatType(1.0f), sourceImg.numDimensions() );
+			final ConstantRandomAccessible< FloatType > constantBright = new ConstantRandomAccessible<>( new FloatType(1.0f), sourceImg.numDimensions() );
 			return new FlatFieldCorrectedRandomAccessibleInterval<>(outputType, sourceImg, Views.interval( constantBright, sourceImg ), Views.interval( Views.extendBorder( darkImg ), intervalDark ) );
 		}
 		else if (darkImg == null)
 		{
 			// assume dark image == constant == 0;
-			final ConstantRandomAccessible< FloatType > constantDark = new ConstantRandomAccessible<FloatType>( new FloatType(0.0f), sourceImg.numDimensions() );
+			final ConstantRandomAccessible< FloatType > constantDark = new ConstantRandomAccessible<>( new FloatType(0.0f), sourceImg.numDimensions() );
 			return new FlatFieldCorrectedRandomAccessibleInterval<>(outputType, sourceImg, Views.interval( Views.extendBorder( brightImg ), intervalBright ), Views.interval( constantDark, sourceImg ) );
 		}
 			

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/FlatFieldCorrectedRandomAccessibleIntervals.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/FlatFieldCorrectedRandomAccessibleIntervals.java
@@ -22,85 +22,145 @@
  */
 package net.preibisch.mvrecon.fiji.spimdata.imgloaders.flatfield;
 
-import java.util.Arrays;
-
-import bdv.util.ConstantRandomAccessible;
-import net.imglib2.FinalInterval;
 import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.algorithm.blocks.BlockAlgoUtils;
+import net.imglib2.algorithm.blocks.BlockSupplier;
+import net.imglib2.cache.img.CachedCellImg;
+import net.imglib2.converter.RealTypeConverters;
+import net.imglib2.type.NativeType;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.real.FloatType;
 import net.imglib2.view.Views;
 
+/**
+ * Factory methods for creating flatfield-corrected images.
+ *
+ * All methods use efficient block-based processing internally via
+ * {@link FlatfieldCorrectionBlockSupplier}, backed by a {@link CachedCellImg}.
+ */
 public class FlatFieldCorrectedRandomAccessibleIntervals
 {
-	public static < R extends RealType< R >, S extends RealType< S >, T extends RealType< T >> RandomAccessibleInterval< R > create(
-			RandomAccessibleInterval< R > sourceImg,
-			RandomAccessibleInterval< S > brightImg,
-			RandomAccessibleInterval< T > darkImg )
+	/** Default cell size for block-based flatfield correction */
+	private static final int[] DEFAULT_CELL_SIZE = new int[] {64, 64, 64};
+
+	/**
+	 * Create a flatfield-corrected image with the same type as the source.
+	 * Uses efficient block-based processing internally.
+	 *
+	 * @param sourceImg source image
+	 * @param brightImg bright (flatfield) image, can be null
+	 * @param darkImg dark image, can be null
+	 * @return corrected image with same type as source
+	 */
+	public static <R extends RealType<R> & NativeType<R>, S extends RealType<S>, T extends RealType<T>>
+	RandomAccessibleInterval<R> create(
+			final RandomAccessibleInterval<R> sourceImg,
+			final RandomAccessibleInterval<S> brightImg,
+			final RandomAccessibleInterval<T> darkImg)
 	{
-		R type = sourceImg.firstElement().createVariable();
-		return create( sourceImg, brightImg, darkImg, type );
+		final R type = sourceImg.getType().createVariable();
+		return create(sourceImg, brightImg, darkImg, type);
 	}
-	public static <O extends RealType< O >, R extends RealType< R >, S extends RealType< S >, T extends RealType< T >> RandomAccessibleInterval< O > create(
-			RandomAccessibleInterval< R > sourceImg,
-			RandomAccessibleInterval< S > brightImg,
-			RandomAccessibleInterval< T > darkImg,
-			O outputType)
+
+	/**
+	 * Create a flatfield-corrected image with a specified output type.
+	 * Uses efficient block-based processing internally.
+	 *
+	 * @param sourceImg source image
+	 * @param brightImg bright (flatfield) image, can be null
+	 * @param darkImg dark image, can be null
+	 * @param outputType the desired output type
+	 * @return corrected image with specified output type
+	 */
+	@SuppressWarnings("unchecked")
+	public static <O extends RealType<O>, R extends RealType<R> & NativeType<R>, S extends RealType<S>, T extends RealType<T>>
+	RandomAccessibleInterval<O> create(
+			final RandomAccessibleInterval<R> sourceImg,
+			final RandomAccessibleInterval<S> brightImg,
+			final RandomAccessibleInterval<T> darkImg,
+			final O outputType)
 	{
+		// Create block-based corrected image (always FloatType internally)
+		final RandomAccessibleInterval<FloatType> correctedFloat = createBlockBased(
+				sourceImg, brightImg, darkImg, DEFAULT_CELL_SIZE);
 
-		// get intervals for bright and/or dark imgs: interval of source img, but only for dimensionality of bright/dark
-		final long[] minsBright;
-		final long[] maxsBright;
-		FinalInterval intervalBright = null;
-		if (brightImg != null)
-		{
-			minsBright = new long[brightImg.numDimensions()];
-			maxsBright = new long[brightImg.numDimensions()];
-			Arrays.fill( maxsBright, 1 );
-			for (int d = 0; d < brightImg.numDimensions(); ++d)
-			{
-				minsBright[d] = sourceImg.min( d );
-				maxsBright[d] = sourceImg.max( d );
-			}
-			intervalBright = new FinalInterval( minsBright, maxsBright );
-		}
-		final long[] minsDark;
-		final long[] maxsDark;
-		FinalInterval intervalDark = null;
-		if (darkImg != null)
-		{
-			minsDark = new long[darkImg.numDimensions()];
-			maxsDark = new long[darkImg.numDimensions()];
-			Arrays.fill( maxsDark, 1 );
-			for (int d = 0; d < darkImg.numDimensions(); ++d)
-			{
-				minsDark[d] = sourceImg.min( d );
-				maxsDark[d] = sourceImg.max( d );
-			}
-			intervalDark = new FinalInterval( minsDark, maxsDark );
-		}
+		// If output type is FloatType, return directly
+		if (outputType instanceof FloatType)
+			return (RandomAccessibleInterval<O>) correctedFloat;
 
+		// Otherwise, convert to the requested output type
+		return RealTypeConverters.convert(correctedFloat, outputType);
+	}
+
+	/**
+	 * Create a flatfield-corrected FloatType image using efficient block-based processing.
+	 * The result is backed by a CachedCellImg that computes correction on-demand.
+	 *
+	 * @param sourceImg source image (can be any RealType)
+	 * @param brightImg bright (flatfield) image, can be null
+	 * @param darkImg dark image, can be null
+	 * @return FloatType RandomAccessibleInterval with flatfield correction applied
+	 */
+	public static <R extends RealType<R> & NativeType<R>, S extends RealType<S>, T extends RealType<T>>
+	RandomAccessibleInterval<FloatType> createBlockBased(
+			final RandomAccessibleInterval<R> sourceImg,
+			final RandomAccessibleInterval<S> brightImg,
+			final RandomAccessibleInterval<T> darkImg)
+	{
+		return createBlockBased(sourceImg, brightImg, darkImg, DEFAULT_CELL_SIZE);
+	}
+
+	/**
+	 * Create a flatfield-corrected FloatType image using efficient block-based processing.
+	 * The result is backed by a CachedCellImg that computes correction on-demand.
+	 *
+	 * @param sourceImg source image (can be any RealType)
+	 * @param brightImg bright (flatfield) image, can be null
+	 * @param darkImg dark image, can be null
+	 * @param cellSize cell size for the cached image
+	 * @return FloatType RandomAccessibleInterval with flatfield correction applied
+	 */
+	public static <R extends RealType<R> & NativeType<R>, S extends RealType<S>, T extends RealType<T>>
+	RandomAccessibleInterval<FloatType> createBlockBased(
+			final RandomAccessibleInterval<R> sourceImg,
+			final RandomAccessibleInterval<S> brightImg,
+			final RandomAccessibleInterval<T> darkImg,
+			final int[] cellSize)
+	{
+		// Handle null bright/dark - if both null, just convert source to float
 		if (brightImg == null && darkImg == null)
 		{
-			// assume bright and dark images constant -> should return original
-			// TODO: 'optimize' by really returning sourceImg?
-			final ConstantRandomAccessible< FloatType > constantBright = new ConstantRandomAccessible<>( new FloatType(1.0f), sourceImg.numDimensions() );
-			final ConstantRandomAccessible< FloatType > constantDark = new ConstantRandomAccessible<>( new FloatType(0.0f), sourceImg.numDimensions() );
-			return new FlatFieldCorrectedRandomAccessibleInterval<>(outputType, sourceImg, Views.interval( constantBright, sourceImg ), Views.interval( constantDark, sourceImg ) );
+			final BlockSupplier<FloatType> blocks = BlockSupplier
+					.of(Views.extendBorder(sourceImg))
+					.andThen(net.imglib2.algorithm.blocks.convert.Convert.convert(new FloatType()));
+			return wrapWithOffset(blocks, sourceImg, cellSize);
 		}
-		else if (brightImg == null)
-		{
-			// assume bright image == constant
-			final ConstantRandomAccessible< FloatType > constantBright = new ConstantRandomAccessible<>( new FloatType(1.0f), sourceImg.numDimensions() );
-			return new FlatFieldCorrectedRandomAccessibleInterval<>(outputType, sourceImg, Views.interval( constantBright, sourceImg ), Views.interval( Views.extendBorder( darkImg ), intervalDark ) );
-		}
-		else if (darkImg == null)
-		{
-			// assume dark image == constant == 0;
-			final ConstantRandomAccessible< FloatType > constantDark = new ConstantRandomAccessible<>( new FloatType(0.0f), sourceImg.numDimensions() );
-			return new FlatFieldCorrectedRandomAccessibleInterval<>(outputType, sourceImg, Views.interval( Views.extendBorder( brightImg ), intervalBright ), Views.interval( constantDark, sourceImg ) );
-		}
-			
-		return new FlatFieldCorrectedRandomAccessibleInterval<>(outputType, sourceImg, Views.interval( Views.extendBorder( brightImg ), intervalBright ), Views.interval( Views.extendBorder( darkImg ), intervalDark ) );
+
+		// Create the block supplier with flatfield correction
+		final BlockSupplier<FloatType> blocks = FlatfieldCorrectionBlockSupplier.of(
+				sourceImg, brightImg, darkImg);
+
+		return wrapWithOffset(blocks, sourceImg, cellSize);
+	}
+
+	/**
+	 * Wrap a BlockSupplier in a CachedCellImg and translate to match source interval.
+	 */
+	private static <R extends RealType<R>> RandomAccessibleInterval<FloatType> wrapWithOffset(
+			final BlockSupplier<FloatType> blocks,
+			final RandomAccessibleInterval<R> sourceImg,
+			final int[] cellSize)
+	{
+		// Create CachedCellImg (zero-min)
+		final CachedCellImg<FloatType, ?> cellImg = BlockAlgoUtils.cellImg(
+				blocks.threadSafe(),
+				sourceImg.dimensionsAsLongArray(),
+				cellSize);
+
+		// Translate to match source interval if not zero-min
+		if (Views.isZeroMin(sourceImg))
+			return cellImg;
+		else
+			return Views.translate(cellImg, sourceImg.minAsLongArray());
 	}
 }

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/FlatfieldCorrectionBlockSupplier.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/FlatfieldCorrectionBlockSupplier.java
@@ -1,0 +1,288 @@
+/*-
+ * #%L
+ * Software for the reconstruction of multi-view microscopic acquisitions
+ * like Selective Plane Illumination Microscopy (SPIM) Data.
+ * %%
+ * Copyright (C) 2012 - 2025 Multiview Reconstruction developers.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+package net.preibisch.mvrecon.fiji.spimdata.imgloaders.flatfield;
+
+import static net.imglib2.type.PrimitiveType.FLOAT;
+import static net.imglib2.util.Util.safeInt;
+
+import bdv.util.ConstantRandomAccessible;
+import net.imglib2.FinalInterval;
+import net.imglib2.Interval;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.algorithm.blocks.BlockSupplier;
+import net.imglib2.algorithm.blocks.convert.Convert;
+import net.imglib2.blocks.BlockInterval;
+import net.imglib2.blocks.TempArray;
+import net.imglib2.type.NativeType;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.real.FloatType;
+import net.imglib2.util.Cast;
+import net.imglib2.util.Intervals;
+import net.imglib2.view.Views;
+
+/**
+ * Block-based flatfield correction for efficient fusion processing.
+ *
+ * Applies the correction formula:
+ *   corrected = (source - dark) * meanBrightCorrected / (bright - dark)
+ *
+ * The bright and dark images are 2D (XY only), while the source may be 3D.
+ * For 3D blocks, the same 2D bright/dark data is reused for all Z slices,
+ * making this much more efficient than per-pixel RandomAccess.
+ */
+public class FlatfieldCorrectionBlockSupplier implements BlockSupplier<FloatType> {
+	private final BlockSupplier<FloatType> source;
+	private final BlockSupplier<FloatType> bright;
+	private final BlockSupplier<FloatType> dark;
+	private final double meanBrightCorrected;
+	private final int numDimensions;
+
+	// Temp arrays for block data
+	private final TempArray<float[]> srcTemp;
+	private final TempArray<float[]> brightTemp;
+	private final TempArray<float[]> darkTemp;
+
+	/**
+	 * Create a flatfield correction BlockSupplier.
+	 *
+	 * @param source source image BlockSupplier (can be 2D or 3D)
+	 * @param bright bright (flatfield) image as BlockSupplier (2D)
+	 * @param dark dark image as BlockSupplier (2D)
+	 * @param meanBrightCorrected pre-computed mean of (bright - dark)
+	 */
+	public FlatfieldCorrectionBlockSupplier(
+			final BlockSupplier<FloatType> source,
+			final BlockSupplier<FloatType> bright,
+			final BlockSupplier<FloatType> dark,
+			final double meanBrightCorrected)
+	{
+		this.source = source;
+		this.bright = bright;
+		this.dark = dark;
+		this.meanBrightCorrected = meanBrightCorrected;
+		this.numDimensions = source.numDimensions();
+
+		this.srcTemp = TempArray.forPrimitiveType(FLOAT);
+		this.brightTemp = TempArray.forPrimitiveType(FLOAT);
+		this.darkTemp = TempArray.forPrimitiveType(FLOAT);
+	}
+
+	private FlatfieldCorrectionBlockSupplier(final FlatfieldCorrectionBlockSupplier s) {
+		this.source = s.source.independentCopy();
+		this.bright = s.bright.independentCopy();
+		this.dark = s.dark.independentCopy();
+		this.meanBrightCorrected = s.meanBrightCorrected;
+		this.numDimensions = s.numDimensions;
+
+		this.srcTemp = TempArray.forPrimitiveType(FLOAT);
+		this.brightTemp = TempArray.forPrimitiveType(FLOAT);
+		this.darkTemp = TempArray.forPrimitiveType(FLOAT);
+	}
+
+	/**
+	 * Factory method to create a flatfield correction BlockSupplier from an existing FloatType source.
+	 */
+	public static BlockSupplier<FloatType> of(
+			final BlockSupplier<FloatType> source,
+			final RandomAccessibleInterval<FloatType> bright,
+			final RandomAccessibleInterval<FloatType> dark,
+			final double meanBrightCorrected)
+	{
+		return new FlatfieldCorrectionBlockSupplier(
+				source,
+				BlockSupplier.of(bright),
+				BlockSupplier.of(dark),
+				meanBrightCorrected);
+	}
+
+	/**
+	 * Factory method to create a flatfield correction BlockSupplier from RAIs.
+	 * Handles interval adjustment for 2D bright/dark with 3D source, similar to
+	 * {@link FlatFieldCorrectedRandomAccessibleIntervals#create}.
+	 *
+	 * @param sourceImg source image (can be any RealType, will be converted to FloatType)
+	 * @param brightImg bright (flatfield) image, can be null
+	 * @param darkImg dark image, can be null
+	 * @return BlockSupplier that applies flatfield correction
+	 */
+	public static <T extends RealType<T> & NativeType<T>, S extends RealType<S>, R extends RealType<R>>
+	BlockSupplier<FloatType> of(
+			final RandomAccessibleInterval<T> sourceImg,
+			final RandomAccessibleInterval<S> brightImg,
+			final RandomAccessibleInterval<R> darkImg)
+	{
+		// Create source BlockSupplier and convert to float
+		final BlockSupplier<FloatType> source = BlockSupplier
+				.of(Views.extendBorder(sourceImg))
+				.andThen(Convert.convert(new FloatType()));
+
+		// Handle null bright/dark images
+		final RandomAccessibleInterval<FloatType> bright;
+		final RandomAccessibleInterval<FloatType> dark;
+
+		if (brightImg == null && darkImg == null) {
+			// No correction needed, return source as-is
+			return source;
+		} else if (brightImg == null) {
+			// Assume bright == constant 1.0
+			final ConstantRandomAccessible<FloatType> constantBright =
+					new ConstantRandomAccessible<>(new FloatType(1.0f), darkImg.numDimensions());
+			bright = Views.interval(constantBright, createInterval(sourceImg, darkImg.numDimensions()));
+			dark = Views.interval(Views.extendBorder(convertToFloat(darkImg)),
+					createInterval(sourceImg, darkImg.numDimensions()));
+		} else if (darkImg == null) {
+			// Assume dark == constant 0.0
+			final ConstantRandomAccessible<FloatType> constantDark =
+					new ConstantRandomAccessible<>(new FloatType(0.0f), brightImg.numDimensions());
+			bright = Views.interval(Views.extendBorder(convertToFloat(brightImg)),
+					createInterval(sourceImg, brightImg.numDimensions()));
+			dark = Views.interval(constantDark, createInterval(sourceImg, brightImg.numDimensions()));
+		} else {
+			bright = Views.interval(Views.extendBorder(convertToFloat(brightImg)),
+					createInterval(sourceImg, brightImg.numDimensions()));
+			dark = Views.interval(Views.extendBorder(convertToFloat(darkImg)),
+					createInterval(sourceImg, darkImg.numDimensions()));
+		}
+
+		final double meanBrightCorrected = FlatFieldCorrectedRandomAccessibleInterval.getMeanCorrected(bright, dark);
+
+		return new FlatfieldCorrectionBlockSupplier(
+				source,
+				BlockSupplier.of(bright),
+				BlockSupplier.of(dark),
+				meanBrightCorrected);
+	}
+
+	/**
+	 * Create an interval matching the source's first N dimensions.
+	 */
+	private static FinalInterval createInterval(final Interval source, final int numDimensions) {
+		final long[] mins = new long[numDimensions];
+		final long[] maxs = new long[numDimensions];
+		for (int d = 0; d < numDimensions; d++) {
+			mins[d] = source.min(d);
+			maxs[d] = source.max(d);
+		}
+		return new FinalInterval(mins, maxs);
+	}
+
+	/**
+	 * Convert a RealType RAI to FloatType.
+	 */
+	@SuppressWarnings("unchecked")
+	private static <T extends RealType<T>> RandomAccessibleInterval<FloatType> convertToFloat(
+			final RandomAccessibleInterval<T> img)
+	{
+		if (img.getType() instanceof FloatType) {
+			return (RandomAccessibleInterval<FloatType>) img;
+		}
+
+		return net.imglib2.converter.RealTypeConverters.convert(img, new FloatType());
+	}
+
+	@Override
+	public void copy(final Interval interval, final Object dest) {
+		final BlockInterval blockInterval = BlockInterval.asBlockInterval(interval);
+		final int[] size = blockInterval.size();
+
+		final int len = safeInt(Intervals.numElements(size));
+		final float[] srcArray = srcTemp.get(len);
+
+		// Copy source block (full 3D or 2D)
+		source.copy(interval, srcArray);
+
+		// Determine XY size for bright/dark
+		final int xyLen;
+		final int zSize;
+		if (numDimensions >= 3) {
+			xyLen = size[0] * size[1];
+			zSize = size[2];
+		} else {
+			xyLen = len;
+			zSize = 1;
+		}
+
+		final float[] brightArray = brightTemp.get(xyLen);
+		final float[] darkArray = darkTemp.get(xyLen);
+
+		// Create 2D interval for bright/dark (XY only)
+		final Interval interval2D;
+		if (numDimensions >= 3) {
+			interval2D = new FinalInterval(
+					new long[]{interval.min(0), interval.min(1)},
+					new long[]{interval.max(0), interval.max(1)});
+		} else {
+			interval2D = interval;
+		}
+
+		// Copy bright/dark blocks (2D)
+		bright.copy(interval2D, brightArray);
+		dark.copy(interval2D, darkArray);
+
+		// Apply correction
+		final float[] fdest = Cast.unchecked(dest);
+		final float meanBC = (float) meanBrightCorrected;
+
+		for (int z = 0; z < zSize; z++) {
+			final int zOffset = z * xyLen;
+			for (int i = 0; i < xyLen; i++) {
+				final float darkVal = darkArray[i];
+				final float corrBright = brightArray[i] - darkVal;
+				final float srcVal = srcArray[zOffset + i];
+				final float corrImg = srcVal - darkVal;
+
+				if (corrBright == 0) {
+					fdest[zOffset + i] = 0;
+				} else {
+					fdest[zOffset + i] = corrImg * meanBC / corrBright;
+				}
+			}
+		}
+	}
+
+	@Override
+	public BlockSupplier<FloatType> independentCopy() {
+		return new FlatfieldCorrectionBlockSupplier(this);
+	}
+
+	@Override
+	public BlockSupplier<FloatType> threadSafe() {
+		return new FlatfieldCorrectionBlockSupplier(
+				source.threadSafe(),
+				bright.threadSafe(),
+				dark.threadSafe(),
+				meanBrightCorrected);
+	}
+
+	@Override
+	public int numDimensions() {
+		return numDimensions;
+	}
+
+	private static final FloatType type = new FloatType();
+
+	@Override
+	public FloatType getType() {
+		return type;
+	}
+}

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/FlatfieldCorrectionWrappedImgLoader.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/FlatfieldCorrectionWrappedImgLoader.java
@@ -9,12 +9,12 @@
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
@@ -22,49 +22,28 @@
  */
 package net.preibisch.mvrecon.fiji.spimdata.imgloaders.flatfield;
 
-import java.io.File;
-import java.net.URI;
-
 import mpicbg.spim.data.sequence.ImgLoader;
 import mpicbg.spim.data.sequence.ViewId;
 
 public interface FlatfieldCorrectionWrappedImgLoader<IL extends ImgLoader> extends ImgLoader
 {
-	public IL getWrappedImgLoder();
-	public void setActive(boolean active);
-	public boolean isActive();
-	public void setCached(boolean cached);
-	public boolean isCached();
+	IL getWrappedImgLoder();
+	void setActive(boolean active);
+	boolean isActive();
+	void setCached(boolean cached);
+	boolean isCached();
 
 	/**
 	 * Set the bright (flatfield) image for a view.
 	 * @param vId view id
-	 * @param imgUri URI to the bright image (supports file://, s3://, gs://, local paths)
+	 * @param info flatfield image info containing URI, format, and optional dataset path
 	 */
-	public void setBrightImage(ViewId vId, URI imgUri);
+	void setBrightImage(ViewId vId, FlatfieldImageInfo info);
 
 	/**
 	 * Set the dark (darkfield) image for a view.
 	 * @param vId view id
-	 * @param imgUri URI to the dark image (supports file://, s3://, gs://, local paths)
+	 * @param info flatfield image info containing URI, format, and optional dataset path
 	 */
-	public void setDarkImage(ViewId vId, URI imgUri);
-
-	/**
-	 * Set the bright (flatfield) image for a view from a local file.
-	 * @param vId view id
-	 * @param imgFile local file path to the bright image
-	 */
-	default void setBrightImage(ViewId vId, File imgFile) {
-		setBrightImage(vId, imgFile == null ? null : imgFile.toURI());
-	}
-
-	/**
-	 * Set the dark (darkfield) image for a view from a local file.
-	 * @param vId view id
-	 * @param imgFile local file path to the dark image
-	 */
-	default void setDarkImage(ViewId vId, File imgFile) {
-		setDarkImage(vId, imgFile == null ? null : imgFile.toURI());
-	}
+	void setDarkImage(ViewId vId, FlatfieldImageInfo info);
 }

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/FlatfieldCorrectionWrappedImgLoader.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/FlatfieldCorrectionWrappedImgLoader.java
@@ -23,6 +23,7 @@
 package net.preibisch.mvrecon.fiji.spimdata.imgloaders.flatfield;
 
 import java.io.File;
+import java.net.URI;
 
 import mpicbg.spim.data.sequence.ImgLoader;
 import mpicbg.spim.data.sequence.ViewId;
@@ -34,6 +35,36 @@ public interface FlatfieldCorrectionWrappedImgLoader<IL extends ImgLoader> exten
 	public boolean isActive();
 	public void setCached(boolean cached);
 	public boolean isCached();
-	public void setBrightImage(ViewId vId, File imgFile);
-	public void setDarkImage(ViewId vId, File imgFile);
+
+	/**
+	 * Set the bright (flatfield) image for a view.
+	 * @param vId view id
+	 * @param imgUri URI to the bright image (supports file://, s3://, gs://, local paths)
+	 */
+	public void setBrightImage(ViewId vId, URI imgUri);
+
+	/**
+	 * Set the dark (darkfield) image for a view.
+	 * @param vId view id
+	 * @param imgUri URI to the dark image (supports file://, s3://, gs://, local paths)
+	 */
+	public void setDarkImage(ViewId vId, URI imgUri);
+
+	/**
+	 * Set the bright (flatfield) image for a view from a local file.
+	 * @param vId view id
+	 * @param imgFile local file path to the bright image
+	 */
+	default void setBrightImage(ViewId vId, File imgFile) {
+		setBrightImage(vId, imgFile == null ? null : imgFile.toURI());
+	}
+
+	/**
+	 * Set the dark (darkfield) image for a view from a local file.
+	 * @param vId view id
+	 * @param imgFile local file path to the dark image
+	 */
+	default void setDarkImage(ViewId vId, File imgFile) {
+		setDarkImage(vId, imgFile == null ? null : imgFile.toURI());
+	}
 }

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/FlatfieldImageInfo.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/FlatfieldImageInfo.java
@@ -1,0 +1,122 @@
+/*-
+ * #%L
+ * Software for the reconstruction of multi-view microscopic acquisitions
+ * like Selective Plane Illumination Microscopy (SPIM) Data.
+ * %%
+ * Copyright (C) 2012 - 2025 Multiview Reconstruction developers.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+package net.preibisch.mvrecon.fiji.spimdata.imgloaders.flatfield;
+
+import java.net.URI;
+import java.util.Objects;
+
+import org.janelia.saalfeldlab.n5.universe.StorageFormat;
+
+/**
+ * Data class holding flatfield image metadata: URI, format, and dataset path.
+ */
+public class FlatfieldImageInfo {
+
+	private final URI uri;
+	private final StorageFormat format;
+	private final String dataset;
+
+	/**
+	 * Create a FlatfieldImageInfo with all parameters.
+	 *
+	 * @param uri the URI to the flatfield image
+	 * @param format the storage format (TIF uses null, others use StorageFormat enum)
+	 * @param dataset the dataset path within the container (null or empty for root)
+	 */
+	public FlatfieldImageInfo(final URI uri, final StorageFormat format, final String dataset) {
+		this.uri = uri;
+		this.format = format;
+		this.dataset = dataset;
+	}
+
+	/**
+	 * Create a FlatfieldImageInfo with URI, using TIF format and root dataset.
+	 */
+	public FlatfieldImageInfo(final URI uri) {
+		this(uri, null, null);
+	}
+
+	/**
+	 * Create a FlatfieldImageInfo with URI and format, using root dataset.
+	 */
+	public FlatfieldImageInfo(final URI uri, final StorageFormat format) {
+		this(uri, format, null);
+	}
+
+	public URI getUri() {
+		return uri;
+	}
+
+	/**
+	 * Get the storage format.
+	 * @return the format, or null for TIF format
+	 */
+	public StorageFormat getFormat() {
+		return format;
+	}
+
+	/**
+	 * Get the dataset path within the container.
+	 * @return the dataset path, or null/empty for root
+	 */
+	public String getDataset() {
+		return dataset;
+	}
+
+	/**
+	 * Get the effective dataset path (empty string if null).
+	 */
+	public String getEffectiveDataset() {
+		return dataset == null ? "" : dataset;
+	}
+
+	/**
+	 * Check if this is a TIF format (format is null).
+	 */
+	public boolean isTif() {
+		return format == null;
+	}
+
+	@Override
+	public String toString() {
+		return "FlatfieldImageInfo{uri=" + uri + ", format=" + format + ", dataset=" + dataset + "}";
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		FlatfieldImageInfo that = (FlatfieldImageInfo) o;
+		if (!Objects.equals(uri, that.uri)) return false;
+		if (format != that.format) return false;
+		return Objects.equals(dataset, that.dataset);
+	}
+
+	@Override
+	public int hashCode() {
+		int result = uri != null ? uri.hashCode() : 0;
+		result = 31 * result + (format != null ? format.hashCode() : 0);
+		result = 31 * result + (dataset != null ? dataset.hashCode() : 0);
+		return result;
+	}
+}

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/FlatfieldImageLoader.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/FlatfieldImageLoader.java
@@ -1,0 +1,181 @@
+/*-
+ * #%L
+ * Software for the reconstruction of multi-view microscopic acquisitions
+ * like Selective Plane Illumination Microscopy (SPIM) Data.
+ * %%
+ * Copyright (C) 2012 - 2025 Multiview Reconstruction developers.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+package net.preibisch.mvrecon.fiji.spimdata.imgloaders.flatfield;
+
+import java.io.File;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.janelia.saalfeldlab.n5.N5Reader;
+import org.janelia.saalfeldlab.n5.imglib2.N5Utils;
+import org.janelia.saalfeldlab.n5.universe.StorageFormat;
+
+import ij.IJ;
+import ij.ImagePlus;
+import mpicbg.spim.data.sequence.ViewId;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.converter.RealTypeConverters;
+import net.imglib2.img.display.imagej.ImageJFunctions;
+import net.imglib2.type.numeric.real.FloatType;
+import net.imglib2.util.Cast;
+import net.imglib2.util.Pair;
+import net.imglib2.util.ValuePair;
+import util.URITools;
+
+/**
+ * Helper class for loading flatfield correction images from various sources.
+ *
+ * This class handles:
+ * - URI-based storage of bright/dark image paths per view
+ * - Lazy loading and caching of images
+ * - Auto-detection of format (TIFF vs N5/Zarr)
+ * - Support for cloud storage (S3, GCS)
+ */
+public class FlatfieldImageLoader {
+
+	protected final Map<URI, RandomAccessibleInterval<FloatType>> raiMap;
+	protected final Map<ViewId, Pair<URI, URI>> uriMap;
+
+	private static final Pair<URI, URI> NULL_PAIR = new ValuePair<>(null, null);
+
+	public FlatfieldImageLoader() {
+		raiMap = new HashMap<>();
+		uriMap = new HashMap<>();
+	}
+
+	public void setBrightImage(ViewId vId, URI imgUri) {
+		final Pair<URI, URI> oldPair = uriMap.getOrDefault(vId, NULL_PAIR);
+		uriMap.put(vId, new ValuePair<>(imgUri, oldPair.getB()));
+	}
+
+	public void setDarkImage(ViewId vId, URI imgUri) {
+		final Pair<URI, URI> oldPair = uriMap.getOrDefault(vId, NULL_PAIR);
+		uriMap.put(vId, new ValuePair<>(oldPair.getA(), imgUri));
+	}
+
+	public void setBrightImage(ViewId vId, File imgFile) {
+		setBrightImage(vId, imgFile == null ? null : imgFile.toURI());
+	}
+
+	public void setDarkImage(ViewId vId, File imgFile) {
+		setDarkImage(vId, imgFile == null ? null : imgFile.toURI());
+	}
+
+	public RandomAccessibleInterval<FloatType> getBrightImg(ViewId vId) {
+		return getImg(vId, Pair::getA);
+	}
+
+	public RandomAccessibleInterval<FloatType> getDarkImg(ViewId vId) {
+		return getImg(vId, Pair::getB);
+	}
+
+	/**
+	 * Get image for view id; the brightfield is stored in the A element of the pair, the darkfield in B
+	 * @param vId view id
+	 * @param uriSelector function to select URI from pair
+	 * @return image, or null if not set
+	 */
+	private RandomAccessibleInterval<FloatType> getImg(ViewId vId, Function<Pair<URI, URI>, URI> uriSelector) {
+		if (!uriMap.containsKey(vId))
+			return null;
+
+		final URI uriToLoad = uriSelector.apply(uriMap.get(vId));
+		if (uriToLoad == null)
+			return null;
+
+		return loadImageIfNecessary(uriToLoad);
+	}
+
+	/**
+	 * Load an image from a URI. Supports:
+	 * - Local TIFF files (via ImageJ)
+	 * - Local/cloud Zarr v3 containers (via N5 API)
+	 * - Local/cloud N5 containers (via N5 API)
+	 *
+	 * @param uri URI to the image
+	 * @return the loaded image as FloatType
+	 */
+	public RandomAccessibleInterval<FloatType> loadImageIfNecessary(URI uri) {
+		if (!raiMap.containsKey(uri)) {
+			RandomAccessibleInterval<FloatType> img;
+
+			if (isChunkedFormat(uri)) {
+				// Use N5/Zarr API for chunked formats
+				final StorageFormat format = detectStorageFormat(uri);
+				final N5Reader reader = URITools.instantiateN5Reader(format, uri);
+				final RandomAccessibleInterval<?> raw = N5Utils.open(reader, "");
+				img = RealTypeConverters.convert(Cast.unchecked(raw), new FloatType());
+			} else {
+				// Legacy TIFF path via ImageJ
+				final File file = new File(uri);
+				final ImagePlus imp = IJ.openImage(file.getAbsolutePath());
+				if (imp == null)
+					throw new RuntimeException("Failed to load image from: " + uri);
+				img = ImageJFunctions.convertFloat(imp).copy();
+			}
+
+			raiMap.put(uri, img);
+		}
+		return raiMap.get(uri);
+	}
+
+	/**
+	 * Determine if the URI points to a chunked format (N5/Zarr) vs TIFF.
+	 */
+	public static boolean isChunkedFormat(URI uri) {
+		final String scheme = uri.getScheme();
+		// Cloud URIs are always chunked format
+		if ("s3".equals(scheme) || "gs".equals(scheme))
+			return true;
+
+		// Check path for .zarr or .n5 extension
+		final String path = uri.getPath();
+		if (path == null)
+			return false;
+
+		final String lowerPath = path.toLowerCase();
+		return lowerPath.endsWith(".zarr") || lowerPath.endsWith(".n5")
+			|| lowerPath.contains(".zarr/") || lowerPath.contains(".n5/");
+	}
+
+	/**
+	 * Detect the storage format from the URI.
+	 */
+	public static StorageFormat detectStorageFormat(URI uri) {
+		final String path = uri.getPath();
+		if (path != null && path.toLowerCase().contains(".n5"))
+			return StorageFormat.N5;
+		// Default to Zarr v3 for cloud and .zarr paths
+		return StorageFormat.ZARR;
+	}
+
+	/**
+	 * Get the URI map for bright/dark images per view.
+	 * @return map from ViewId to (brightUri, darkUri) pair
+	 */
+	public Map<ViewId, Pair<URI, URI>> getUriMap() {
+		return uriMap;
+	}
+}

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/FlatfieldImageLoader.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/FlatfieldImageLoader.java
@@ -48,39 +48,31 @@ import util.URITools;
  * Helper class for loading flatfield correction images from various sources.
  *
  * This class handles:
- * - URI-based storage of bright/dark image paths per view
+ * - Storage of bright/dark image info per view (URI, format, dataset path)
  * - Lazy loading and caching of images
- * - Auto-detection of format (TIFF vs N5/Zarr)
- * - Support for cloud storage (S3, GCS)
+ * - Support for TIF, N5, Zarr (v2/v3), and HDF5 formats
+ * - Support for cloud storage (S3, GCS) for N5/Zarr formats
  */
 public class FlatfieldImageLoader {
 
-	protected final Map<URI, RandomAccessibleInterval<FloatType>> raiMap;
-	protected final Map<ViewId, Pair<URI, URI>> uriMap;
+	protected final Map<FlatfieldImageInfo, RandomAccessibleInterval<FloatType>> raiMap;
+	protected final Map<ViewId, Pair<FlatfieldImageInfo, FlatfieldImageInfo>> infoMap;
 
-	private static final Pair<URI, URI> NULL_PAIR = new ValuePair<>(null, null);
+	private static final Pair<FlatfieldImageInfo, FlatfieldImageInfo> NULL_PAIR = new ValuePair<>(null, null);
 
 	public FlatfieldImageLoader() {
 		raiMap = new HashMap<>();
-		uriMap = new HashMap<>();
+		infoMap = new HashMap<>();
 	}
 
-	public void setBrightImage(ViewId vId, URI imgUri) {
-		final Pair<URI, URI> oldPair = uriMap.getOrDefault(vId, NULL_PAIR);
-		uriMap.put(vId, new ValuePair<>(imgUri, oldPair.getB()));
+	public void setBrightImage(ViewId vId, FlatfieldImageInfo info) {
+		final Pair<FlatfieldImageInfo, FlatfieldImageInfo> oldPair = infoMap.getOrDefault(vId, NULL_PAIR);
+		infoMap.put(vId, new ValuePair<>(info, oldPair.getB()));
 	}
 
-	public void setDarkImage(ViewId vId, URI imgUri) {
-		final Pair<URI, URI> oldPair = uriMap.getOrDefault(vId, NULL_PAIR);
-		uriMap.put(vId, new ValuePair<>(oldPair.getA(), imgUri));
-	}
-
-	public void setBrightImage(ViewId vId, File imgFile) {
-		setBrightImage(vId, imgFile == null ? null : imgFile.toURI());
-	}
-
-	public void setDarkImage(ViewId vId, File imgFile) {
-		setDarkImage(vId, imgFile == null ? null : imgFile.toURI());
+	public void setDarkImage(ViewId vId, FlatfieldImageInfo info) {
+		final Pair<FlatfieldImageInfo, FlatfieldImageInfo> oldPair = infoMap.getOrDefault(vId, NULL_PAIR);
+		infoMap.put(vId, new ValuePair<>(oldPair.getA(), info));
 	}
 
 	public RandomAccessibleInterval<FloatType> getBrightImg(ViewId vId) {
@@ -94,88 +86,125 @@ public class FlatfieldImageLoader {
 	/**
 	 * Get image for view id; the brightfield is stored in the A element of the pair, the darkfield in B
 	 * @param vId view id
-	 * @param uriSelector function to select URI from pair
+	 * @param infoSelector function to select info from pair
 	 * @return image, or null if not set
 	 */
-	private RandomAccessibleInterval<FloatType> getImg(ViewId vId, Function<Pair<URI, URI>, URI> uriSelector) {
-		if (!uriMap.containsKey(vId))
+	private RandomAccessibleInterval<FloatType> getImg(ViewId vId, Function<Pair<FlatfieldImageInfo, FlatfieldImageInfo>, FlatfieldImageInfo> infoSelector) {
+		if (!infoMap.containsKey(vId))
 			return null;
 
-		final URI uriToLoad = uriSelector.apply(uriMap.get(vId));
-		if (uriToLoad == null)
+		final FlatfieldImageInfo info = infoSelector.apply(infoMap.get(vId));
+		if (info == null)
 			return null;
 
-		return loadImageIfNecessary(uriToLoad);
+		return loadImageIfNecessary(info);
 	}
 
 	/**
-	 * Load an image from a URI. Supports:
-	 * - Local TIFF files (via ImageJ)
-	 * - Local/cloud Zarr v3 containers (via N5 API)
-	 * - Local/cloud N5 containers (via N5 API)
+	 * Load an image using the specified format. Supports:
+	 * - TIF files (local only, via ImageJ)
+	 * - N5 containers (local + cloud)
+	 * - Zarr v2/v3 containers (local + cloud)
+	 * - HDF5 files (local only)
 	 *
-	 * @param uri URI to the image
+	 * @param info the flatfield image info containing URI, format, and dataset path
 	 * @return the loaded image as FloatType
 	 */
-	public RandomAccessibleInterval<FloatType> loadImageIfNecessary(URI uri) {
-		if (!raiMap.containsKey(uri)) {
+	public RandomAccessibleInterval<FloatType> loadImageIfNecessary(FlatfieldImageInfo info) {
+		if (!raiMap.containsKey(info)) {
 			RandomAccessibleInterval<FloatType> img;
 
-			if (isChunkedFormat(uri)) {
-				// Use N5/Zarr API for chunked formats
-				final StorageFormat format = detectStorageFormat(uri);
-				final N5Reader reader = URITools.instantiateN5Reader(format, uri);
-				final RandomAccessibleInterval<?> raw = N5Utils.open(reader, "");
-				img = RealTypeConverters.convert(Cast.unchecked(raw), new FloatType());
-			} else {
-				// Legacy TIFF path via ImageJ
-				final File file = new File(uri);
+			if (info.isTif()) {
+				// TIF format via ImageJ
+				final File file = new File(info.getUri());
 				final ImagePlus imp = IJ.openImage(file.getAbsolutePath());
 				if (imp == null)
-					throw new RuntimeException("Failed to load image from: " + uri);
+					throw new RuntimeException("Failed to load TIF image from: " + info.getUri());
 				img = ImageJFunctions.convertFloat(imp).copy();
+			} else {
+				// N5, Zarr, or HDF5 via N5 API
+				final StorageFormat format = info.getFormat();
+				final URI uri = info.getUri();
+
+				// Validate HDF5 is not used with cloud storage
+				if (format == StorageFormat.HDF5) {
+					final String scheme = uri.getScheme();
+					if ("s3".equals(scheme) || "gs".equals(scheme)) {
+						throw new RuntimeException("HDF5 format does not support cloud storage (s3/gs). URI: " + uri);
+					}
+				}
+
+				final N5Reader reader = URITools.instantiateN5Reader(format, uri);
+				final String dataset = info.getEffectiveDataset();
+				final RandomAccessibleInterval<?> raw = N5Utils.open(reader, dataset);
+				img = RealTypeConverters.convert(Cast.unchecked(raw), new FloatType());
 			}
 
-			raiMap.put(uri, img);
+			raiMap.put(info, img);
 		}
-		return raiMap.get(uri);
+		return raiMap.get(info);
 	}
 
 	/**
-	 * Determine if the URI points to a chunked format (N5/Zarr) vs TIFF.
+	 * Get the info map for bright/dark images per view.
+	 * @return map from ViewId to (brightInfo, darkInfo) pair
 	 */
-	public static boolean isChunkedFormat(URI uri) {
-		final String scheme = uri.getScheme();
-		// Cloud URIs are always chunked format
-		if ("s3".equals(scheme) || "gs".equals(scheme))
-			return true;
+	public Map<ViewId, Pair<FlatfieldImageInfo, FlatfieldImageInfo>> getInfoMap() {
+		return infoMap;
+	}
 
-		// Check path for .zarr or .n5 extension
-		final String path = uri.getPath();
-		if (path == null)
-			return false;
+	// ==================== Format Parsing Utilities ====================
 
-		final String lowerPath = path.toLowerCase();
-		return lowerPath.endsWith(".zarr") || lowerPath.endsWith(".n5")
-			|| lowerPath.contains(".zarr/") || lowerPath.contains(".n5/");
+	/**
+	 * Parse a format string to StorageFormat.
+	 * @param formatStr the format string (tif, n5, zarr, zarr2, hdf5)
+	 * @return StorageFormat, or null for TIF format
+	 * @throws IllegalArgumentException if format string is unknown
+	 */
+	public static StorageFormat parseFormat(String formatStr) {
+		if (formatStr == null || formatStr.isEmpty())
+			throw new IllegalArgumentException("Format attribute is required");
+
+		switch (formatStr.toLowerCase()) {
+			case "tif":
+			case "tiff":
+				return null; // null indicates TIF format
+			case "n5":
+				return StorageFormat.N5;
+			case "zarr":
+			case "zarr3":
+				return StorageFormat.ZARR;
+			case "zarr2":
+				return StorageFormat.ZARR2;
+			case "hdf5":
+			case "h5":
+				return StorageFormat.HDF5;
+			default:
+				throw new IllegalArgumentException("Unknown flatfield format: " + formatStr
+						+ ". Supported formats: tif, n5, zarr, zarr2, hdf5");
+		}
 	}
 
 	/**
-	 * Detect the storage format from the URI.
+	 * Convert StorageFormat to format string for XML serialization.
+	 * @param format the StorageFormat (null for TIF)
+	 * @return format string
 	 */
-	public static StorageFormat detectStorageFormat(URI uri) {
-		final String path = uri.getPath();
-		if (path != null && path.toLowerCase().contains(".n5"))
-			return StorageFormat.N5;
-		// Default to Zarr v3 for cloud and .zarr paths
-		return StorageFormat.ZARR;
-	}
+	public static String formatToString(StorageFormat format) {
+		if (format == null)
+			return "tif";
 
-	/**
-	 * Get the URI map for bright/dark images per view.
-	 * @return map from ViewId to (brightUri, darkUri) pair
-	 */
-	public Map<ViewId, Pair<URI, URI>> getUriMap() {
-		return uriMap;
+		switch (format) {
+			case N5:
+				return "n5";
+			case ZARR:
+				return "zarr";
+			case ZARR2:
+				return "zarr2";
+			case HDF5:
+				return "hdf5";
+			default:
+				throw new IllegalArgumentException("Unsupported format for flatfield: " + format);
+		}
 	}
 }

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/LazyLoadingFlatFieldCorrectionMap.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/LazyLoadingFlatFieldCorrectionMap.java
@@ -112,7 +112,7 @@ public abstract class LazyLoadingFlatFieldCorrectionMap<IL extends ImgLoader> im
 				// Use N5/Zarr API for chunked formats
 				final StorageFormat format = detectStorageFormat(uri);
 				final N5Reader reader = URITools.instantiateN5Reader(format, uri);
-				final RandomAccessibleInterval<?> raw = N5Utils.open(reader, "/");
+				final RandomAccessibleInterval<?> raw = N5Utils.open(reader, "");
 				img = RealTypeConverters.convert(Cast.unchecked(raw), new FloatType());
 			} else {
 				// Legacy TIFF path via ImageJ

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/LazyLoadingFlatFieldCorrectionMap.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/LazyLoadingFlatFieldCorrectionMap.java
@@ -9,12 +9,12 @@
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
@@ -23,44 +23,51 @@
 package net.preibisch.mvrecon.fiji.spimdata.imgloaders.flatfield;
 
 import java.io.File;
+import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
+
+import org.janelia.saalfeldlab.n5.N5Reader;
+import org.janelia.saalfeldlab.n5.imglib2.N5Utils;
+import org.janelia.saalfeldlab.n5.universe.StorageFormat;
 
 import ij.IJ;
 import ij.ImagePlus;
 import mpicbg.spim.data.sequence.ImgLoader;
 import mpicbg.spim.data.sequence.ViewId;
 import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.converter.RealTypeConverters;
 import net.imglib2.img.display.imagej.ImageJFunctions;
 import net.imglib2.type.numeric.real.FloatType;
+import net.imglib2.util.Cast;
 import net.imglib2.util.Pair;
 import net.imglib2.util.ValuePair;
+import util.URITools;
 
-public abstract class LazyLoadingFlatFieldCorrectionMap<IL extends ImgLoader> implements FlatfieldCorrectionWrappedImgLoader< IL >
+public abstract class LazyLoadingFlatFieldCorrectionMap<IL extends ImgLoader> implements FlatfieldCorrectionWrappedImgLoader<IL>
 {
-	
-	protected final Map< File, RandomAccessibleInterval< FloatType > > raiMap;
-	protected final Map<ViewId, Pair<File, File>> fileMap;
+	protected final Map<URI, RandomAccessibleInterval<FloatType>> raiMap;
+	protected final Map<ViewId, Pair<URI, URI>> uriMap;
 
-	private static final Pair<File, File> NULL_PAIR = new ValuePair<>(null, null);
+	private static final Pair<URI, URI> NULL_PAIR = new ValuePair<>(null, null);
 
 	public LazyLoadingFlatFieldCorrectionMap()
 	{
 		raiMap = new HashMap<>();
-		fileMap = new HashMap<>();
-	}
-	
-	@Override
-	public void setBrightImage(ViewId vId, File imgFile) {
-		final Pair<File, File> oldPair = fileMap.getOrDefault(vId, NULL_PAIR);
-		fileMap.put(vId, new ValuePair<>(imgFile, oldPair.getB()));
+		uriMap = new HashMap<>();
 	}
 
 	@Override
-	public void setDarkImage(ViewId vId, File imgFile) {
-		final Pair<File, File> oldPair = fileMap.getOrDefault(vId, NULL_PAIR);
-        fileMap.put(vId, new ValuePair<>(oldPair.getA(), imgFile));
+	public void setBrightImage(ViewId vId, URI imgUri) {
+		final Pair<URI, URI> oldPair = uriMap.getOrDefault(vId, NULL_PAIR);
+		uriMap.put(vId, new ValuePair<>(imgUri, oldPair.getB()));
+	}
+
+	@Override
+	public void setDarkImage(ViewId vId, URI imgUri) {
+		final Pair<URI, URI> oldPair = uriMap.getOrDefault(vId, NULL_PAIR);
+		uriMap.put(vId, new ValuePair<>(oldPair.getA(), imgUri));
 	}
 
 	protected RandomAccessibleInterval<FloatType> getBrightImg(ViewId vId) {
@@ -74,43 +81,98 @@ public abstract class LazyLoadingFlatFieldCorrectionMap<IL extends ImgLoader> im
 	/**
 	 * Get image for view id; the brightfield is stored in the A element of the pair, the darkfield in B
 	 * @param vId view id
-	 * @param fileSelector function to select file from pair
+	 * @param uriSelector function to select URI from pair
 	 * @return image, or null if not set
 	 */
-	private RandomAccessibleInterval<FloatType> getImg(ViewId vId, Function<Pair<File, File>, File> fileSelector) {
-		if (!fileMap.containsKey(vId))
+	private RandomAccessibleInterval<FloatType> getImg(ViewId vId, Function<Pair<URI, URI>, URI> uriSelector) {
+		if (!uriMap.containsKey(vId))
 			return null;
 
-		final File fileToLoad = fileSelector.apply(fileMap.get(vId));
-		if (fileToLoad == null)
+		final URI uriToLoad = uriSelector.apply(uriMap.get(vId));
+		if (uriToLoad == null)
 			return null;
 
-		return loadFileIfNecessary(fileToLoad);
+		return loadImageIfNecessary(uriToLoad);
 	}
-	
-	private RandomAccessibleInterval<FloatType> loadFileIfNecessary(File file) {
-		if (!raiMap.containsKey(file)) {
-			final ImagePlus imp = IJ.openImage(file.getAbsolutePath());
-			final RandomAccessibleInterval<FloatType> img = ImageJFunctions.convertFloat(imp).copy();
-			raiMap.put(file, img);
+
+	/**
+	 * Load an image from a URI. Supports:
+	 * - Local TIFF files (via ImageJ)
+	 * - Local/cloud Zarr v3 containers (via N5 API)
+	 * - Local/cloud N5 containers (via N5 API)
+	 *
+	 * @param uri URI to the image
+	 * @return the loaded image as FloatType
+	 */
+	private RandomAccessibleInterval<FloatType> loadImageIfNecessary(URI uri) {
+		if (!raiMap.containsKey(uri)) {
+			RandomAccessibleInterval<FloatType> img;
+
+			if (isChunkedFormat(uri)) {
+				// Use N5/Zarr API for chunked formats
+				final StorageFormat format = detectStorageFormat(uri);
+				final N5Reader reader = URITools.instantiateN5Reader(format, uri);
+				final RandomAccessibleInterval<?> raw = N5Utils.open(reader, "/");
+				img = RealTypeConverters.convert(Cast.unchecked(raw), new FloatType());
+			} else {
+				// Legacy TIFF path via ImageJ
+				final File file = new File(uri);
+				final ImagePlus imp = IJ.openImage(file.getAbsolutePath());
+				if (imp == null)
+					throw new RuntimeException("Failed to load image from: " + uri);
+				img = ImageJFunctions.convertFloat(imp).copy();
+			}
+
+			raiMap.put(uri, img);
 		}
-		return raiMap.get(file);
+		return raiMap.get(uri);
 	}
-	
+
+	/**
+	 * Determine if the URI points to a chunked format (N5/Zarr) vs TIFF.
+	 */
+	private static boolean isChunkedFormat(URI uri) {
+		final String scheme = uri.getScheme();
+		// Cloud URIs are always chunked format
+		if ("s3".equals(scheme) || "gs".equals(scheme))
+			return true;
+
+		// Check path for .zarr or .n5 extension
+		final String path = uri.getPath();
+		if (path == null)
+			return false;
+
+		final String lowerPath = path.toLowerCase();
+		return lowerPath.endsWith(".zarr") || lowerPath.endsWith(".n5")
+			|| lowerPath.contains(".zarr/") || lowerPath.contains(".n5/");
+	}
+
+	/**
+	 * Detect the storage format from the URI.
+	 */
+	private static StorageFormat detectStorageFormat(URI uri) {
+		final String path = uri.getPath();
+		if (path != null && path.toLowerCase().contains(".n5"))
+			return StorageFormat.N5;
+		// Default to Zarr v3 for cloud and .zarr paths
+		return StorageFormat.ZARR;
+	}
+
 	public static void main(String[] args)
 	{
-		DefaultFlatfieldCorrectionWrappedImgLoader testImgLoader = new DefaultFlatfieldCorrectionWrappedImgLoader( null );
-		testImgLoader.setBrightImage( new ViewId(0,0), new File("/Users/David/Desktop/ell2.tif" ));
-		RandomAccessibleInterval< FloatType > brightImg = testImgLoader.getBrightImg( new ViewId( 0, 0 ) );
-		
-		ImageJFunctions.show( brightImg );
-		
+		DefaultFlatfieldCorrectionWrappedImgLoader testImgLoader = new DefaultFlatfieldCorrectionWrappedImgLoader(null);
+		testImgLoader.setBrightImage(new ViewId(0, 0), new File("/Users/David/Desktop/ell2.tif"));
+		RandomAccessibleInterval<FloatType> brightImg = testImgLoader.getBrightImg(new ViewId(0, 0));
+
+		ImageJFunctions.show(brightImg);
 	}
 
-	public Map< ViewId, Pair< File, File > > getFileMap()
+	/**
+	 * Get the URI map for bright/dark images per view.
+	 * @return map from ViewId to (brightUri, darkUri) pair
+	 */
+	public Map<ViewId, Pair<URI, URI>> getUriMap()
 	{
-		return fileMap;
+		return uriMap;
 	}
-	
-
 }

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/LazyLoadingFlatFieldCorrectionMap.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/LazyLoadingFlatFieldCorrectionMap.java
@@ -24,138 +24,40 @@ package net.preibisch.mvrecon.fiji.spimdata.imgloaders.flatfield;
 
 import java.io.File;
 import java.net.URI;
-import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Function;
 
-import org.janelia.saalfeldlab.n5.N5Reader;
-import org.janelia.saalfeldlab.n5.imglib2.N5Utils;
-import org.janelia.saalfeldlab.n5.universe.StorageFormat;
-
-import ij.IJ;
-import ij.ImagePlus;
 import mpicbg.spim.data.sequence.ImgLoader;
 import mpicbg.spim.data.sequence.ViewId;
 import net.imglib2.RandomAccessibleInterval;
-import net.imglib2.converter.RealTypeConverters;
 import net.imglib2.img.display.imagej.ImageJFunctions;
 import net.imglib2.type.numeric.real.FloatType;
-import net.imglib2.util.Cast;
 import net.imglib2.util.Pair;
-import net.imglib2.util.ValuePair;
-import util.URITools;
 
 public abstract class LazyLoadingFlatFieldCorrectionMap<IL extends ImgLoader> implements FlatfieldCorrectionWrappedImgLoader<IL>
 {
-	protected final Map<URI, RandomAccessibleInterval<FloatType>> raiMap;
-	protected final Map<ViewId, Pair<URI, URI>> uriMap;
-
-	private static final Pair<URI, URI> NULL_PAIR = new ValuePair<>(null, null);
+	protected final FlatfieldImageLoader imageLoader;
 
 	public LazyLoadingFlatFieldCorrectionMap()
 	{
-		raiMap = new HashMap<>();
-		uriMap = new HashMap<>();
+		imageLoader = new FlatfieldImageLoader();
 	}
 
 	@Override
 	public void setBrightImage(ViewId vId, URI imgUri) {
-		final Pair<URI, URI> oldPair = uriMap.getOrDefault(vId, NULL_PAIR);
-		uriMap.put(vId, new ValuePair<>(imgUri, oldPair.getB()));
+		imageLoader.setBrightImage(vId, imgUri);
 	}
 
 	@Override
 	public void setDarkImage(ViewId vId, URI imgUri) {
-		final Pair<URI, URI> oldPair = uriMap.getOrDefault(vId, NULL_PAIR);
-		uriMap.put(vId, new ValuePair<>(oldPair.getA(), imgUri));
+		imageLoader.setDarkImage(vId, imgUri);
 	}
 
 	protected RandomAccessibleInterval<FloatType> getBrightImg(ViewId vId) {
-		return getImg(vId, Pair::getA);
+		return imageLoader.getBrightImg(vId);
 	}
 
 	protected RandomAccessibleInterval<FloatType> getDarkImg(ViewId vId) {
-		return getImg(vId, Pair::getB);
-	}
-
-	/**
-	 * Get image for view id; the brightfield is stored in the A element of the pair, the darkfield in B
-	 * @param vId view id
-	 * @param uriSelector function to select URI from pair
-	 * @return image, or null if not set
-	 */
-	private RandomAccessibleInterval<FloatType> getImg(ViewId vId, Function<Pair<URI, URI>, URI> uriSelector) {
-		if (!uriMap.containsKey(vId))
-			return null;
-
-		final URI uriToLoad = uriSelector.apply(uriMap.get(vId));
-		if (uriToLoad == null)
-			return null;
-
-		return loadImageIfNecessary(uriToLoad);
-	}
-
-	/**
-	 * Load an image from a URI. Supports:
-	 * - Local TIFF files (via ImageJ)
-	 * - Local/cloud Zarr v3 containers (via N5 API)
-	 * - Local/cloud N5 containers (via N5 API)
-	 *
-	 * @param uri URI to the image
-	 * @return the loaded image as FloatType
-	 */
-	private RandomAccessibleInterval<FloatType> loadImageIfNecessary(URI uri) {
-		if (!raiMap.containsKey(uri)) {
-			RandomAccessibleInterval<FloatType> img;
-
-			if (isChunkedFormat(uri)) {
-				// Use N5/Zarr API for chunked formats
-				final StorageFormat format = detectStorageFormat(uri);
-				final N5Reader reader = URITools.instantiateN5Reader(format, uri);
-				final RandomAccessibleInterval<?> raw = N5Utils.open(reader, "");
-				img = RealTypeConverters.convert(Cast.unchecked(raw), new FloatType());
-			} else {
-				// Legacy TIFF path via ImageJ
-				final File file = new File(uri);
-				final ImagePlus imp = IJ.openImage(file.getAbsolutePath());
-				if (imp == null)
-					throw new RuntimeException("Failed to load image from: " + uri);
-				img = ImageJFunctions.convertFloat(imp).copy();
-			}
-
-			raiMap.put(uri, img);
-		}
-		return raiMap.get(uri);
-	}
-
-	/**
-	 * Determine if the URI points to a chunked format (N5/Zarr) vs TIFF.
-	 */
-	private static boolean isChunkedFormat(URI uri) {
-		final String scheme = uri.getScheme();
-		// Cloud URIs are always chunked format
-		if ("s3".equals(scheme) || "gs".equals(scheme))
-			return true;
-
-		// Check path for .zarr or .n5 extension
-		final String path = uri.getPath();
-		if (path == null)
-			return false;
-
-		final String lowerPath = path.toLowerCase();
-		return lowerPath.endsWith(".zarr") || lowerPath.endsWith(".n5")
-			|| lowerPath.contains(".zarr/") || lowerPath.contains(".n5/");
-	}
-
-	/**
-	 * Detect the storage format from the URI.
-	 */
-	private static StorageFormat detectStorageFormat(URI uri) {
-		final String path = uri.getPath();
-		if (path != null && path.toLowerCase().contains(".n5"))
-			return StorageFormat.N5;
-		// Default to Zarr v3 for cloud and .zarr paths
-		return StorageFormat.ZARR;
+		return imageLoader.getDarkImg(vId);
 	}
 
 	public static void main(String[] args)
@@ -173,6 +75,6 @@ public abstract class LazyLoadingFlatFieldCorrectionMap<IL extends ImgLoader> im
 	 */
 	public Map<ViewId, Pair<URI, URI>> getUriMap()
 	{
-		return uriMap;
+		return imageLoader.getUriMap();
 	}
 }

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/LazyLoadingFlatFieldCorrectionMap.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/LazyLoadingFlatFieldCorrectionMap.java
@@ -23,7 +23,6 @@
 package net.preibisch.mvrecon.fiji.spimdata.imgloaders.flatfield;
 
 import java.io.File;
-import java.net.URI;
 import java.util.Map;
 
 import mpicbg.spim.data.sequence.ImgLoader;
@@ -43,13 +42,13 @@ public abstract class LazyLoadingFlatFieldCorrectionMap<IL extends ImgLoader> im
 	}
 
 	@Override
-	public void setBrightImage(ViewId vId, URI imgUri) {
-		imageLoader.setBrightImage(vId, imgUri);
+	public void setBrightImage(ViewId vId, FlatfieldImageInfo info) {
+		imageLoader.setBrightImage(vId, info);
 	}
 
 	@Override
-	public void setDarkImage(ViewId vId, URI imgUri) {
-		imageLoader.setDarkImage(vId, imgUri);
+	public void setDarkImage(ViewId vId, FlatfieldImageInfo info) {
+		imageLoader.setDarkImage(vId, info);
 	}
 
 	protected RandomAccessibleInterval<FloatType> getBrightImg(ViewId vId) {
@@ -63,18 +62,18 @@ public abstract class LazyLoadingFlatFieldCorrectionMap<IL extends ImgLoader> im
 	public static void main(String[] args)
 	{
 		DefaultFlatfieldCorrectionWrappedImgLoader testImgLoader = new DefaultFlatfieldCorrectionWrappedImgLoader(null);
-		testImgLoader.setBrightImage(new ViewId(0, 0), new File("/Users/David/Desktop/ell2.tif"));
+		testImgLoader.setBrightImage(new ViewId(0, 0), new FlatfieldImageInfo(new File("/Users/David/Desktop/ell2.tif").toURI()));
 		RandomAccessibleInterval<FloatType> brightImg = testImgLoader.getBrightImg(new ViewId(0, 0));
 
 		ImageJFunctions.show(brightImg);
 	}
 
 	/**
-	 * Get the URI map for bright/dark images per view.
-	 * @return map from ViewId to (brightUri, darkUri) pair
+	 * Get the info map for bright/dark images per view.
+	 * @return map from ViewId to (brightInfo, darkInfo) pair
 	 */
-	public Map<ViewId, Pair<URI, URI>> getUriMap()
+	public Map<ViewId, Pair<FlatfieldImageInfo, FlatfieldImageInfo>> getInfoMap()
 	{
-		return imageLoader.getUriMap();
+		return imageLoader.getInfoMap();
 	}
 }

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/LazyLoadingFlatFieldCorrectionMap.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/LazyLoadingFlatFieldCorrectionMap.java
@@ -25,6 +25,7 @@ package net.preibisch.mvrecon.fiji.spimdata.imgloaders.flatfield;
 import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Function;
 
 import ij.IJ;
 import ij.ImagePlus;
@@ -41,7 +42,9 @@ public abstract class LazyLoadingFlatFieldCorrectionMap<IL extends ImgLoader> im
 	
 	protected final Map< File, RandomAccessibleInterval< FloatType > > raiMap;
 	protected final Map<ViewId, Pair<File, File>> fileMap;
-	
+
+	private static final Pair<File, File> NULL_PAIR = new ValuePair<>(null, null);
+
 	public LazyLoadingFlatFieldCorrectionMap()
 	{
 		raiMap = new HashMap<>();
@@ -49,62 +52,49 @@ public abstract class LazyLoadingFlatFieldCorrectionMap<IL extends ImgLoader> im
 	}
 	
 	@Override
-	public void setBrightImage(ViewId vId, File imgFile)
-	{
-		if (!fileMap.containsKey( vId ))
-			fileMap.put( vId, new ValuePair< File, File >( null, null ) );
-
-		final Pair< File, File > oldPair = fileMap.get( vId );
-		fileMap.put( vId, new ValuePair< File, File >( imgFile, oldPair.getB() ) );
+	public void setBrightImage(ViewId vId, File imgFile) {
+		final Pair<File, File> oldPair = fileMap.getOrDefault(vId, NULL_PAIR);
+		fileMap.put(vId, new ValuePair<>(imgFile, oldPair.getB()));
 	}
 
 	@Override
-	public void setDarkImage(ViewId vId, File imgFile)
-	{
-		if (!fileMap.containsKey( vId ))
-			fileMap.put( vId, new ValuePair< File, File >( null, null ) );
-
-		final Pair< File, File > oldPair = fileMap.get( vId );
-		fileMap.put( vId, new ValuePair< File, File >( oldPair.getA(), imgFile ) );
+	public void setDarkImage(ViewId vId, File imgFile) {
+		final Pair<File, File> oldPair = fileMap.getOrDefault(vId, NULL_PAIR);
+        fileMap.put(vId, new ValuePair<>(oldPair.getA(), imgFile));
 	}
-	
-	protected RandomAccessibleInterval< FloatType > getBrightImg(ViewId vId)
-	{
-		if (!fileMap.containsKey( vId ))
+
+	protected RandomAccessibleInterval<FloatType> getBrightImg(ViewId vId) {
+		return getImg(vId, Pair::getA);
+	}
+
+	protected RandomAccessibleInterval<FloatType> getDarkImg(ViewId vId) {
+		return getImg(vId, Pair::getB);
+	}
+
+	/**
+	 * Get image for view id; the brightfield is stored in the A element of the pair, the darkfield in B
+	 * @param vId view id
+	 * @param fileSelector function to select file from pair
+	 * @return image, or null if not set
+	 */
+	private RandomAccessibleInterval<FloatType> getImg(ViewId vId, Function<Pair<File, File>, File> fileSelector) {
+		if (!fileMap.containsKey(vId))
 			return null;
 
-		final File fileToLoad = fileMap.get( vId ).getA();
-
+		final File fileToLoad = fileSelector.apply(fileMap.get(vId));
 		if (fileToLoad == null)
 			return null;
 
-		loadFileIfNecessary( fileToLoad );
-		return raiMap.get( fileToLoad );
-	}
-
-	protected RandomAccessibleInterval< FloatType > getDarkImg(ViewId vId)
-	{
-		if (!fileMap.containsKey( vId ))
-			return null;
-
-		final File fileToLoad = fileMap.get( vId ).getB();
-
-		if (fileToLoad == null)
-			return null;
-
-		loadFileIfNecessary( fileToLoad );
-		return raiMap.get( fileToLoad );
+		return loadFileIfNecessary(fileToLoad);
 	}
 	
-	protected void loadFileIfNecessary(File file)
-	{
-		if (raiMap.containsKey( file ))
-			return;
-		
-		final ImagePlus imp = IJ.openImage( file.getAbsolutePath() );
-		final RandomAccessibleInterval< FloatType > img = ImageJFunctions.convertFloat( imp ).copy();
-		
-		raiMap.put( file, img );
+	private RandomAccessibleInterval<FloatType> loadFileIfNecessary(File file) {
+		if (!raiMap.containsKey(file)) {
+			final ImagePlus imp = IJ.openImage(file.getAbsolutePath());
+			final RandomAccessibleInterval<FloatType> img = ImageJFunctions.convertFloat(imp).copy();
+			raiMap.put(file, img);
+		}
+		return raiMap.get(file);
 	}
 	
 	public static void main(String[] args)

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/MultiResolutionFlatfieldCorrectionWrappedImgLoader.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/MultiResolutionFlatfieldCorrectionWrappedImgLoader.java
@@ -108,7 +108,7 @@ public class MultiResolutionFlatfieldCorrectionWrappedImgLoader
 	) {
 		// Convert to a list here to have a proper hash code for the map key
 		List<Integer> dsFactorList = Arrays.stream(downsamplingFactors).boxed().collect(Collectors.toList());
-		final ValuePair<URI, List<Integer>> key = new ValuePair<>(uriSelector.apply(uriMap.get(vId)), dsFactorList);
+		final ValuePair<URI, List<Integer>> key = new ValuePair<>(uriSelector.apply(getUriMap().get(vId)), dsFactorList);
 
 		if (!dsRaiMap.containsKey(key)) {
 			final RandomAccessibleInterval<FloatType> img = imgGetter.apply(vId);

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/MultiResolutionFlatfieldCorrectionWrappedImgLoader.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/MultiResolutionFlatfieldCorrectionWrappedImgLoader.java
@@ -28,6 +28,8 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import bdv.export.WriteSequenceToHdf5;
 import ij.ImageJ;
@@ -55,6 +57,7 @@ import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.real.FloatType;
 import net.imglib2.util.Pair;
 import net.imglib2.util.ValuePair;
+import net.imglib2.view.IntervalView;
 import net.imglib2.view.Views;
 import net.preibisch.mvrecon.fiji.plugin.queryXML.LoadParseQueryXML;
 import net.preibisch.mvrecon.fiji.spimdata.SpimData2;
@@ -66,7 +69,7 @@ public class MultiResolutionFlatfieldCorrectionWrappedImgLoader
 		extends LazyLoadingFlatFieldCorrectionMap< MultiResolutionImgLoader > implements MultiResolutionImgLoader
 {
 
-	private MultiResolutionImgLoader wrappedImgLoader;
+	private final MultiResolutionImgLoader wrappedImgLoader;
 	private boolean active;
 	private boolean cacheResult;
 
@@ -89,55 +92,41 @@ public class MultiResolutionFlatfieldCorrectionWrappedImgLoader
 		dsRaiMap = new HashMap<>();
 	}
 
-	protected RandomAccessibleInterval< FloatType > getOrCreateBrightImgDownsampled(ViewId vId,
-			int[] downsamplingFactors)
-	{
-		ArrayList< Integer > dsFactorList = new ArrayList< Integer >();
-		for ( int i : downsamplingFactors )
-			dsFactorList.add( i );
-
-		final ValuePair< File, List< Integer > > key = new ValuePair<>( fileMap.get( vId ).getA(), dsFactorList );
-
-		if ( !dsRaiMap.containsKey( key ) )
-		{
-			final RandomAccessibleInterval< FloatType > brightImg = getBrightImg( vId );
-
-			if ( brightImg == null )
-				return null;
-
-			// NB: we add a singleton z-dimension here for downsampleHDF5 to
-			// work
-			final RandomAccessibleInterval< FloatType > downsampled = downsampleHDF5(
-					Views.addDimension( brightImg, 0, 0 ), downsamplingFactors );
-			dsRaiMap.put( key, downsampled );
-		}
-
-		return dsRaiMap.get( key );
+	protected RandomAccessibleInterval< FloatType > getOrCreateBrightImgDownsampled(ViewId vId, int[] downsamplingFactors) {
+		return getOrCreateDownsampledImg(vId, downsamplingFactors, Pair::getA, this::getBrightImg);
 	}
 
-	protected RandomAccessibleInterval< FloatType > getOrCreateDarkImgDownsampled(ViewId vId, int[] downsamplingFactors)
-	{
-		ArrayList< Integer > dsFactorList = new ArrayList< Integer >();
-		for ( int i : downsamplingFactors )
-			dsFactorList.add( i );
+	protected RandomAccessibleInterval< FloatType > getOrCreateDarkImgDownsampled(ViewId vId, int[] downsamplingFactors) {
+		return getOrCreateDownsampledImg(vId, downsamplingFactors, Pair::getB, this::getDarkImg);
+	}
 
-		final ValuePair< File, List< Integer > > key = new ValuePair<>( fileMap.get( vId ).getB(), dsFactorList );
+	/**
+	 * Generic method to get a downsampled image or do downsampling on the fly. The bright image
+	 * is stored in the A element of the pair, the dark image in B.
+	 */
+	private RandomAccessibleInterval<FloatType> getOrCreateDownsampledImg(
+			ViewId vId,
+			int[] downsamplingFactors,
+			Function<Pair<File, File>, File> fileSelector,
+			Function<ViewId, RandomAccessibleInterval<FloatType>> imgGetter
+	) {
+		// Convert to a list here to have a proper hash code for the map key
+		List<Integer> dsFactorList = Arrays.stream(downsamplingFactors).boxed().collect(Collectors.toList());
+		final ValuePair<File, List<Integer>> key = new ValuePair<>(fileSelector.apply(fileMap.get(vId)), dsFactorList);
 
-		if ( !dsRaiMap.containsKey( key ) )
-		{
-			final RandomAccessibleInterval< FloatType > darkImg = getDarkImg( vId );
+		if (!dsRaiMap.containsKey(key)) {
+			final RandomAccessibleInterval<FloatType> img = imgGetter.apply(vId);
 
-			if ( darkImg == null )
+			if (img == null)
 				return null;
 
-			// NB: we add a singleton z-dimension here for downsampleHDF5 to
-			// work
-			final RandomAccessibleInterval< FloatType > downsampled = downsampleHDF5(
-					Views.addDimension( darkImg, 0, 0 ), downsamplingFactors );
-			dsRaiMap.put( key, downsampled );
+			// Add a singleton z-dimension here for downsampleHDF5 to work
+			final IntervalView<FloatType> extendedImg = Views.addDimension(img, 0, 0);
+			final RandomAccessibleInterval<FloatType> downsampled = downsampleHDF5(extendedImg, downsamplingFactors);
+			dsRaiMap.put(key, downsampled);
 		}
 
-		return dsRaiMap.get( key );
+		return dsRaiMap.get(key);
 	}
 
 	@Override

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/MultiResolutionFlatfieldCorrectionWrappedImgLoader.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/MultiResolutionFlatfieldCorrectionWrappedImgLoader.java
@@ -57,7 +57,6 @@ import net.imglib2.util.ValuePair;
 import net.imglib2.view.Views;
 import net.preibisch.mvrecon.fiji.plugin.queryXML.LoadParseQueryXML;
 import net.preibisch.mvrecon.fiji.spimdata.SpimData2;
-import net.preibisch.mvrecon.fiji.spimdata.imgloaders.filemap2.FileMapImgLoaderLOCI2;
 import net.preibisch.mvrecon.process.fusion.FusionTools;
 
 
@@ -168,8 +167,11 @@ public class MultiResolutionFlatfieldCorrectionWrappedImgLoader
 
 			final MultiResolutionSetupImgLoader< ? > wrpSetupIL = wrappedImgLoader.getSetupImgLoader( setupId );
 
-			if(!active)
-				return (RandomAccessibleInterval< T >) wrpSetupIL.getImage( timepointId, level, hints );
+			if(!active) {
+				@SuppressWarnings("unchecked")
+				RandomAccessibleInterval<T> image = (RandomAccessibleInterval<T>) wrpSetupIL.getImage(timepointId, level, hints);
+				return image;
+			}
 
 			final int n = wrpSetupIL.getImageSize( timepointId ).numDimensions();
 
@@ -188,9 +190,12 @@ public class MultiResolutionFlatfieldCorrectionWrappedImgLoader
 					getOrCreateDarkImgDownsampled( new ViewId( timepointId, setupId ), dsFactors ) );
 
 			boolean loadCompletelyRequested = false;
-			for (ImgLoaderHint hint : hints)
-				if (hint == ImgLoaderHints.LOAD_COMPLETELY)
+			for (ImgLoaderHint hint : hints) {
+				if (hint == ImgLoaderHints.LOAD_COMPLETELY) {
 					loadCompletelyRequested = true;
+					break;
+				}
+			}
 
 			if (loadCompletelyRequested)
 			{
@@ -199,13 +204,14 @@ public class MultiResolutionFlatfieldCorrectionWrappedImgLoader
 					numPx *= rai.dimension( d );
 
 				final ImgFactory< T > imgFactory;
-				if (Math.log(numPx) / Math.log( 2 ) < 31)
-					imgFactory = new ArrayImgFactory<T>();
-				else
-					imgFactory = new CellImgFactory<T>();
+				if (Math.log(numPx) / Math.log(2) < 31) {
+					imgFactory = new ArrayImgFactory<>(getImageType());
+				} else {
+					imgFactory = new CellImgFactory<>(getImageType());
+				}
 
-				Img< T > loadedImg = imgFactory.create( rai, getImageType() );
-				RealTypeConverters.copyFromTo( Views.extendZero( rai ), loadedImg );
+				Img<T> loadedImg = imgFactory.create(rai);
+				RealTypeConverters.copyFromTo(Views.extendZero(rai), loadedImg);
 
 				rai = loadedImg;
 			}
@@ -215,8 +221,8 @@ public class MultiResolutionFlatfieldCorrectionWrappedImgLoader
 				Arrays.fill( cellSize, 1 );
 				for ( int d = 0; d < rai.numDimensions() - 1; d++ )
 					cellSize[d] = (int) rai.dimension( d );
-				rai =  FusionTools.cacheRandomAccessibleInterval( rai, Long.MAX_VALUE,
-						Views.iterable( rai ).firstElement().createVariable(), cellSize );
+				rai =  FusionTools.cacheRandomAccessibleInterval(
+						rai, Long.MAX_VALUE, rai.firstElement().createVariable(), cellSize);
 			}
 			return rai;
 		}
@@ -251,9 +257,12 @@ public class MultiResolutionFlatfieldCorrectionWrappedImgLoader
 				RandomAccessibleInterval< FloatType > raiNormalized = new VirtuallyNormalizedRandomAccessibleInterval<>(
 						rai );
 				boolean loadCompletelyRequested = false;
-				for (ImgLoaderHint hint : hints)
-					if (hint == ImgLoaderHints.LOAD_COMPLETELY)
+				for (ImgLoaderHint hint : hints) {
+					if (hint == ImgLoaderHints.LOAD_COMPLETELY) {
 						loadCompletelyRequested = true;
+						break;
+					}
+				}
 
 				if (loadCompletelyRequested)
 				{
@@ -262,13 +271,14 @@ public class MultiResolutionFlatfieldCorrectionWrappedImgLoader
 						numPx *= raiNormalized.dimension( d );
 
 					final ImgFactory< FloatType > imgFactory;
-					if (Math.log(numPx) / Math.log( 2 ) < 31)
-						imgFactory = new ArrayImgFactory<FloatType>();
-					else
-						imgFactory = new CellImgFactory<FloatType>();
+					if (Math.log(numPx) / Math.log(2) < 31) {
+						imgFactory = new ArrayImgFactory<>(new FloatType());
+					} else {
+						imgFactory = new CellImgFactory<>(new FloatType());
+					}
 
-					Img< FloatType > loadedImg = imgFactory.create( raiNormalized, new FloatType() );
-					FileMapImgLoaderLOCI2.copy(Views.extendZero( raiNormalized ), loadedImg);
+					Img<FloatType> loadedImg = imgFactory.create(raiNormalized);
+					RealTypeConverters.copyFromTo(Views.extendZero(raiNormalized), loadedImg);
 
 					raiNormalized = loadedImg;
 				}
@@ -278,17 +288,19 @@ public class MultiResolutionFlatfieldCorrectionWrappedImgLoader
 					Arrays.fill( cellSize, 1 );
 					for ( int d = 0; d < raiNormalized.numDimensions() - 1; d++ )
 						cellSize[d] = (int) raiNormalized.dimension( d );
-					rai =  FusionTools.cacheRandomAccessibleInterval( raiNormalized, Long.MAX_VALUE,
-							Views.iterable( rai ).firstElement().createVariable(), cellSize );
+					rai =  FusionTools.cacheRandomAccessibleInterval(
+							raiNormalized, Long.MAX_VALUE, rai.firstElement().createVariable(), cellSize);
 				}
 				rai = raiNormalized;
 			}
-			else
-			{
+			else {
 				boolean loadCompletelyRequested = false;
-				for (ImgLoaderHint hint : hints)
-					if (hint == ImgLoaderHints.LOAD_COMPLETELY)
+				for (ImgLoaderHint hint : hints) {
+					if (hint == ImgLoaderHints.LOAD_COMPLETELY) {
 						loadCompletelyRequested = true;
+						break;
+					}
+				}
 
 				if (loadCompletelyRequested)
 				{
@@ -298,12 +310,12 @@ public class MultiResolutionFlatfieldCorrectionWrappedImgLoader
 
 					final ImgFactory< FloatType > imgFactory;
 					if (Math.log(numPx) / Math.log( 2 ) < 31)
-						imgFactory = new ArrayImgFactory<FloatType>();
+						imgFactory = new ArrayImgFactory<>(new FloatType());
 					else
-						imgFactory = new CellImgFactory<FloatType>();
+						imgFactory = new CellImgFactory<>(new FloatType());
 
-					Img< FloatType > loadedImg = imgFactory.create( rai, new FloatType() );
-					FileMapImgLoaderLOCI2.copy(Views.extendZero( rai ), loadedImg);
+					Img<FloatType> loadedImg = imgFactory.create(rai);
+					RealTypeConverters.copyFromTo(Views.extendZero(rai), loadedImg);
 
 					rai = loadedImg;
 				}
@@ -313,8 +325,8 @@ public class MultiResolutionFlatfieldCorrectionWrappedImgLoader
 					Arrays.fill( cellSize, 1 );
 					for ( int d = 0; d < rai.numDimensions() - 1; d++ )
 						cellSize[d] = (int) rai.dimension( d );
-					rai = FusionTools.cacheRandomAccessibleInterval( rai, Long.MAX_VALUE,
-							Views.iterable( rai ).firstElement().createVariable(), cellSize );
+					rai = FusionTools.cacheRandomAccessibleInterval(
+							rai, Long.MAX_VALUE, rai.firstElement().createVariable(), cellSize);
 				}
 
 			}

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/MultiResolutionFlatfieldCorrectionWrappedImgLoader.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/MultiResolutionFlatfieldCorrectionWrappedImgLoader.java
@@ -23,6 +23,7 @@
 package net.preibisch.mvrecon.fiji.spimdata.imgloaders.flatfield;
 
 import java.io.File;
+import java.net.URI;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -69,7 +70,7 @@ public class MultiResolutionFlatfieldCorrectionWrappedImgLoader
 	private boolean cacheResult;
 
 	/* downsampled bright/dark images */
-	private final Map< Pair< File, List< Integer > >, RandomAccessibleInterval< FloatType > > dsRaiMap;
+	private final Map<Pair<URI, List<Integer>>, RandomAccessibleInterval<FloatType>> dsRaiMap;
 
 	public MultiResolutionFlatfieldCorrectionWrappedImgLoader(MultiResolutionImgLoader wrappedImgLoader)
 	{
@@ -102,12 +103,12 @@ public class MultiResolutionFlatfieldCorrectionWrappedImgLoader
 	private RandomAccessibleInterval<FloatType> getOrCreateDownsampledImg(
 			ViewId vId,
 			int[] downsamplingFactors,
-			Function<Pair<File, File>, File> fileSelector,
+			Function<Pair<URI, URI>, URI> uriSelector,
 			Function<ViewId, RandomAccessibleInterval<FloatType>> imgGetter
 	) {
 		// Convert to a list here to have a proper hash code for the map key
 		List<Integer> dsFactorList = Arrays.stream(downsamplingFactors).boxed().collect(Collectors.toList());
-		final ValuePair<File, List<Integer>> key = new ValuePair<>(fileSelector.apply(fileMap.get(vId)), dsFactorList);
+		final ValuePair<URI, List<Integer>> key = new ValuePair<>(uriSelector.apply(uriMap.get(vId)), dsFactorList);
 
 		if (!dsRaiMap.containsKey(key)) {
 			final RandomAccessibleInterval<FloatType> img = imgGetter.apply(vId);

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/MultiResolutionFlatfieldCorrectionWrappedImgLoader.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/MultiResolutionFlatfieldCorrectionWrappedImgLoader.java
@@ -47,6 +47,8 @@ import net.imglib2.converter.RealTypeConverters;
 import net.imglib2.img.Img;
 import net.imglib2.img.ImgFactory;
 import net.imglib2.img.array.ArrayImgFactory;
+import net.imglib2.img.cell.AbstractCellImg;
+import net.imglib2.img.cell.CellGrid;
 import net.imglib2.img.cell.CellImgFactory;
 import net.imglib2.img.display.imagej.ImageJFunctions;
 import net.imglib2.realtransform.AffineTransform3D;
@@ -395,6 +397,9 @@ public class MultiResolutionFlatfieldCorrectionWrappedImgLoader
 
 	/**
 	 * Downsample an image using the imglib2-algorithm blocks API.
+	 * <p>
+	 * If the input is a cell/chunked image, the output cell size is computed
+	 * to align with input chunk boundaries (input chunk size / downsampling factor).
 	 *
 	 * @param input image to downsample
 	 * @param dsFactor factors to downsample by (may have more dimensions than input)
@@ -424,10 +429,21 @@ public class MultiResolutionFlatfieldCorrectionWrappedImgLoader
 		for (int d = 0; d < n; d++)
 			outDim[d] = Math.max(input.dimension(d) / effectiveFactors[d], 1);
 
+		// Determine output cell size - use input chunk size if available
+		final int[] cellSize = new int[n];
+		if (input instanceof AbstractCellImg) {
+			@SuppressWarnings("rawtypes")
+			final CellGrid grid = ((AbstractCellImg) input).getCellGrid();
+			grid.cellDimensions(cellSize);
+		} else {
+			// Default fallback for non-chunked images
+			Arrays.fill(cellSize, 128);
+		}
+
 		final BlockSupplier<T> blocks = BlockSupplier.of(input)
 				.andThen(Downsample.downsample(effectiveFactors));
 
-		return BlockAlgoUtils.cellImg(blocks, outDim, new int[]{64});
+		return BlockAlgoUtils.cellImg(blocks, outDim, cellSize);
 	}
 
 	public static void main(String[] args)

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/MultiResolutionFlatfieldCorrectionWrappedImgLoader.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/MultiResolutionFlatfieldCorrectionWrappedImgLoader.java
@@ -23,7 +23,6 @@
 package net.preibisch.mvrecon.fiji.spimdata.imgloaders.flatfield;
 
 import java.io.File;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -31,7 +30,6 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import bdv.export.WriteSequenceToHdf5;
 import ij.ImageJ;
 import mpicbg.spim.data.generic.sequence.ImgLoaderHint;
 import mpicbg.spim.data.generic.sequence.ImgLoaderHints;
@@ -39,12 +37,11 @@ import mpicbg.spim.data.sequence.MultiResolutionImgLoader;
 import mpicbg.spim.data.sequence.MultiResolutionSetupImgLoader;
 import mpicbg.spim.data.sequence.ViewId;
 import mpicbg.spim.data.sequence.VoxelDimensions;
-import net.imglib2.Cursor;
 import net.imglib2.Dimensions;
-import net.imglib2.FinalDimensions;
-import net.imglib2.RandomAccess;
-import net.imglib2.RandomAccessible;
 import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.algorithm.blocks.BlockAlgoUtils;
+import net.imglib2.algorithm.blocks.BlockSupplier;
+import net.imglib2.algorithm.blocks.downsample.Downsample;
 import net.imglib2.converter.RealTypeConverters;
 import net.imglib2.img.Img;
 import net.imglib2.img.ImgFactory;
@@ -57,7 +54,6 @@ import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.real.FloatType;
 import net.imglib2.util.Pair;
 import net.imglib2.util.ValuePair;
-import net.imglib2.view.IntervalView;
 import net.imglib2.view.Views;
 import net.preibisch.mvrecon.fiji.plugin.queryXML.LoadParseQueryXML;
 import net.preibisch.mvrecon.fiji.spimdata.SpimData2;
@@ -120,9 +116,7 @@ public class MultiResolutionFlatfieldCorrectionWrappedImgLoader
 			if (img == null)
 				return null;
 
-			// Add a singleton z-dimension here for downsampleHDF5 to work
-			final IntervalView<FloatType> extendedImg = Views.addDimension(img, 0, 0);
-			final RandomAccessibleInterval<FloatType> downsampled = downsampleHDF5(extendedImg, downsamplingFactors);
+			final RandomAccessibleInterval<FloatType> downsampled = downsampleHDF5(img, downsamplingFactors);
 			dsRaiMap.put(key, downsampled);
 		}
 
@@ -387,84 +381,40 @@ public class MultiResolutionFlatfieldCorrectionWrappedImgLoader
 	}
 
 	/**
-	 * downsampling code form {@link WriteSequenceToHdf5}, distilled into one
-	 * method
-	 * 
-	 * @param input
-	 *            image to downsample
-	 * @param dsFactor
-	 *            factors to downsample by
-	 * @param <T>
-	 *            the image type
-	 * @return downsampled image
+	 * Downsample an image using the imglib2-algorithm blocks API.
+	 *
+	 * @param input image to downsample
+	 * @param dsFactor factors to downsample by (may have more dimensions than input)
+	 * @param <T> the image type
+	 * @return downsampled image, or input unchanged if no downsampling needed
 	 */
-	public static <T extends RealType< T > & NativeType< T >> RandomAccessibleInterval< T > downsampleHDF5(
-			RandomAccessibleInterval< T > input, final int[] dsFactor)
-	{
-		final long[] blockMin = new long[input.numDimensions()];
+	public static <T extends RealType<T> & NativeType<T>> RandomAccessibleInterval<T> downsampleHDF5(
+			RandomAccessibleInterval<T> input,
+			final int[] dsFactor
+	) {
+		final int n = input.numDimensions();
 
-		final long[] outDim = new long[input.numDimensions()];
-		for ( int d = 0; d < input.numDimensions(); d++ )
-			outDim[d] = Math.max( input.dimension( d ) / dsFactor[d], 1 );
-
-		final Img< T > downsampled = new ArrayImgFactory< T >().create( new FinalDimensions( outDim ),
-				Views.iterable( input ).firstElement().createVariable() );
-		final RandomAccess< T > randomAccess = Views.extendBorder( input ).randomAccess();
-
-		final Cursor< T > out = downsampled.cursor();
-
-		double scale = 1;
-		for ( int f : dsFactor )
-			scale *= f;
-		scale = 1.0 / scale;
-
-		final int numBlockPixels = (int) ( outDim[0] * outDim[1] * outDim[2] );
-		final double[] accumulator = new double[numBlockPixels];
-
-		randomAccess.setPosition( blockMin );
-
-		final int ox = (int) outDim[0];
-		final int oy = (int) outDim[1];
-		final int oz = (int) outDim[2];
-
-		final int sx = ox * dsFactor[0];
-		final int sy = oy * dsFactor[1];
-		final int sz = oz * dsFactor[2];
-
-		int i = 0;
-		for ( int z = 0, bz = 0; z < sz; ++z )
-		{
-			for ( int y = 0, by = 0; y < sy; ++y )
-			{
-				for ( int x = 0, bx = 0; x < sx; ++x )
-				{
-					accumulator[i] += randomAccess.get().getRealDouble();
-					randomAccess.fwd( 0 );
-					if ( ++bx == dsFactor[0] )
-					{
-						bx = 0;
-						++i;
-					}
-				}
-				randomAccess.move( -sx, 0 );
-				randomAccess.fwd( 1 );
-				if ( ++by == dsFactor[1] )
-					by = 0;
-				else
-					i -= ox;
-			}
-			randomAccess.move( -sy, 1 );
-			randomAccess.fwd( 2 );
-			if ( ++bz == dsFactor[2] )
-				bz = 0;
-			else
-				i -= ox * oy;
+		// Build effective factors matching input dimensions, check if downsampling needed
+		boolean needsDownsampling = false;
+		final int[] effectiveFactors = new int[n];
+		for (int d = 0; d < n; d++) {
+			effectiveFactors[d] = (d < dsFactor.length) ? dsFactor[d] : 1;
+			if (effectiveFactors[d] > 1)
+				needsDownsampling = true;
 		}
 
-		for ( int j = 0; j < numBlockPixels; ++j )
-			out.next().setReal( accumulator[j] * scale );
+		// Return input unchanged if all factors are 1
+		if (!needsDownsampling)
+			return input;
 
-		return downsampled;
+		final long[] outDim = new long[n];
+		for (int d = 0; d < n; d++)
+			outDim[d] = Math.max(input.dimension(d) / effectiveFactors[d], 1);
+
+		final BlockSupplier<T> blocks = BlockSupplier.of(input)
+				.andThen(Downsample.downsample(effectiveFactors));
+
+		return BlockAlgoUtils.cellImg(blocks, outDim, new int[]{64});
 	}
 
 	public static void main(String[] args)

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/MultiResolutionFlatfieldCorrectionWrappedImgLoader.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/MultiResolutionFlatfieldCorrectionWrappedImgLoader.java
@@ -23,7 +23,6 @@
 package net.preibisch.mvrecon.fiji.spimdata.imgloaders.flatfield;
 
 import java.io.File;
-import java.net.URI;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -72,7 +71,7 @@ public class MultiResolutionFlatfieldCorrectionWrappedImgLoader
 	private boolean cacheResult;
 
 	/* downsampled bright/dark images */
-	private final Map<Pair<URI, List<Integer>>, RandomAccessibleInterval<FloatType>> dsRaiMap;
+	private final Map<Pair<FlatfieldImageInfo, List<Integer>>, RandomAccessibleInterval<FloatType>> dsRaiMap;
 
 	public MultiResolutionFlatfieldCorrectionWrappedImgLoader(MultiResolutionImgLoader wrappedImgLoader)
 	{
@@ -105,12 +104,12 @@ public class MultiResolutionFlatfieldCorrectionWrappedImgLoader
 	private RandomAccessibleInterval<FloatType> getOrCreateDownsampledImg(
 			ViewId vId,
 			int[] downsamplingFactors,
-			Function<Pair<URI, URI>, URI> uriSelector,
+			Function<Pair<FlatfieldImageInfo, FlatfieldImageInfo>, FlatfieldImageInfo> infoSelector,
 			Function<ViewId, RandomAccessibleInterval<FloatType>> imgGetter
 	) {
 		// Convert to a list here to have a proper hash code for the map key
 		List<Integer> dsFactorList = Arrays.stream(downsamplingFactors).boxed().collect(Collectors.toList());
-		final ValuePair<URI, List<Integer>> key = new ValuePair<>(uriSelector.apply(getUriMap().get(vId)), dsFactorList);
+		final ValuePair<FlatfieldImageInfo, List<Integer>> key = new ValuePair<>(infoSelector.apply(getInfoMap().get(vId)), dsFactorList);
 
 		if (!dsRaiMap.containsKey(key)) {
 			final RandomAccessibleInterval<FloatType> img = imgGetter.apply(vId);
@@ -456,7 +455,7 @@ public class MultiResolutionFlatfieldCorrectionWrappedImgLoader
 		MultiResolutionImgLoader il = (MultiResolutionImgLoader) data.getSequenceDescription().getImgLoader();
 		MultiResolutionFlatfieldCorrectionWrappedImgLoader ffcil = new MultiResolutionFlatfieldCorrectionWrappedImgLoader(
 				il );
-		ffcil.setDarkImage( new ViewId( 0, 0 ), new File( "/Users/david/desktop/ff.tif" ) );
+		ffcil.setDarkImage( new ViewId( 0, 0 ), new FlatfieldImageInfo( new File( "/Users/david/desktop/ff.tif" ).toURI(), null ) );
 
 		data.getSequenceDescription().setImgLoader( ffcil );
 

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/TestDecoratorChain.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/TestDecoratorChain.java
@@ -109,12 +109,12 @@ public class TestDecoratorChain {
 			final ViewId viewId = new ViewId(timepoint, setupId);
 
 			if (darkfield.exists()) {
-				correctedLoader.setDarkImage(viewId, darkfield);
+				correctedLoader.setDarkImage(viewId, new FlatfieldImageInfo(darkfield.toURI(), null));
 				System.out.println("  Setup " + setupId + ": darkfield = " + darkfield.getName());
 			}
 
 			if (flatfield.exists()) {
-				correctedLoader.setBrightImage(viewId, flatfield);
+				correctedLoader.setBrightImage(viewId, new FlatfieldImageInfo(flatfield.toURI(), null));
 				System.out.println("  Setup " + setupId + ": flatfield = " + flatfield.getName());
 			}
 		}

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/TestDecoratorChain.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/TestDecoratorChain.java
@@ -50,23 +50,21 @@ import net.preibisch.mvrecon.fiji.spimdata.imgloaders.splitting.SplitMultiResolu
  * This shows how to compose multiple wrapper/decorator layers while maintaining
  * the MultiResolutionImgLoader interface throughout the chain.
  */
-public class TestDecoratorChain
-{
+public class TestDecoratorChain {
 	// Mapping from ViewSetup ID to Tile ID (from dataset.xml)
 	private static final int[][] SETUP_TO_TILE = {
-		{ 0, 187 },
-		{ 1, 188 },
-		{ 2, 189 },
-		{ 3, 200 },
-		{ 4, 201 },
-		{ 5, 202 },
-		{ 6, 213 },
-		{ 7, 214 },
-		{ 8, 215 }
+		{0, 187},
+		{1, 188},
+		{2, 189},
+		{3, 200},
+		{4, 201},
+		{5, 202},
+		{6, 213},
+		{7, 214},
+		{8, 215}
 	};
 
-	public static void main( String[] args ) throws SpimDataException
-	{
+	public static void main(String[] args) throws SpimDataException {
 		// ========== CONFIGURATION ==========
 		final String basePath = "/Users/innerbergerm/Projects/janelia/multiview-reconstruction/";
 		final String xmlPath = basePath + "data/dataset.xml";
@@ -77,88 +75,85 @@ public class TestDecoratorChain
 		final int timepoint = 0;
 
 		// ========== STEP 1: Load dataset and get base loader ==========
-		System.out.println( "=== STEP 1: Loading dataset ===" );
-		System.out.println( "XML path: " + xmlPath );
+		System.out.println("=== STEP 1: Loading dataset ===");
+		System.out.println("XML path: " + xmlPath);
 
-		final SpimData2 data = new XmlIoSpimData2().load( xmlPath );
+		final SpimData2 data = new XmlIoSpimData2().load(xmlPath);
 		final SequenceDescription seqDesc = data.getSequenceDescription();
 
 		// The base loader - this could be N5ImageLoader, AllenOMEZarrLoader, etc.
 		final MultiResolutionImgLoader baseLoader =
 			(MultiResolutionImgLoader) seqDesc.getImgLoader();
 
-		System.out.println( "Base loader type: " + baseLoader.getClass().getSimpleName() );
+		System.out.println("Base loader type: " + baseLoader.getClass().getSimpleName());
 
 		// ========== STEP 2: Wrap with flatfield correction ==========
-		System.out.println( "\n=== STEP 2: Wrapping with flatfield correction ===" );
+		System.out.println("\n=== STEP 2: Wrapping with flatfield correction ===");
 
 		final MultiResolutionFlatfieldCorrectionWrappedImgLoader correctedLoader =
-			new MultiResolutionFlatfieldCorrectionWrappedImgLoader( baseLoader, true );
+			new MultiResolutionFlatfieldCorrectionWrappedImgLoader(baseLoader, true);
 
 		// Configure correction images for each view setup
-		for ( int[] mapping : SETUP_TO_TILE )
-		{
-			final int setupId = mapping[ 0 ];
-			final int tileId = mapping[ 1 ];
+		for (int[] mapping : SETUP_TO_TILE) {
+			final int setupId = mapping[0];
+			final int tileId = mapping[1];
 
 			// Find darkfield file
-			final File darkfield = new File( correctionPath + "setup" + tileId + "-AVG_darkfield-fromdata.tif" );
+			final File darkfield = new File(correctionPath + "setup" + tileId + "-AVG_darkfield-fromdata.tif");
 
 			// Find flatfield file (try both naming conventions)
-			File flatfield = new File( correctionPath + "setup" + tileId + "-flatfield.tif" );
-			if ( !flatfield.exists() )
-				flatfield = new File( correctionPath + "setup" + tileId + "-flatfield (fixed by mirroring).tif" );
+			File flatfield = new File(correctionPath + "setup" + tileId + "-flatfield.tif");
+			if (!flatfield.exists())
+				flatfield = new File(correctionPath + "setup" + tileId + "-flatfield (fixed by mirroring).tif");
 
-			final ViewId viewId = new ViewId( timepoint, setupId );
+			final ViewId viewId = new ViewId(timepoint, setupId);
 
-			if ( darkfield.exists() )
-			{
-				correctedLoader.setDarkImage( viewId, darkfield );
-				System.out.println( "  Setup " + setupId + ": darkfield = " + darkfield.getName() );
+			if (darkfield.exists()) {
+				correctedLoader.setDarkImage(viewId, darkfield);
+				System.out.println("  Setup " + setupId + ": darkfield = " + darkfield.getName());
 			}
 
-			if ( flatfield.exists() )
-			{
-				correctedLoader.setBrightImage( viewId, flatfield );
-				System.out.println( "  Setup " + setupId + ": flatfield = " + flatfield.getName() );
+			if (flatfield.exists()) {
+				correctedLoader.setBrightImage(viewId, flatfield);
+				System.out.println("  Setup " + setupId + ": flatfield = " + flatfield.getName());
 			}
 		}
 
 		// ========== STEP 3: Wrap with splitting ==========
-		System.out.println( "\n=== STEP 3: Wrapping with splitting ===" );
+		System.out.println("\n=== STEP 3: Wrapping with splitting ===");
 
 		// Get original image dimensions for the setup we're demonstrating
-		final ViewSetup vs = seqDesc.getViewSetups().get( setupToShow );
-		final long[] dims = new long[ 3 ];
-		vs.getSize().dimensions( dims );
-		System.out.println( "Original image size: " + dims[0] + " x " + dims[1] + " x " + dims[2] );
+		final ViewSetup vs = seqDesc.getViewSetups().get(setupToShow);
+		final long[] dims = new long[3];
+		vs.getSize().dimensions(dims);
+		System.out.println("Original image size: " + dims[0] + " x " + dims[1] + " x " + dims[2]);
 
 		// Create a simple 2x1 split in X dimension
 		// Split the 512-wide image into two 256-wide regions
-		final long splitX = dims[ 0 ] / 2;
+		final long splitX = dims[0] / 2;
 
 		// Define the mappings for split regions
 		// New setup IDs 100, 101 will map to original setup 0, with different X intervals
-		final HashMap< Integer, Integer > new2oldSetupId = new HashMap<>();
-		final HashMap< Integer, Interval > newSetupId2Interval = new HashMap<>();
+		final HashMap<Integer, Integer> new2oldSetupId = new HashMap<>();
+		final HashMap<Integer, Interval> newSetupId2Interval = new HashMap<>();
 
 		// Split region 0: left half [0, splitX) x [0, dimY) x [0, dimZ)
-		new2oldSetupId.put( 100, setupToShow );
-		newSetupId2Interval.put( 100, new FinalInterval(
-			new long[] { 0, 0, 0 },
-			new long[] { splitX - 1, dims[1] - 1, dims[2] - 1 }
+		new2oldSetupId.put(100, setupToShow);
+		newSetupId2Interval.put(100, new FinalInterval(
+			new long[] {0, 0, 0},
+			new long[] {splitX - 1, dims[1] - 1, dims[2] - 1}
 		));
 
 		// Split region 1: right half [splitX, dimX) x [0, dimY) x [0, dimZ)
-		new2oldSetupId.put( 101, setupToShow );
-		newSetupId2Interval.put( 101, new FinalInterval(
-			new long[] { splitX, 0, 0 },
-			new long[] { dims[0] - 1, dims[1] - 1, dims[2] - 1 }
+		new2oldSetupId.put(101, setupToShow);
+		newSetupId2Interval.put(101, new FinalInterval(
+			new long[] {splitX, 0, 0},
+			new long[] {dims[0] - 1, dims[1] - 1, dims[2] - 1}
 		));
 
-		System.out.println( "Created 2 split regions:" );
-		System.out.println( "  Setup 100: X=[0, " + (splitX-1) + "] (left half)" );
-		System.out.println( "  Setup 101: X=[" + splitX + ", " + (dims[0]-1) + "] (right half)" );
+		System.out.println("Created 2 split regions:");
+		System.out.println("  Setup 100: X=[0, " + (splitX-1) + "] (left half)");
+		System.out.println("  Setup 101: X=[" + splitX + ", " + (dims[0]-1) + "] (right half)");
 
 		// Create the split loader wrapping the CORRECTED loader
 		// This is the key: correction is applied BEFORE splitting
@@ -170,53 +165,53 @@ public class TestDecoratorChain
 		);
 
 		// ========== STEP 4: Display comparison images ==========
-		System.out.println( "\n=== STEP 4: Displaying images ===" );
+		System.out.println("\n=== STEP 4: Displaying images ===");
 		new ImageJ();
 
-		final int tileId = SETUP_TO_TILE[ setupToShow ][ 1 ];
+		final int tileId = SETUP_TO_TILE[setupToShow][1];
 
 		// 4a. Show UNCORRECTED original (full image, level 0)
-		System.out.println( "Loading uncorrected image..." );
-		final RandomAccessibleInterval< FloatType > uncorrected =
-			baseLoader.getSetupImgLoader( setupToShow ).getFloatImage( timepoint, 0, false );
-		ImageJFunctions.show( uncorrected, "1. Uncorrected - Setup " + setupToShow + " (tile " + tileId + ")" );
+		System.out.println("Loading uncorrected image...");
+		final RandomAccessibleInterval<FloatType> uncorrected =
+			baseLoader.getSetupImgLoader(setupToShow).getFloatImage(timepoint, 0, false);
+		ImageJFunctions.show(uncorrected, "1. Uncorrected - Setup " + setupToShow + " (tile " + tileId + ")");
 
 		// 4b. Show CORRECTED (full image, level 0)
-		System.out.println( "Loading corrected image..." );
-		final RandomAccessibleInterval< FloatType > corrected =
-			correctedLoader.getSetupImgLoader( setupToShow ).getFloatImage( timepoint, 0, false );
-		ImageJFunctions.show( corrected, "2. Corrected - Setup " + setupToShow + " (tile " + tileId + ")" );
+		System.out.println("Loading corrected image...");
+		final RandomAccessibleInterval<FloatType> corrected =
+			correctedLoader.getSetupImgLoader(setupToShow).getFloatImage(timepoint, 0, false);
+		ImageJFunctions.show(corrected, "2. Corrected - Setup " + setupToShow + " (tile " + tileId + ")");
 
 		// 4c. Show CORRECTED + SPLIT (left half, level 0)
-		System.out.println( "Loading corrected + split (left half)..." );
-		final RandomAccessibleInterval< FloatType > splitLeft =
-			splitLoader.getSetupImgLoader( 100 ).getFloatImage( timepoint, 0, false );
-		ImageJFunctions.show( splitLeft, "3. Corrected+Split LEFT - Setup 100" );
+		System.out.println("Loading corrected + split (left half)...");
+		final RandomAccessibleInterval<FloatType> splitLeft =
+			splitLoader.getSetupImgLoader(100).getFloatImage(timepoint, 0, false);
+		ImageJFunctions.show(splitLeft, "3. Corrected+Split LEFT - Setup 100");
 
 		// 4d. Show CORRECTED + SPLIT (right half, level 0)
-		System.out.println( "Loading corrected + split (right half)..." );
-		final RandomAccessibleInterval< FloatType > splitRight =
-			splitLoader.getSetupImgLoader( 101 ).getFloatImage( timepoint, 0, false );
-		ImageJFunctions.show( splitRight, "4. Corrected+Split RIGHT - Setup 101" );
+		System.out.println("Loading corrected + split (right half)...");
+		final RandomAccessibleInterval<FloatType> splitRight =
+			splitLoader.getSetupImgLoader(101).getFloatImage(timepoint, 0, false);
+		ImageJFunctions.show(splitRight, "4. Corrected+Split RIGHT - Setup 101");
 
 		// ========== Summary ==========
-		System.out.println( "\n=== DECORATOR CHAIN SUMMARY ===" );
-		System.out.println( "Layer 1 (innermost): " + baseLoader.getClass().getSimpleName() );
-		System.out.println( "Layer 2 (middle):    " + correctedLoader.getClass().getSimpleName() );
-		System.out.println( "Layer 3 (outermost): " + splitLoader.getClass().getSimpleName() );
-		System.out.println( "" );
-		System.out.println( "Data flow:" );
-		System.out.println( "  Request for split region 100 or 101" );
-		System.out.println( "    → SplitMultiResolutionImgLoader maps to setup " + setupToShow + " with interval" );
-		System.out.println( "    → MultiResolutionFlatfieldCorrectionWrappedImgLoader applies correction" );
-		System.out.println( "    → Base loader fetches raw pixels from N5" );
-		System.out.println( "    → Corrected pixels flow back up through the chain" );
-		System.out.println( "    → Split interval is extracted and returned" );
-		System.out.println( "" );
-		System.out.println( "Compare the images to verify:" );
-		System.out.println( "  - Image 1 vs 2: See flatfield correction effect" );
-		System.out.println( "  - Image 2 vs 3+4: Verify split regions match the corrected full image" );
-		System.out.println( "" );
-		System.out.println( "Tip: Use Image > Adjust > Brightness/Contrast (Ctrl+Shift+C)" );
+		System.out.println("\n=== DECORATOR CHAIN SUMMARY ===");
+		System.out.println("Layer 1 (innermost): " + baseLoader.getClass().getSimpleName());
+		System.out.println("Layer 2 (middle):    " + correctedLoader.getClass().getSimpleName());
+		System.out.println("Layer 3 (outermost): " + splitLoader.getClass().getSimpleName());
+		System.out.println();
+		System.out.println("Data flow:");
+		System.out.println("  Request for split region 100 or 101");
+		System.out.println("    → SplitMultiResolutionImgLoader maps to setup " + setupToShow + " with interval");
+		System.out.println("    → MultiResolutionFlatfieldCorrectionWrappedImgLoader applies correction");
+		System.out.println("    → Base loader fetches raw pixels from N5");
+		System.out.println("    → Corrected pixels flow back up through the chain");
+		System.out.println("    → Split interval is extracted and returned");
+		System.out.println();
+		System.out.println("Compare the images to verify:");
+		System.out.println("  - Image 1 vs 2: See flatfield correction effect");
+		System.out.println("  - Image 2 vs 3+4: Verify split regions match the corrected full image");
+		System.out.println();
+		System.out.println("Tip: Use Image > Adjust > Brightness/Contrast (Ctrl+Shift+C)");
 	}
 }

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/TestDecoratorChain.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/TestDecoratorChain.java
@@ -1,0 +1,222 @@
+/*-
+ * #%L
+ * Software for the reconstruction of multi-view microscopic acquisitions
+ * like Selective Plane Illumination Microscopy (SPIM) Data.
+ * %%
+ * Copyright (C) 2012 - 2025 Multiview Reconstruction developers.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+package net.preibisch.mvrecon.fiji.spimdata.imgloaders.flatfield;
+
+import java.io.File;
+import java.util.HashMap;
+
+import ij.ImageJ;
+import mpicbg.spim.data.SpimDataException;
+import mpicbg.spim.data.sequence.MultiResolutionImgLoader;
+import mpicbg.spim.data.sequence.SequenceDescription;
+import mpicbg.spim.data.sequence.ViewId;
+import mpicbg.spim.data.sequence.ViewSetup;
+import net.imglib2.FinalInterval;
+import net.imglib2.Interval;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.display.imagej.ImageJFunctions;
+import net.imglib2.type.numeric.real.FloatType;
+import net.preibisch.mvrecon.fiji.spimdata.SpimData2;
+import net.preibisch.mvrecon.fiji.spimdata.XmlIoSpimData2;
+import net.preibisch.mvrecon.fiji.spimdata.imgloaders.splitting.SplitMultiResolutionImgLoader;
+
+/**
+ * Test class demonstrating the full decorator chain:
+ *
+ * BaseLoader (N5/OME-Zarr)
+ *     → MultiResolutionFlatfieldCorrectionWrappedImgLoader (applies correction)
+ *         → SplitMultiResolutionImgLoader (splits into regions)
+ *
+ * This shows how to compose multiple wrapper/decorator layers while maintaining
+ * the MultiResolutionImgLoader interface throughout the chain.
+ */
+public class TestDecoratorChain
+{
+	// Mapping from ViewSetup ID to Tile ID (from dataset.xml)
+	private static final int[][] SETUP_TO_TILE = {
+		{ 0, 187 },
+		{ 1, 188 },
+		{ 2, 189 },
+		{ 3, 200 },
+		{ 4, 201 },
+		{ 5, 202 },
+		{ 6, 213 },
+		{ 7, 214 },
+		{ 8, 215 }
+	};
+
+	public static void main( String[] args ) throws SpimDataException
+	{
+		// ========== CONFIGURATION ==========
+		final String basePath = "/Users/innerbergerm/Projects/janelia/multiview-reconstruction/";
+		final String xmlPath = basePath + "data/dataset.xml";
+		final String correctionPath = basePath + "dark_and_flatfields/";
+
+		// Which setup to demonstrate (0-8)
+		final int setupToShow = 0;
+		final int timepoint = 0;
+
+		// ========== STEP 1: Load dataset and get base loader ==========
+		System.out.println( "=== STEP 1: Loading dataset ===" );
+		System.out.println( "XML path: " + xmlPath );
+
+		final SpimData2 data = new XmlIoSpimData2().load( xmlPath );
+		final SequenceDescription seqDesc = data.getSequenceDescription();
+
+		// The base loader - this could be N5ImageLoader, AllenOMEZarrLoader, etc.
+		final MultiResolutionImgLoader baseLoader =
+			(MultiResolutionImgLoader) seqDesc.getImgLoader();
+
+		System.out.println( "Base loader type: " + baseLoader.getClass().getSimpleName() );
+
+		// ========== STEP 2: Wrap with flatfield correction ==========
+		System.out.println( "\n=== STEP 2: Wrapping with flatfield correction ===" );
+
+		final MultiResolutionFlatfieldCorrectionWrappedImgLoader correctedLoader =
+			new MultiResolutionFlatfieldCorrectionWrappedImgLoader( baseLoader, true );
+
+		// Configure correction images for each view setup
+		for ( int[] mapping : SETUP_TO_TILE )
+		{
+			final int setupId = mapping[ 0 ];
+			final int tileId = mapping[ 1 ];
+
+			// Find darkfield file
+			final File darkfield = new File( correctionPath + "setup" + tileId + "-AVG_darkfield-fromdata.tif" );
+
+			// Find flatfield file (try both naming conventions)
+			File flatfield = new File( correctionPath + "setup" + tileId + "-flatfield.tif" );
+			if ( !flatfield.exists() )
+				flatfield = new File( correctionPath + "setup" + tileId + "-flatfield (fixed by mirroring).tif" );
+
+			final ViewId viewId = new ViewId( timepoint, setupId );
+
+			if ( darkfield.exists() )
+			{
+				correctedLoader.setDarkImage( viewId, darkfield );
+				System.out.println( "  Setup " + setupId + ": darkfield = " + darkfield.getName() );
+			}
+
+			if ( flatfield.exists() )
+			{
+				correctedLoader.setBrightImage( viewId, flatfield );
+				System.out.println( "  Setup " + setupId + ": flatfield = " + flatfield.getName() );
+			}
+		}
+
+		// ========== STEP 3: Wrap with splitting ==========
+		System.out.println( "\n=== STEP 3: Wrapping with splitting ===" );
+
+		// Get original image dimensions for the setup we're demonstrating
+		final ViewSetup vs = seqDesc.getViewSetups().get( setupToShow );
+		final long[] dims = new long[ 3 ];
+		vs.getSize().dimensions( dims );
+		System.out.println( "Original image size: " + dims[0] + " x " + dims[1] + " x " + dims[2] );
+
+		// Create a simple 2x1 split in X dimension
+		// Split the 512-wide image into two 256-wide regions
+		final long splitX = dims[ 0 ] / 2;
+
+		// Define the mappings for split regions
+		// New setup IDs 100, 101 will map to original setup 0, with different X intervals
+		final HashMap< Integer, Integer > new2oldSetupId = new HashMap<>();
+		final HashMap< Integer, Interval > newSetupId2Interval = new HashMap<>();
+
+		// Split region 0: left half [0, splitX) x [0, dimY) x [0, dimZ)
+		new2oldSetupId.put( 100, setupToShow );
+		newSetupId2Interval.put( 100, new FinalInterval(
+			new long[] { 0, 0, 0 },
+			new long[] { splitX - 1, dims[1] - 1, dims[2] - 1 }
+		));
+
+		// Split region 1: right half [splitX, dimX) x [0, dimY) x [0, dimZ)
+		new2oldSetupId.put( 101, setupToShow );
+		newSetupId2Interval.put( 101, new FinalInterval(
+			new long[] { splitX, 0, 0 },
+			new long[] { dims[0] - 1, dims[1] - 1, dims[2] - 1 }
+		));
+
+		System.out.println( "Created 2 split regions:" );
+		System.out.println( "  Setup 100: X=[0, " + (splitX-1) + "] (left half)" );
+		System.out.println( "  Setup 101: X=[" + splitX + ", " + (dims[0]-1) + "] (right half)" );
+
+		// Create the split loader wrapping the CORRECTED loader
+		// This is the key: correction is applied BEFORE splitting
+		final SplitMultiResolutionImgLoader splitLoader = new SplitMultiResolutionImgLoader(
+			correctedLoader,  // <-- corrected loader, not base loader!
+			new2oldSetupId,
+			newSetupId2Interval,
+			seqDesc
+		);
+
+		// ========== STEP 4: Display comparison images ==========
+		System.out.println( "\n=== STEP 4: Displaying images ===" );
+		new ImageJ();
+
+		final int tileId = SETUP_TO_TILE[ setupToShow ][ 1 ];
+
+		// 4a. Show UNCORRECTED original (full image, level 0)
+		System.out.println( "Loading uncorrected image..." );
+		final RandomAccessibleInterval< FloatType > uncorrected =
+			baseLoader.getSetupImgLoader( setupToShow ).getFloatImage( timepoint, 0, false );
+		ImageJFunctions.show( uncorrected, "1. Uncorrected - Setup " + setupToShow + " (tile " + tileId + ")" );
+
+		// 4b. Show CORRECTED (full image, level 0)
+		System.out.println( "Loading corrected image..." );
+		final RandomAccessibleInterval< FloatType > corrected =
+			correctedLoader.getSetupImgLoader( setupToShow ).getFloatImage( timepoint, 0, false );
+		ImageJFunctions.show( corrected, "2. Corrected - Setup " + setupToShow + " (tile " + tileId + ")" );
+
+		// 4c. Show CORRECTED + SPLIT (left half, level 0)
+		System.out.println( "Loading corrected + split (left half)..." );
+		final RandomAccessibleInterval< FloatType > splitLeft =
+			splitLoader.getSetupImgLoader( 100 ).getFloatImage( timepoint, 0, false );
+		ImageJFunctions.show( splitLeft, "3. Corrected+Split LEFT - Setup 100" );
+
+		// 4d. Show CORRECTED + SPLIT (right half, level 0)
+		System.out.println( "Loading corrected + split (right half)..." );
+		final RandomAccessibleInterval< FloatType > splitRight =
+			splitLoader.getSetupImgLoader( 101 ).getFloatImage( timepoint, 0, false );
+		ImageJFunctions.show( splitRight, "4. Corrected+Split RIGHT - Setup 101" );
+
+		// ========== Summary ==========
+		System.out.println( "\n=== DECORATOR CHAIN SUMMARY ===" );
+		System.out.println( "Layer 1 (innermost): " + baseLoader.getClass().getSimpleName() );
+		System.out.println( "Layer 2 (middle):    " + correctedLoader.getClass().getSimpleName() );
+		System.out.println( "Layer 3 (outermost): " + splitLoader.getClass().getSimpleName() );
+		System.out.println( "" );
+		System.out.println( "Data flow:" );
+		System.out.println( "  Request for split region 100 or 101" );
+		System.out.println( "    → SplitMultiResolutionImgLoader maps to setup " + setupToShow + " with interval" );
+		System.out.println( "    → MultiResolutionFlatfieldCorrectionWrappedImgLoader applies correction" );
+		System.out.println( "    → Base loader fetches raw pixels from N5" );
+		System.out.println( "    → Corrected pixels flow back up through the chain" );
+		System.out.println( "    → Split interval is extracted and returned" );
+		System.out.println( "" );
+		System.out.println( "Compare the images to verify:" );
+		System.out.println( "  - Image 1 vs 2: See flatfield correction effect" );
+		System.out.println( "  - Image 2 vs 3+4: Verify split regions match the corrected full image" );
+		System.out.println( "" );
+		System.out.println( "Tip: Use Image > Adjust > Brightness/Contrast (Ctrl+Shift+C)" );
+	}
+}

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/TestFlatfieldCorrection.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/TestFlatfieldCorrection.java
@@ -1,0 +1,153 @@
+/*-
+ * #%L
+ * Software for the reconstruction of multi-view microscopic acquisitions
+ * like Selective Plane Illumination Microscopy (SPIM) Data.
+ * %%
+ * Copyright (C) 2012 - 2025 Multiview Reconstruction developers.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+package net.preibisch.mvrecon.fiji.spimdata.imgloaders.flatfield;
+
+import java.io.File;
+
+import ij.ImageJ;
+import mpicbg.spim.data.SpimDataException;
+import mpicbg.spim.data.sequence.ImgLoader;
+import mpicbg.spim.data.sequence.ViewId;
+import mpicbg.spim.data.sequence.ViewSetup;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.display.imagej.ImageJFunctions;
+import net.imglib2.type.numeric.real.FloatType;
+import net.preibisch.mvrecon.fiji.spimdata.SpimData2;
+import net.preibisch.mvrecon.fiji.spimdata.XmlIoSpimData2;
+
+/**
+ * Test class for on-the-fly flatfield/darkfield correction.
+ *
+ * Loads dataset.xml, wraps the ImgLoader with flatfield correction,
+ * and displays corrected vs uncorrected images for comparison.
+ */
+public class TestFlatfieldCorrection
+{
+	// Mapping from ViewSetup ID to Tile ID (from dataset.xml)
+	private static final int[][] SETUP_TO_TILE = {
+		{ 0, 187 },
+		{ 1, 188 },
+		{ 2, 189 },
+		{ 3, 200 },
+		{ 4, 201 },
+		{ 5, 202 },
+		{ 6, 213 },
+		{ 7, 214 },
+		{ 8, 215 }
+	};
+
+	public static void main( String[] args ) throws SpimDataException
+	{
+		// Paths - adjust these as needed
+		final String basePath = "/Users/innerbergerm/Projects/janelia/multiview-reconstruction/";
+		final String xmlPath = basePath + "data/dataset.xml";
+		final String correctionPath = basePath + "dark_and_flatfields/";
+
+		// Which setup to display (0-8)
+		final int setupToShow = 0;
+		final int timepoint = 0;
+
+		// Load the dataset
+		System.out.println( "Loading dataset from: " + xmlPath );
+		final SpimData2 data = new XmlIoSpimData2().load( xmlPath );
+
+		// Get the original ImgLoader
+		final ImgLoader originalImgLoader = data.getSequenceDescription().getImgLoader();
+
+		// Create the flatfield-corrected wrapper
+		final DefaultFlatfieldCorrectionWrappedImgLoader ffcImgLoader =
+			new DefaultFlatfieldCorrectionWrappedImgLoader( originalImgLoader, true );
+
+		// Configure correction images for each view setup
+		System.out.println( "\nConfiguring flatfield correction:" );
+		for ( int[] mapping : SETUP_TO_TILE )
+		{
+			final int setupId = mapping[ 0 ];
+			final int tileId = mapping[ 1 ];
+
+			// Find darkfield file
+			final File darkfield = new File( correctionPath + "setup" + tileId + "-AVG_darkfield-fromdata.tif" );
+
+			// Find flatfield file (try both naming conventions)
+			File flatfield = new File( correctionPath + "setup" + tileId + "-flatfield.tif" );
+			if ( !flatfield.exists() )
+				flatfield = new File( correctionPath + "setup" + tileId + "-flatfield (fixed by mirroring).tif" );
+
+			// Set the correction images
+			final ViewId viewId = new ViewId( timepoint, setupId );
+
+			if ( darkfield.exists() )
+			{
+				ffcImgLoader.setDarkImage( viewId, darkfield );
+				System.out.println( "  Setup " + setupId + " (tile " + tileId + "): darkfield = " + darkfield.getName() );
+			}
+			else
+			{
+				System.out.println( "  Setup " + setupId + " (tile " + tileId + "): WARNING - darkfield not found: " + darkfield.getAbsolutePath() );
+			}
+
+			if ( flatfield.exists() )
+			{
+				ffcImgLoader.setBrightImage( viewId, flatfield );
+				System.out.println( "  Setup " + setupId + " (tile " + tileId + "): flatfield = " + flatfield.getName() );
+			}
+			else
+			{
+				System.out.println( "  Setup " + setupId + " (tile " + tileId + "): WARNING - flatfield not found" );
+			}
+		}
+
+		// Start ImageJ
+		new ImageJ();
+
+		// Get tile ID for display title
+		int tileId = SETUP_TO_TILE[ setupToShow ][ 1 ];
+		final ViewSetup vs = data.getSequenceDescription().getViewSetups().get( setupToShow );
+		System.out.println( "\nDisplaying setup " + setupToShow + " (tile " + tileId + ")" );
+		System.out.println( "  Dimensions: " + vs.getSize() );
+
+		// Load and display UNCORRECTED image
+		System.out.println( "Loading uncorrected image..." );
+		ffcImgLoader.setActive( false );
+		data.getSequenceDescription().setImgLoader( ffcImgLoader );
+
+		final RandomAccessibleInterval< FloatType > uncorrected =
+			data.getSequenceDescription().getImgLoader()
+				.getSetupImgLoader( setupToShow )
+				.getFloatImage( timepoint, false );
+		ImageJFunctions.show( uncorrected, "Uncorrected - Setup " + setupToShow + " (tile " + tileId + ")" );
+
+		// Load and display CORRECTED image
+		System.out.println( "Loading corrected image..." );
+		ffcImgLoader.setActive( true );
+
+		final RandomAccessibleInterval< FloatType > corrected =
+			data.getSequenceDescription().getImgLoader()
+				.getSetupImgLoader( setupToShow )
+				.getFloatImage( timepoint, false );
+		ImageJFunctions.show( corrected, "Corrected - Setup " + setupToShow + " (tile " + tileId + ")" );
+
+		System.out.println( "\nDone! Compare the two images to verify correction." );
+		System.out.println( "Tip: Use Image > Adjust > Brightness/Contrast to compare intensity distributions." );
+	}
+}

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/TestFlatfieldCorrection.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/TestFlatfieldCorrection.java
@@ -40,11 +40,9 @@ import net.preibisch.mvrecon.fiji.spimdata.XmlIoSpimData2;
  * The XML wraps the N5 loader with MultiResolutionFlatfieldCorrectionWrappedImgLoader
  * and specifies bright/dark images for each view setup.
  */
-public class TestFlatfieldCorrection
-{
+public class TestFlatfieldCorrection {
 
-	public static void main( String[] args ) throws SpimDataException
-	{
+	public static void main(String[] args) throws SpimDataException {
 		// Paths
 		final String basePath = "/Users/innerbergerm/Projects/janelia/multiview-reconstruction/";
 		final String correctedXmlPath = basePath + "data/dataset_corrected.xml";
@@ -55,65 +53,64 @@ public class TestFlatfieldCorrection
 		final int timepoint = 0;
 
 		// ========== Load CORRECTED dataset (from XML with flatfield config) ==========
-		System.out.println( "=== Loading CORRECTED dataset ===" );
-		System.out.println( "XML path: " + correctedXmlPath );
+		System.out.println("=== Loading CORRECTED dataset ===");
+		System.out.println("XML path: " + correctedXmlPath);
 
-		final SpimData2 correctedData = new XmlIoSpimData2().load( correctedXmlPath );
+		final SpimData2 correctedData = new XmlIoSpimData2().load(correctedXmlPath);
 		final ImgLoader correctedImgLoader = correctedData.getSequenceDescription().getImgLoader();
 
-		System.out.println( "ImgLoader type: " + correctedImgLoader.getClass().getSimpleName() );
+		System.out.println("ImgLoader type: " + correctedImgLoader.getClass().getSimpleName());
 
 		// Verify it's a flatfield-corrected loader
-		if ( correctedImgLoader instanceof FlatfieldCorrectionWrappedImgLoader )
-		{
-			final FlatfieldCorrectionWrappedImgLoader< ? > ffcLoader =
-				(FlatfieldCorrectionWrappedImgLoader< ? >) correctedImgLoader;
-			System.out.println( "  Correction active: " + ffcLoader.isActive() );
-			System.out.println( "  Caching enabled: " + ffcLoader.isCached() );
-			System.out.println( "  Wrapped loader: " + ffcLoader.getWrappedImgLoder().getClass().getSimpleName() );
+		if (correctedImgLoader instanceof FlatfieldCorrectionWrappedImgLoader) {
+			final FlatfieldCorrectionWrappedImgLoader<?> ffcLoader =
+				(FlatfieldCorrectionWrappedImgLoader<?>) correctedImgLoader;
+			System.out.println("  Correction active: " + ffcLoader.isActive());
+			System.out.println("  Caching enabled: " + ffcLoader.isCached());
+			System.out.println("  Wrapped loader: " + ffcLoader.getWrappedImgLoder().getClass().getSimpleName());
 		}
 
 		// ========== Load UNCORRECTED dataset (original XML) ==========
-		System.out.println( "\n=== Loading UNCORRECTED dataset ===" );
-		System.out.println( "XML path: " + uncorrectedXmlPath );
+		System.out.println("\n=== Loading UNCORRECTED dataset ===");
+		System.out.println("XML path: " + uncorrectedXmlPath);
 
-		final SpimData2 uncorrectedData = new XmlIoSpimData2().load( uncorrectedXmlPath );
+		final SpimData2 uncorrectedData = new XmlIoSpimData2().load(uncorrectedXmlPath);
 		final ImgLoader uncorrectedImgLoader = uncorrectedData.getSequenceDescription().getImgLoader();
 
-		System.out.println( "ImgLoader type: " + uncorrectedImgLoader.getClass().getSimpleName() );
+		System.out.println("ImgLoader type: " + uncorrectedImgLoader.getClass().getSimpleName());
 
 		// ========== Display images for comparison ==========
 		new ImageJ();
 
 		// Get tile ID from ViewSetup metadata (no hardcoded mapping needed!)
         final int tileId = correctedData.getSequenceDescription()
-			.getViewSetups().get( setupToShow ).getTile().getId();
+			.getViewSetups().get(setupToShow).getTile().getId();
 
-		System.out.println( "\n=== Displaying setup " + setupToShow + " (tile " + tileId + ") ===" );
-		System.out.println( "  Dimensions: " + correctedData.getSequenceDescription()
-			.getViewSetups().get( setupToShow ).getSize() );
+		System.out.println("\n=== Displaying setup " + setupToShow + " (tile " + tileId + ") ===");
+		System.out.println("  Dimensions: " + correctedData.getSequenceDescription()
+			.getViewSetups().get(setupToShow).getSize());
 
 		// Load and display UNCORRECTED image
-		System.out.println( "Loading uncorrected image..." );
-		final RandomAccessibleInterval< FloatType > uncorrected =
-			uncorrectedImgLoader.getSetupImgLoader( setupToShow ).getFloatImage( timepoint, false );
-		ImageJFunctions.show( uncorrected, "1. Uncorrected - Setup " + setupToShow + " (tile " + tileId + ")" );
+		System.out.println("Loading uncorrected image...");
+		final RandomAccessibleInterval<FloatType> uncorrected =
+			uncorrectedImgLoader.getSetupImgLoader(setupToShow).getFloatImage(timepoint, false);
+		ImageJFunctions.show(uncorrected, "1. Uncorrected - Setup " + setupToShow + " (tile " + tileId + ")");
 
 		// Load and display CORRECTED image
-		System.out.println( "Loading corrected image..." );
-		final RandomAccessibleInterval< FloatType > corrected =
-			correctedImgLoader.getSetupImgLoader( setupToShow ).getFloatImage( timepoint, false );
-		ImageJFunctions.show( corrected, "2. Corrected - Setup " + setupToShow + " (tile " + tileId + ")" );
+		System.out.println("Loading corrected image...");
+		final RandomAccessibleInterval<FloatType> corrected =
+			correctedImgLoader.getSetupImgLoader(setupToShow).getFloatImage(timepoint, false);
+		ImageJFunctions.show(corrected, "2. Corrected - Setup " + setupToShow + " (tile " + tileId + ")");
 
 		// ========== Summary ==========
-		System.out.println( "\n=== SUMMARY ===" );
-		System.out.println( "Flatfield correction is now configured in the XML!" );
-		System.out.println( "No manual setBrightImage()/setDarkImage() calls needed." );
-		System.out.println( "" );
-		System.out.println( "Compare the two images to verify correction:" );
-		System.out.println( "  - Image 1: Raw data from N5" );
-		System.out.println( "  - Image 2: Corrected with flatfield/darkfield" );
-		System.out.println( "" );
-		System.out.println( "Tip: Use Image > Adjust > Brightness/Contrast (Ctrl+Shift+C)" );
+		System.out.println("\n=== SUMMARY ===");
+		System.out.println("Flatfield correction is now configured in the XML!");
+		System.out.println("No manual setBrightImage()/setDarkImage() calls needed.");
+		System.out.println();
+		System.out.println("Compare the two images to verify correction:");
+		System.out.println("  - Image 1: Raw data from N5");
+		System.out.println("  - Image 2: Corrected with flatfield/darkfield");
+		System.out.println();
+		System.out.println("Tip: Use Image > Adjust > Brightness/Contrast (Ctrl+Shift+C)");
 	}
 }

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/TestFlatfieldCorrection.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/TestFlatfieldCorrection.java
@@ -22,13 +22,9 @@
  */
 package net.preibisch.mvrecon.fiji.spimdata.imgloaders.flatfield;
 
-import java.io.File;
-
 import ij.ImageJ;
 import mpicbg.spim.data.SpimDataException;
 import mpicbg.spim.data.sequence.ImgLoader;
-import mpicbg.spim.data.sequence.ViewId;
-import mpicbg.spim.data.sequence.ViewSetup;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.img.display.imagej.ImageJFunctions;
 import net.imglib2.type.numeric.real.FloatType;
@@ -36,118 +32,88 @@ import net.preibisch.mvrecon.fiji.spimdata.SpimData2;
 import net.preibisch.mvrecon.fiji.spimdata.XmlIoSpimData2;
 
 /**
- * Test class for on-the-fly flatfield/darkfield correction.
+ * Test class for XML-based on-the-fly flatfield/darkfield correction.
  *
- * Loads dataset.xml, wraps the ImgLoader with flatfield correction,
- * and displays corrected vs uncorrected images for comparison.
+ * Loads dataset_corrected.xml which has flatfield correction configured
+ * directly in the ImageLoader section. No manual configuration needed!
+ *
+ * The XML wraps the N5 loader with MultiResolutionFlatfieldCorrectionWrappedImgLoader
+ * and specifies bright/dark images for each view setup.
  */
 public class TestFlatfieldCorrection
 {
-	// Mapping from ViewSetup ID to Tile ID (from dataset.xml)
-	private static final int[][] SETUP_TO_TILE = {
-		{ 0, 187 },
-		{ 1, 188 },
-		{ 2, 189 },
-		{ 3, 200 },
-		{ 4, 201 },
-		{ 5, 202 },
-		{ 6, 213 },
-		{ 7, 214 },
-		{ 8, 215 }
-	};
 
 	public static void main( String[] args ) throws SpimDataException
 	{
-		// Paths - adjust these as needed
+		// Paths
 		final String basePath = "/Users/innerbergerm/Projects/janelia/multiview-reconstruction/";
-		final String xmlPath = basePath + "data/dataset.xml";
-		final String correctionPath = basePath + "dark_and_flatfields/";
+		final String correctedXmlPath = basePath + "data/dataset_corrected.xml";
+		final String uncorrectedXmlPath = basePath + "data/dataset.xml";
 
 		// Which setup to display (0-8)
 		final int setupToShow = 0;
 		final int timepoint = 0;
 
-		// Load the dataset
-		System.out.println( "Loading dataset from: " + xmlPath );
-		final SpimData2 data = new XmlIoSpimData2().load( xmlPath );
+		// ========== Load CORRECTED dataset (from XML with flatfield config) ==========
+		System.out.println( "=== Loading CORRECTED dataset ===" );
+		System.out.println( "XML path: " + correctedXmlPath );
 
-		// Get the original ImgLoader
-		final ImgLoader originalImgLoader = data.getSequenceDescription().getImgLoader();
+		final SpimData2 correctedData = new XmlIoSpimData2().load( correctedXmlPath );
+		final ImgLoader correctedImgLoader = correctedData.getSequenceDescription().getImgLoader();
 
-		// Create the flatfield-corrected wrapper
-		final DefaultFlatfieldCorrectionWrappedImgLoader ffcImgLoader =
-			new DefaultFlatfieldCorrectionWrappedImgLoader( originalImgLoader, true );
+		System.out.println( "ImgLoader type: " + correctedImgLoader.getClass().getSimpleName() );
 
-		// Configure correction images for each view setup
-		System.out.println( "\nConfiguring flatfield correction:" );
-		for ( int[] mapping : SETUP_TO_TILE )
+		// Verify it's a flatfield-corrected loader
+		if ( correctedImgLoader instanceof FlatfieldCorrectionWrappedImgLoader )
 		{
-			final int setupId = mapping[ 0 ];
-			final int tileId = mapping[ 1 ];
-
-			// Find darkfield file
-			final File darkfield = new File( correctionPath + "setup" + tileId + "-AVG_darkfield-fromdata.tif" );
-
-			// Find flatfield file (try both naming conventions)
-			File flatfield = new File( correctionPath + "setup" + tileId + "-flatfield.tif" );
-			if ( !flatfield.exists() )
-				flatfield = new File( correctionPath + "setup" + tileId + "-flatfield (fixed by mirroring).tif" );
-
-			// Set the correction images
-			final ViewId viewId = new ViewId( timepoint, setupId );
-
-			if ( darkfield.exists() )
-			{
-				ffcImgLoader.setDarkImage( viewId, darkfield );
-				System.out.println( "  Setup " + setupId + " (tile " + tileId + "): darkfield = " + darkfield.getName() );
-			}
-			else
-			{
-				System.out.println( "  Setup " + setupId + " (tile " + tileId + "): WARNING - darkfield not found: " + darkfield.getAbsolutePath() );
-			}
-
-			if ( flatfield.exists() )
-			{
-				ffcImgLoader.setBrightImage( viewId, flatfield );
-				System.out.println( "  Setup " + setupId + " (tile " + tileId + "): flatfield = " + flatfield.getName() );
-			}
-			else
-			{
-				System.out.println( "  Setup " + setupId + " (tile " + tileId + "): WARNING - flatfield not found" );
-			}
+			final FlatfieldCorrectionWrappedImgLoader< ? > ffcLoader =
+				(FlatfieldCorrectionWrappedImgLoader< ? >) correctedImgLoader;
+			System.out.println( "  Correction active: " + ffcLoader.isActive() );
+			System.out.println( "  Caching enabled: " + ffcLoader.isCached() );
+			System.out.println( "  Wrapped loader: " + ffcLoader.getWrappedImgLoder().getClass().getSimpleName() );
 		}
 
-		// Start ImageJ
+		// ========== Load UNCORRECTED dataset (original XML) ==========
+		System.out.println( "\n=== Loading UNCORRECTED dataset ===" );
+		System.out.println( "XML path: " + uncorrectedXmlPath );
+
+		final SpimData2 uncorrectedData = new XmlIoSpimData2().load( uncorrectedXmlPath );
+		final ImgLoader uncorrectedImgLoader = uncorrectedData.getSequenceDescription().getImgLoader();
+
+		System.out.println( "ImgLoader type: " + uncorrectedImgLoader.getClass().getSimpleName() );
+
+		// ========== Display images for comparison ==========
 		new ImageJ();
 
-		// Get tile ID for display title
-		int tileId = SETUP_TO_TILE[ setupToShow ][ 1 ];
-		final ViewSetup vs = data.getSequenceDescription().getViewSetups().get( setupToShow );
-		System.out.println( "\nDisplaying setup " + setupToShow + " (tile " + tileId + ")" );
-		System.out.println( "  Dimensions: " + vs.getSize() );
+		// Get tile ID from ViewSetup metadata (no hardcoded mapping needed!)
+        final int tileId = correctedData.getSequenceDescription()
+			.getViewSetups().get( setupToShow ).getTile().getId();
+
+		System.out.println( "\n=== Displaying setup " + setupToShow + " (tile " + tileId + ") ===" );
+		System.out.println( "  Dimensions: " + correctedData.getSequenceDescription()
+			.getViewSetups().get( setupToShow ).getSize() );
 
 		// Load and display UNCORRECTED image
 		System.out.println( "Loading uncorrected image..." );
-		ffcImgLoader.setActive( false );
-		data.getSequenceDescription().setImgLoader( ffcImgLoader );
-
 		final RandomAccessibleInterval< FloatType > uncorrected =
-			data.getSequenceDescription().getImgLoader()
-				.getSetupImgLoader( setupToShow )
-				.getFloatImage( timepoint, false );
-		ImageJFunctions.show( uncorrected, "Uncorrected - Setup " + setupToShow + " (tile " + tileId + ")" );
+			uncorrectedImgLoader.getSetupImgLoader( setupToShow ).getFloatImage( timepoint, false );
+		ImageJFunctions.show( uncorrected, "1. Uncorrected - Setup " + setupToShow + " (tile " + tileId + ")" );
 
 		// Load and display CORRECTED image
 		System.out.println( "Loading corrected image..." );
-		ffcImgLoader.setActive( true );
-
 		final RandomAccessibleInterval< FloatType > corrected =
-			data.getSequenceDescription().getImgLoader()
-				.getSetupImgLoader( setupToShow )
-				.getFloatImage( timepoint, false );
-		ImageJFunctions.show( corrected, "Corrected - Setup " + setupToShow + " (tile " + tileId + ")" );
+			correctedImgLoader.getSetupImgLoader( setupToShow ).getFloatImage( timepoint, false );
+		ImageJFunctions.show( corrected, "2. Corrected - Setup " + setupToShow + " (tile " + tileId + ")" );
 
-		System.out.println( "\nDone! Compare the two images to verify correction." );
-		System.out.println( "Tip: Use Image > Adjust > Brightness/Contrast to compare intensity distributions." );
+		// ========== Summary ==========
+		System.out.println( "\n=== SUMMARY ===" );
+		System.out.println( "Flatfield correction is now configured in the XML!" );
+		System.out.println( "No manual setBrightImage()/setDarkImage() calls needed." );
+		System.out.println( "" );
+		System.out.println( "Compare the two images to verify correction:" );
+		System.out.println( "  - Image 1: Raw data from N5" );
+		System.out.println( "  - Image 2: Corrected with flatfield/darkfield" );
+		System.out.println( "" );
+		System.out.println( "Tip: Use Image > Adjust > Brightness/Contrast (Ctrl+Shift+C)" );
 	}
 }

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/TestViewerFlatfieldCorrection.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/TestViewerFlatfieldCorrection.java
@@ -1,0 +1,257 @@
+/*-
+ * #%L
+ * Software for the reconstruction of multi-view microscopic acquisitions
+ * like Selective Plane Illumination Microscopy (SPIM) Data.
+ * %%
+ * Copyright (C) 2012 - 2025 Multiview Reconstruction developers.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+package net.preibisch.mvrecon.fiji.spimdata.imgloaders.flatfield;
+
+import java.io.File;
+import java.util.HashMap;
+
+import bdv.ViewerImgLoader;
+import bdv.ViewerSetupImgLoader;
+import ij.ImageJ;
+import mpicbg.spim.data.SpimDataException;
+import mpicbg.spim.data.sequence.SequenceDescription;
+import mpicbg.spim.data.sequence.ViewId;
+import mpicbg.spim.data.sequence.ViewSetup;
+import net.imglib2.FinalInterval;
+import net.imglib2.Interval;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.display.imagej.ImageJFunctions;
+import net.imglib2.type.numeric.real.FloatType;
+import net.preibisch.mvrecon.fiji.spimdata.SpimData2;
+import net.preibisch.mvrecon.fiji.spimdata.XmlIoSpimData2;
+import net.preibisch.mvrecon.fiji.spimdata.imgloaders.splitting.SplitViewerImgLoader;
+
+/**
+ * Test class for ViewerFlatfieldCorrectionWrappedImgLoader.
+ *
+ * Demonstrates the full ViewerImgLoader-compatible decorator chain:
+ *   N5ImageLoader (ViewerImgLoader)
+ *       -> ViewerFlatfieldCorrectionWrappedImgLoader (ViewerImgLoader)
+ *           -> SplitViewerImgLoader (ViewerImgLoader)
+ *
+ * This maintains full BDV compatibility throughout the chain, including:
+ * - Cache control delegation
+ * - Volatile image support
+ * - Multi-resolution mipmap levels
+ */
+public class TestViewerFlatfieldCorrection
+{
+	// Mapping from ViewSetup ID to Tile ID (from dataset.xml)
+	private static final int[][] SETUP_TO_TILE = {
+		{ 0, 187 },
+		{ 1, 188 },
+		{ 2, 189 },
+		{ 3, 200 },
+		{ 4, 201 },
+		{ 5, 202 },
+		{ 6, 213 },
+		{ 7, 214 },
+		{ 8, 215 }
+	};
+
+	public static void main( String[] args ) throws SpimDataException
+	{
+		// ========== CONFIGURATION ==========
+		final String basePath = "/Users/innerbergerm/Projects/janelia/multiview-reconstruction/";
+		final String xmlPath = basePath + "data/dataset.xml";
+		final String correctionPath = basePath + "dark_and_flatfields/";
+
+		// Which setup to demonstrate (0-8)
+		final int setupToShow = 0;
+		final int timepoint = 0;
+
+		// ========== STEP 1: Load dataset and get base ViewerImgLoader ==========
+		System.out.println( "=== STEP 1: Loading dataset ===" );
+		System.out.println( "XML path: " + xmlPath );
+
+		final SpimData2 data = new XmlIoSpimData2().load( xmlPath );
+		final SequenceDescription seqDesc = data.getSequenceDescription();
+
+		// Verify the base loader is a ViewerImgLoader
+		if ( !( seqDesc.getImgLoader() instanceof ViewerImgLoader ) )
+		{
+			System.err.println( "ERROR: Base loader is not a ViewerImgLoader!" );
+			System.err.println( "Loader type: " + seqDesc.getImgLoader().getClass().getName() );
+			return;
+		}
+
+		final ViewerImgLoader baseLoader = (ViewerImgLoader) seqDesc.getImgLoader();
+		System.out.println( "Base loader type: " + baseLoader.getClass().getSimpleName() );
+		System.out.println( "Base loader implements ViewerImgLoader: YES" );
+
+		// ========== STEP 2: Wrap with ViewerFlatfieldCorrectionWrappedImgLoader ==========
+		System.out.println( "\n=== STEP 2: Wrapping with ViewerFlatfieldCorrectionWrappedImgLoader ===" );
+
+		final ViewerFlatfieldCorrectionWrappedImgLoader correctedLoader =
+			new ViewerFlatfieldCorrectionWrappedImgLoader( baseLoader, true );
+
+		// Configure correction images for each view setup
+		for ( int[] mapping : SETUP_TO_TILE )
+		{
+			final int setupId = mapping[ 0 ];
+			final int tileId = mapping[ 1 ];
+
+			// Find darkfield file
+			final File darkfield = new File( correctionPath + "setup" + tileId + "-AVG_darkfield-fromdata.tif" );
+
+			// Find flatfield file (try both naming conventions)
+			File flatfield = new File( correctionPath + "setup" + tileId + "-flatfield.tif" );
+			if ( !flatfield.exists() )
+				flatfield = new File( correctionPath + "setup" + tileId + "-flatfield (fixed by mirroring).tif" );
+
+			final ViewId viewId = new ViewId( timepoint, setupId );
+
+			if ( darkfield.exists() )
+			{
+				correctedLoader.setDarkImage( viewId, darkfield );
+				System.out.println( "  Setup " + setupId + ": darkfield = " + darkfield.getName() );
+			}
+
+			if ( flatfield.exists() )
+			{
+				correctedLoader.setBrightImage( viewId, flatfield );
+				System.out.println( "  Setup " + setupId + ": flatfield = " + flatfield.getName() );
+			}
+		}
+
+		System.out.println( "Corrected loader implements ViewerImgLoader: " +
+			( correctedLoader instanceof ViewerImgLoader ? "YES" : "NO" ) );
+
+		// ========== STEP 3: Wrap with SplitViewerImgLoader ==========
+		System.out.println( "\n=== STEP 3: Wrapping with SplitViewerImgLoader ===" );
+
+		// Get original image dimensions for the setup we're demonstrating
+		final ViewSetup vs = seqDesc.getViewSetups().get( setupToShow );
+		final long[] dims = new long[ 3 ];
+		vs.getSize().dimensions( dims );
+		System.out.println( "Original image size: " + dims[0] + " x " + dims[1] + " x " + dims[2] );
+
+		// Create a simple 2x1 split in X dimension
+		final long splitX = dims[ 0 ] / 2;
+
+		// Define the mappings for split regions
+		final HashMap< Integer, Integer > new2oldSetupId = new HashMap<>();
+		final HashMap< Integer, Interval > newSetupId2Interval = new HashMap<>();
+
+		// Split region 0: left half
+		new2oldSetupId.put( 100, setupToShow );
+		newSetupId2Interval.put( 100, new FinalInterval(
+			new long[] { 0, 0, 0 },
+			new long[] { splitX - 1, dims[1] - 1, dims[2] - 1 }
+		));
+
+		// Split region 1: right half
+		new2oldSetupId.put( 101, setupToShow );
+		newSetupId2Interval.put( 101, new FinalInterval(
+			new long[] { splitX, 0, 0 },
+			new long[] { dims[0] - 1, dims[1] - 1, dims[2] - 1 }
+		));
+
+		System.out.println( "Created 2 split regions:" );
+		System.out.println( "  Setup 100: X=[0, " + (splitX-1) + "] (left half)" );
+		System.out.println( "  Setup 101: X=[" + splitX + ", " + (dims[0]-1) + "] (right half)" );
+
+		// Create the split loader wrapping the CORRECTED ViewerImgLoader
+		final SplitViewerImgLoader splitLoader = new SplitViewerImgLoader(
+			correctedLoader,  // <-- ViewerImgLoader compatible!
+			new2oldSetupId,
+			newSetupId2Interval,
+			seqDesc
+		);
+
+		System.out.println( "Split loader implements ViewerImgLoader: " +
+			( splitLoader instanceof ViewerImgLoader ? "YES" : "NO" ) );
+
+		// ========== STEP 4: Test ViewerImgLoader-specific features ==========
+		System.out.println( "\n=== STEP 4: Testing ViewerImgLoader features ===" );
+
+		// Test cache control delegation
+		System.out.println( "Cache control available: " + ( splitLoader.getCacheControl() != null ) );
+
+		// Test mipmap levels
+		final ViewerSetupImgLoader< ?, ? > setupImgLoader = splitLoader.getSetupImgLoader( 100 );
+		System.out.println( "Number of mipmap levels: " + setupImgLoader.numMipmapLevels() );
+
+		final double[][] resolutions = setupImgLoader.getMipmapResolutions();
+		System.out.println( "Mipmap resolutions:" );
+		for ( int level = 0; level < resolutions.length; level++ )
+		{
+			System.out.println( "  Level " + level + ": " +
+				resolutions[level][0] + " x " + resolutions[level][1] + " x " + resolutions[level][2] );
+		}
+
+		// ========== STEP 5: Display comparison images ==========
+		System.out.println( "\n=== STEP 5: Displaying images ===" );
+		new ImageJ();
+
+		final int tileId = SETUP_TO_TILE[ setupToShow ][ 1 ];
+
+		// 5a. Show UNCORRECTED original at level 0
+		System.out.println( "Loading uncorrected image (level 0)..." );
+		correctedLoader.setActive( false );
+		final RandomAccessibleInterval< FloatType > uncorrected =
+			correctedLoader.getSetupImgLoader( setupToShow ).getFloatImage( timepoint, 0, false );
+		ImageJFunctions.show( uncorrected, "1. Uncorrected - Setup " + setupToShow + " (tile " + tileId + ")" );
+
+		// 5b. Show CORRECTED at level 0
+		System.out.println( "Loading corrected image (level 0)..." );
+		correctedLoader.setActive( true );
+		final RandomAccessibleInterval< FloatType > corrected =
+			correctedLoader.getSetupImgLoader( setupToShow ).getFloatImage( timepoint, 0, false );
+		ImageJFunctions.show( corrected, "2. Corrected - Setup " + setupToShow + " (tile " + tileId + ")" );
+
+		// 5c. Show CORRECTED + SPLIT (left half) at level 0
+		System.out.println( "Loading corrected + split (left half, level 0)..." );
+		final RandomAccessibleInterval< FloatType > splitLeft =
+			splitLoader.getSetupImgLoader( 100 ).getFloatImage( timepoint, 0, false );
+		ImageJFunctions.show( splitLeft, "3. Corrected+Split LEFT - Setup 100" );
+
+		// 5d. Show at different mipmap level if available
+		if ( setupImgLoader.numMipmapLevels() > 1 )
+		{
+			System.out.println( "Loading corrected + split (left half, level 1)..." );
+			final RandomAccessibleInterval< FloatType > splitLeftLevel1 =
+				splitLoader.getSetupImgLoader( 100 ).getFloatImage( timepoint, 1, false );
+			ImageJFunctions.show( splitLeftLevel1, "4. Corrected+Split LEFT (Level 1) - Setup 100" );
+		}
+
+		// ========== Summary ==========
+		System.out.println( "\n=== VIEWERIMGLOADER CHAIN SUMMARY ===" );
+		System.out.println( "Layer 1 (innermost): " + baseLoader.getClass().getSimpleName() + " [ViewerImgLoader]" );
+		System.out.println( "Layer 2 (middle):    " + correctedLoader.getClass().getSimpleName() + " [ViewerImgLoader]" );
+		System.out.println( "Layer 3 (outermost): " + splitLoader.getClass().getSimpleName() + " [ViewerImgLoader]" );
+		System.out.println( "" );
+		System.out.println( "All layers maintain ViewerImgLoader compatibility:" );
+		System.out.println( "  - Cache control: delegated through chain" );
+		System.out.println( "  - Volatile images: supported at all levels" );
+		System.out.println( "  - Multi-resolution: " + setupImgLoader.numMipmapLevels() + " mipmap levels available" );
+		System.out.println( "" );
+		System.out.println( "Compare the images to verify:" );
+		System.out.println( "  - Image 1 vs 2: See flatfield correction effect" );
+		System.out.println( "  - Image 2 vs 3: Verify split region matches corrected full image" );
+		if ( setupImgLoader.numMipmapLevels() > 1 )
+			System.out.println( "  - Image 3 vs 4: Compare different mipmap levels" );
+		System.out.println( "" );
+		System.out.println( "Tip: Use Image > Adjust > Brightness/Contrast (Ctrl+Shift+C)" );
+	}
+}

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/TestViewerFlatfieldCorrection.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/TestViewerFlatfieldCorrection.java
@@ -22,15 +22,14 @@
  */
 package net.preibisch.mvrecon.fiji.spimdata.imgloaders.flatfield;
 
-import java.io.File;
 import java.util.HashMap;
 
 import bdv.ViewerImgLoader;
 import bdv.ViewerSetupImgLoader;
 import ij.ImageJ;
 import mpicbg.spim.data.SpimDataException;
+import mpicbg.spim.data.sequence.MultiResolutionSetupImgLoader;
 import mpicbg.spim.data.sequence.SequenceDescription;
-import mpicbg.spim.data.sequence.ViewId;
 import mpicbg.spim.data.sequence.ViewSetup;
 import net.imglib2.FinalInterval;
 import net.imglib2.Interval;
@@ -42,12 +41,15 @@ import net.preibisch.mvrecon.fiji.spimdata.XmlIoSpimData2;
 import net.preibisch.mvrecon.fiji.spimdata.imgloaders.splitting.SplitViewerImgLoader;
 
 /**
- * Test class for ViewerFlatfieldCorrectionWrappedImgLoader.
+ * Test class for XML-based ViewerFlatfieldCorrectionWrappedImgLoader.
  *
  * Demonstrates the full ViewerImgLoader-compatible decorator chain:
  *   N5ImageLoader (ViewerImgLoader)
  *       -> ViewerFlatfieldCorrectionWrappedImgLoader (ViewerImgLoader)
  *           -> SplitViewerImgLoader (ViewerImgLoader)
+ *
+ * Loads dataset_corrected_viewer.xml which has flatfield correction configured
+ * directly in the ImageLoader section. No manual configuration needed!
  *
  * This maintains full BDV compatibility throughout the chain, including:
  * - Cache control delegation
@@ -56,92 +58,64 @@ import net.preibisch.mvrecon.fiji.spimdata.imgloaders.splitting.SplitViewerImgLo
  */
 public class TestViewerFlatfieldCorrection
 {
-	// Mapping from ViewSetup ID to Tile ID (from dataset.xml)
-	private static final int[][] SETUP_TO_TILE = {
-		{ 0, 187 },
-		{ 1, 188 },
-		{ 2, 189 },
-		{ 3, 200 },
-		{ 4, 201 },
-		{ 5, 202 },
-		{ 6, 213 },
-		{ 7, 214 },
-		{ 8, 215 }
-	};
-
 	public static void main( String[] args ) throws SpimDataException
 	{
-		// ========== CONFIGURATION ==========
+		// Paths
 		final String basePath = "/Users/innerbergerm/Projects/janelia/multiview-reconstruction/";
-		final String xmlPath = basePath + "data/dataset.xml";
-		final String correctionPath = basePath + "dark_and_flatfields/";
+		final String correctedXmlPath = basePath + "data/dataset_corrected_viewer.xml";
+		final String uncorrectedXmlPath = basePath + "data/dataset.xml";
 
 		// Which setup to demonstrate (0-8)
 		final int setupToShow = 0;
 		final int timepoint = 0;
 
-		// ========== STEP 1: Load dataset and get base ViewerImgLoader ==========
-		System.out.println( "=== STEP 1: Loading dataset ===" );
-		System.out.println( "XML path: " + xmlPath );
+		// ========== STEP 1: Load CORRECTED dataset (from XML with flatfield config) ==========
+		System.out.println( "=== STEP 1: Loading CORRECTED dataset ===");
+		System.out.println( "XML path: " + correctedXmlPath );
 
-		final SpimData2 data = new XmlIoSpimData2().load( xmlPath );
-		final SequenceDescription seqDesc = data.getSequenceDescription();
+		final SpimData2 correctedData = new XmlIoSpimData2().load( correctedXmlPath );
+		final SequenceDescription correctedSeqDesc = correctedData.getSequenceDescription();
 
-		// Verify the base loader is a ViewerImgLoader
-		if ( !( seqDesc.getImgLoader() instanceof ViewerImgLoader ) )
+		// Verify it's a ViewerFlatfieldCorrectionWrappedImgLoader
+		if ( !( correctedSeqDesc.getImgLoader() instanceof ViewerFlatfieldCorrectionWrappedImgLoader ) )
 		{
-			System.err.println( "ERROR: Base loader is not a ViewerImgLoader!" );
-			System.err.println( "Loader type: " + seqDesc.getImgLoader().getClass().getName() );
+			System.err.println( "ERROR: Expected ViewerFlatfieldCorrectionWrappedImgLoader!" );
+			System.err.println( "Loader type: " + correctedSeqDesc.getImgLoader().getClass().getName() );
 			return;
 		}
 
-		final ViewerImgLoader baseLoader = (ViewerImgLoader) seqDesc.getImgLoader();
-		System.out.println( "Base loader type: " + baseLoader.getClass().getSimpleName() );
-		System.out.println( "Base loader implements ViewerImgLoader: YES" );
-
-		// ========== STEP 2: Wrap with ViewerFlatfieldCorrectionWrappedImgLoader ==========
-		System.out.println( "\n=== STEP 2: Wrapping with ViewerFlatfieldCorrectionWrappedImgLoader ===" );
-
 		final ViewerFlatfieldCorrectionWrappedImgLoader correctedLoader =
-			new ViewerFlatfieldCorrectionWrappedImgLoader( baseLoader, true );
+				(ViewerFlatfieldCorrectionWrappedImgLoader) correctedSeqDesc.getImgLoader();
 
-		// Configure correction images for each view setup
-		for ( int[] mapping : SETUP_TO_TILE )
+		System.out.println( "Corrected loader type: " + correctedLoader.getClass().getSimpleName() );
+		System.out.println( "  Correction active: " + correctedLoader.isActive() );
+		System.out.println( "  Caching enabled: " + correctedLoader.isCached() );
+		System.out.println( "  Wrapped loader: " + correctedLoader.getWrappedImgLoader().getClass().getSimpleName() );
+		System.out.println( "  Implements ViewerImgLoader: " + ( correctedLoader instanceof ViewerImgLoader ? "YES" : "NO" ) );
+
+		// ========== STEP 2: Load UNCORRECTED dataset (original XML) ==========
+		System.out.println( "\n=== STEP 2: Loading UNCORRECTED dataset ===" );
+		System.out.println( "XML path: " + uncorrectedXmlPath );
+
+		final SpimData2 uncorrectedData = new XmlIoSpimData2().load( uncorrectedXmlPath );
+		final SequenceDescription uncorrectedSeqDesc = uncorrectedData.getSequenceDescription();
+
+		// Verify the base loader is a ViewerImgLoader
+		if ( !( uncorrectedSeqDesc.getImgLoader() instanceof ViewerImgLoader ) )
 		{
-			final int setupId = mapping[ 0 ];
-			final int tileId = mapping[ 1 ];
-
-			// Find darkfield file
-			final File darkfield = new File( correctionPath + "setup" + tileId + "-AVG_darkfield-fromdata.tif" );
-
-			// Find flatfield file (try both naming conventions)
-			File flatfield = new File( correctionPath + "setup" + tileId + "-flatfield.tif" );
-			if ( !flatfield.exists() )
-				flatfield = new File( correctionPath + "setup" + tileId + "-flatfield (fixed by mirroring).tif" );
-
-			final ViewId viewId = new ViewId( timepoint, setupId );
-
-			if ( darkfield.exists() )
-			{
-				correctedLoader.setDarkImage( viewId, darkfield );
-				System.out.println( "  Setup " + setupId + ": darkfield = " + darkfield.getName() );
-			}
-
-			if ( flatfield.exists() )
-			{
-				correctedLoader.setBrightImage( viewId, flatfield );
-				System.out.println( "  Setup " + setupId + ": flatfield = " + flatfield.getName() );
-			}
+			System.err.println( "ERROR: Base loader is not a ViewerImgLoader!" );
+			System.err.println( "Loader type: " + uncorrectedSeqDesc.getImgLoader().getClass().getName() );
+			return;
 		}
 
-		System.out.println( "Corrected loader implements ViewerImgLoader: " +
-			( correctedLoader instanceof ViewerImgLoader ? "YES" : "NO" ) );
+		final ViewerImgLoader uncorrectedLoader = (ViewerImgLoader) uncorrectedSeqDesc.getImgLoader();
+		System.out.println( "Uncorrected loader type: " + uncorrectedLoader.getClass().getSimpleName() );
 
-		// ========== STEP 3: Wrap with SplitViewerImgLoader ==========
-		System.out.println( "\n=== STEP 3: Wrapping with SplitViewerImgLoader ===" );
+		// ========== STEP 3: Create SplitViewerImgLoader wrapping the corrected loader ==========
+		System.out.println( "\n=== STEP 3: Creating SplitViewerImgLoader ===" );
 
 		// Get original image dimensions for the setup we're demonstrating
-		final ViewSetup vs = seqDesc.getViewSetups().get( setupToShow );
+		final ViewSetup vs = correctedSeqDesc.getViewSetups().get( setupToShow );
 		final long[] dims = new long[ 3 ];
 		vs.getSize().dimensions( dims );
 		System.out.println( "Original image size: " + dims[0] + " x " + dims[1] + " x " + dims[2] );
@@ -176,7 +150,7 @@ public class TestViewerFlatfieldCorrection
 			correctedLoader,  // <-- ViewerImgLoader compatible!
 			new2oldSetupId,
 			newSetupId2Interval,
-			seqDesc
+			correctedSeqDesc
 		);
 
 		System.out.println( "Split loader implements ViewerImgLoader: " +
@@ -204,18 +178,21 @@ public class TestViewerFlatfieldCorrection
 		System.out.println( "\n=== STEP 5: Displaying images ===" );
 		new ImageJ();
 
-		final int tileId = SETUP_TO_TILE[ setupToShow ][ 1 ];
+		// Get tile ID from ViewSetup metadata
+		final int tileId = correctedData.getSequenceDescription()
+				.getViewSetups().get( setupToShow ).getTile().getId();
 
 		// 5a. Show UNCORRECTED original at level 0
 		System.out.println( "Loading uncorrected image (level 0)..." );
-		correctedLoader.setActive( false );
+		@SuppressWarnings("unchecked")
+		final MultiResolutionSetupImgLoader< FloatType > uncorrectedSetupLoader =
+			(MultiResolutionSetupImgLoader< FloatType >) uncorrectedLoader.getSetupImgLoader( setupToShow );
 		final RandomAccessibleInterval< FloatType > uncorrected =
-			correctedLoader.getSetupImgLoader( setupToShow ).getFloatImage( timepoint, 0, false );
+			uncorrectedSetupLoader.getFloatImage( timepoint, 0, false );
 		ImageJFunctions.show( uncorrected, "1. Uncorrected - Setup " + setupToShow + " (tile " + tileId + ")" );
 
 		// 5b. Show CORRECTED at level 0
 		System.out.println( "Loading corrected image (level 0)..." );
-		correctedLoader.setActive( true );
 		final RandomAccessibleInterval< FloatType > corrected =
 			correctedLoader.getSetupImgLoader( setupToShow ).getFloatImage( timepoint, 0, false );
 		ImageJFunctions.show( corrected, "2. Corrected - Setup " + setupToShow + " (tile " + tileId + ")" );
@@ -237,9 +214,12 @@ public class TestViewerFlatfieldCorrection
 
 		// ========== Summary ==========
 		System.out.println( "\n=== VIEWERIMGLOADER CHAIN SUMMARY ===" );
-		System.out.println( "Layer 1 (innermost): " + baseLoader.getClass().getSimpleName() + " [ViewerImgLoader]" );
+		System.out.println( "Layer 1 (innermost): " + correctedLoader.getWrappedImgLoader().getClass().getSimpleName() + " [ViewerImgLoader]" );
 		System.out.println( "Layer 2 (middle):    " + correctedLoader.getClass().getSimpleName() + " [ViewerImgLoader]" );
 		System.out.println( "Layer 3 (outermost): " + splitLoader.getClass().getSimpleName() + " [ViewerImgLoader]" );
+		System.out.println( "" );
+		System.out.println( "Flatfield correction is now configured in the XML!" );
+		System.out.println( "No manual setBrightImage()/setDarkImage() calls needed." );
 		System.out.println( "" );
 		System.out.println( "All layers maintain ViewerImgLoader compatibility:" );
 		System.out.println( "  - Cache control: delegated through chain" );

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/TestViewerFlatfieldCorrection.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/TestViewerFlatfieldCorrection.java
@@ -56,10 +56,8 @@ import net.preibisch.mvrecon.fiji.spimdata.imgloaders.splitting.SplitViewerImgLo
  * - Volatile image support
  * - Multi-resolution mipmap levels
  */
-public class TestViewerFlatfieldCorrection
-{
-	public static void main( String[] args ) throws SpimDataException
-	{
+public class TestViewerFlatfieldCorrection {
+	public static void main(String[] args) throws SpimDataException {
 		// Paths
 		final String basePath = "/Users/innerbergerm/Projects/janelia/multiview-reconstruction/";
 		final String correctedXmlPath = basePath + "data/dataset_corrected_viewer.xml";
@@ -70,80 +68,78 @@ public class TestViewerFlatfieldCorrection
 		final int timepoint = 0;
 
 		// ========== STEP 1: Load CORRECTED dataset (from XML with flatfield config) ==========
-		System.out.println( "=== STEP 1: Loading CORRECTED dataset ===");
-		System.out.println( "XML path: " + correctedXmlPath );
+		System.out.println("=== STEP 1: Loading CORRECTED dataset ===");
+		System.out.println("XML path: " + correctedXmlPath);
 
-		final SpimData2 correctedData = new XmlIoSpimData2().load( correctedXmlPath );
+		final SpimData2 correctedData = new XmlIoSpimData2().load(correctedXmlPath);
 		final SequenceDescription correctedSeqDesc = correctedData.getSequenceDescription();
 
 		// Verify it's a ViewerFlatfieldCorrectionWrappedImgLoader
-		if ( !( correctedSeqDesc.getImgLoader() instanceof ViewerFlatfieldCorrectionWrappedImgLoader ) )
-		{
-			System.err.println( "ERROR: Expected ViewerFlatfieldCorrectionWrappedImgLoader!" );
-			System.err.println( "Loader type: " + correctedSeqDesc.getImgLoader().getClass().getName() );
+		if (!(correctedSeqDesc.getImgLoader() instanceof ViewerFlatfieldCorrectionWrappedImgLoader)) {
+			System.err.println("ERROR: Expected ViewerFlatfieldCorrectionWrappedImgLoader!");
+			System.err.println("Loader type: " + correctedSeqDesc.getImgLoader().getClass().getName());
 			return;
 		}
 
 		final ViewerFlatfieldCorrectionWrappedImgLoader correctedLoader =
 				(ViewerFlatfieldCorrectionWrappedImgLoader) correctedSeqDesc.getImgLoader();
 
-		System.out.println( "Corrected loader type: " + correctedLoader.getClass().getSimpleName() );
-		System.out.println( "  Correction active: " + correctedLoader.isActive() );
-		System.out.println( "  Caching enabled: " + correctedLoader.isCached() );
-		System.out.println( "  Wrapped loader: " + correctedLoader.getWrappedImgLoader().getClass().getSimpleName() );
-		System.out.println( "  Implements ViewerImgLoader: " + ( correctedLoader instanceof ViewerImgLoader ? "YES" : "NO" ) );
+		System.out.println("Corrected loader type: " + correctedLoader.getClass().getSimpleName());
+		System.out.println("  Correction active: " + correctedLoader.isActive());
+		System.out.println("  Caching enabled: " + correctedLoader.isCached());
+		System.out.println("  Wrapped loader: " + correctedLoader.getWrappedImgLoader().getClass().getSimpleName());
+		System.out.println("  Implements ViewerImgLoader: " + (correctedLoader instanceof ViewerImgLoader ? "YES" : "NO"));
 
 		// ========== STEP 2: Load UNCORRECTED dataset (original XML) ==========
-		System.out.println( "\n=== STEP 2: Loading UNCORRECTED dataset ===" );
-		System.out.println( "XML path: " + uncorrectedXmlPath );
+		System.out.println("\n=== STEP 2: Loading UNCORRECTED dataset ===");
+		System.out.println("XML path: " + uncorrectedXmlPath);
 
-		final SpimData2 uncorrectedData = new XmlIoSpimData2().load( uncorrectedXmlPath );
+		final SpimData2 uncorrectedData = new XmlIoSpimData2().load(uncorrectedXmlPath);
 		final SequenceDescription uncorrectedSeqDesc = uncorrectedData.getSequenceDescription();
 
 		// Verify the base loader is a ViewerImgLoader
-		if ( !( uncorrectedSeqDesc.getImgLoader() instanceof ViewerImgLoader ) )
-		{
-			System.err.println( "ERROR: Base loader is not a ViewerImgLoader!" );
-			System.err.println( "Loader type: " + uncorrectedSeqDesc.getImgLoader().getClass().getName() );
+		if (!(uncorrectedSeqDesc.getImgLoader() instanceof ViewerImgLoader)) {
+			System.err.println("ERROR: Base loader is not a ViewerImgLoader!");
+			System.err.println("Loader type: " + uncorrectedSeqDesc.getImgLoader().getClass().getName());
 			return;
 		}
 
 		final ViewerImgLoader uncorrectedLoader = (ViewerImgLoader) uncorrectedSeqDesc.getImgLoader();
-		System.out.println( "Uncorrected loader type: " + uncorrectedLoader.getClass().getSimpleName() );
+		System.out.println("Uncorrected loader type: " + uncorrectedLoader.getClass().getSimpleName());
 
 		// ========== STEP 3: Create SplitViewerImgLoader wrapping the corrected loader ==========
-		System.out.println( "\n=== STEP 3: Creating SplitViewerImgLoader ===" );
+		System.out.println("\n=== STEP 3: Creating SplitViewerImgLoader ===");
 
 		// Get original image dimensions for the setup we're demonstrating
-		final ViewSetup vs = correctedSeqDesc.getViewSetups().get( setupToShow );
-		final long[] dims = new long[ 3 ];
-		vs.getSize().dimensions( dims );
-		System.out.println( "Original image size: " + dims[0] + " x " + dims[1] + " x " + dims[2] );
+		final ViewSetup vs = correctedSeqDesc.getViewSetups().get(setupToShow);
+		final long[] dims = new long[3];
+		vs.getSize().dimensions(dims);
+		System.out.println("Original image size: " + dims[0] + " x " + dims[1] + " x " + dims[2]);
 
 		// Create a simple 2x1 split in X dimension
-		final long splitX = dims[ 0 ] / 2;
+		final long splitX = dims[0] / 2;
 
 		// Define the mappings for split regions
-		final HashMap< Integer, Integer > new2oldSetupId = new HashMap<>();
-		final HashMap< Integer, Interval > newSetupId2Interval = new HashMap<>();
+		final HashMap<Integer, Integer> new2oldSetupId = new HashMap<>();
+		final HashMap<Integer, Interval> newSetupId2Interval = new HashMap<>();
 
 		// Split region 0: left half
-		new2oldSetupId.put( 100, setupToShow );
-		newSetupId2Interval.put( 100, new FinalInterval(
-			new long[] { 0, 0, 0 },
-			new long[] { splitX - 1, dims[1] - 1, dims[2] - 1 }
+		new2oldSetupId.put(100, setupToShow);
+		newSetupId2Interval.put(100, new FinalInterval(
+			new long[] {0, 0, 0},
+			new long[] {splitX - 1, dims[1] - 1, dims[2] - 1}
 		));
 
 		// Split region 1: right half
-		new2oldSetupId.put( 101, setupToShow );
-		newSetupId2Interval.put( 101, new FinalInterval(
-			new long[] { splitX, 0, 0 },
-			new long[] { dims[0] - 1, dims[1] - 1, dims[2] - 1 }
+		new2oldSetupId.put(101, setupToShow);
+		newSetupId2Interval.put(101, new FinalInterval(
+			new long[] {splitX, 0, 0},
+			new long[] {dims[0] - 1, dims[1] - 1, dims[2] - 1}
 		));
 
-		System.out.println( "Created 2 split regions:" );
-		System.out.println( "  Setup 100: X=[0, " + (splitX-1) + "] (left half)" );
-		System.out.println( "  Setup 101: X=[" + splitX + ", " + (dims[0]-1) + "] (right half)" );
+		System.out.println("Created 2 split regions:");
+		System.out.println("  Setup 100: X=[0, " + (splitX-1) + "] (left half)");
+		System.out.println("  Setup 101: X=[" + splitX + ", " + (dims[0]-1) + "] (right half)");
 
 		// Create the split loader wrapping the CORRECTED ViewerImgLoader
 		final SplitViewerImgLoader splitLoader = new SplitViewerImgLoader(
@@ -153,85 +149,83 @@ public class TestViewerFlatfieldCorrection
 			correctedSeqDesc
 		);
 
-		System.out.println( "Split loader implements ViewerImgLoader: " +
-			( splitLoader instanceof ViewerImgLoader ? "YES" : "NO" ) );
+		System.out.println("Split loader implements ViewerImgLoader: " +
+			(splitLoader instanceof ViewerImgLoader ? "YES" : "NO"));
 
 		// ========== STEP 4: Test ViewerImgLoader-specific features ==========
-		System.out.println( "\n=== STEP 4: Testing ViewerImgLoader features ===" );
+		System.out.println("\n=== STEP 4: Testing ViewerImgLoader features ===");
 
 		// Test cache control delegation
-		System.out.println( "Cache control available: " + ( splitLoader.getCacheControl() != null ) );
+		System.out.println("Cache control available: " + (splitLoader.getCacheControl() != null));
 
 		// Test mipmap levels
-		final ViewerSetupImgLoader< ?, ? > setupImgLoader = splitLoader.getSetupImgLoader( 100 );
-		System.out.println( "Number of mipmap levels: " + setupImgLoader.numMipmapLevels() );
+		final ViewerSetupImgLoader<?, ?> setupImgLoader = splitLoader.getSetupImgLoader(100);
+		System.out.println("Number of mipmap levels: " + setupImgLoader.numMipmapLevels());
 
 		final double[][] resolutions = setupImgLoader.getMipmapResolutions();
-		System.out.println( "Mipmap resolutions:" );
-		for ( int level = 0; level < resolutions.length; level++ )
-		{
-			System.out.println( "  Level " + level + ": " +
-				resolutions[level][0] + " x " + resolutions[level][1] + " x " + resolutions[level][2] );
+		System.out.println("Mipmap resolutions:");
+		for (int level = 0; level < resolutions.length; level++) {
+			System.out.println("  Level " + level + ": " +
+				resolutions[level][0] + " x " + resolutions[level][1] + " x " + resolutions[level][2]);
 		}
 
 		// ========== STEP 5: Display comparison images ==========
-		System.out.println( "\n=== STEP 5: Displaying images ===" );
+		System.out.println("\n=== STEP 5: Displaying images ===");
 		new ImageJ();
 
 		// Get tile ID from ViewSetup metadata
 		final int tileId = correctedData.getSequenceDescription()
-				.getViewSetups().get( setupToShow ).getTile().getId();
+				.getViewSetups().get(setupToShow).getTile().getId();
 
 		// 5a. Show UNCORRECTED original at level 0
-		System.out.println( "Loading uncorrected image (level 0)..." );
+		System.out.println("Loading uncorrected image (level 0)...");
 		@SuppressWarnings("unchecked")
-		final MultiResolutionSetupImgLoader< FloatType > uncorrectedSetupLoader =
-			(MultiResolutionSetupImgLoader< FloatType >) uncorrectedLoader.getSetupImgLoader( setupToShow );
-		final RandomAccessibleInterval< FloatType > uncorrected =
-			uncorrectedSetupLoader.getFloatImage( timepoint, 0, false );
-		ImageJFunctions.show( uncorrected, "1. Uncorrected - Setup " + setupToShow + " (tile " + tileId + ")" );
+		final MultiResolutionSetupImgLoader<FloatType> uncorrectedSetupLoader =
+			(MultiResolutionSetupImgLoader<FloatType>) uncorrectedLoader.getSetupImgLoader(setupToShow);
+		final RandomAccessibleInterval<FloatType> uncorrected =
+			uncorrectedSetupLoader.getFloatImage(timepoint, 0, false);
+		ImageJFunctions.show(uncorrected, "1. Uncorrected - Setup " + setupToShow + " (tile " + tileId + ")");
 
 		// 5b. Show CORRECTED at level 0
-		System.out.println( "Loading corrected image (level 0)..." );
-		final RandomAccessibleInterval< FloatType > corrected =
-			correctedLoader.getSetupImgLoader( setupToShow ).getFloatImage( timepoint, 0, false );
-		ImageJFunctions.show( corrected, "2. Corrected - Setup " + setupToShow + " (tile " + tileId + ")" );
+		System.out.println("Loading corrected image (level 0)...");
+		final RandomAccessibleInterval<FloatType> corrected =
+			correctedLoader.getSetupImgLoader(setupToShow).getFloatImage(timepoint, 0, false);
+		ImageJFunctions.show(corrected, "2. Corrected - Setup " + setupToShow + " (tile " + tileId + ")");
 
 		// 5c. Show CORRECTED + SPLIT (left half) at level 0
-		System.out.println( "Loading corrected + split (left half, level 0)..." );
-		final RandomAccessibleInterval< FloatType > splitLeft =
-			splitLoader.getSetupImgLoader( 100 ).getFloatImage( timepoint, 0, false );
-		ImageJFunctions.show( splitLeft, "3. Corrected+Split LEFT - Setup 100" );
+		System.out.println("Loading corrected + split (left half, level 0)...");
+		final RandomAccessibleInterval<FloatType> splitLeft =
+			splitLoader.getSetupImgLoader(100).getFloatImage(timepoint, 0, false);
+		ImageJFunctions.show(splitLeft, "3. Corrected+Split LEFT - Setup 100");
 
 		// 5d. Show at different mipmap level if available
-		if ( setupImgLoader.numMipmapLevels() > 1 )
-		{
-			System.out.println( "Loading corrected + split (left half, level 1)..." );
-			final RandomAccessibleInterval< FloatType > splitLeftLevel1 =
-				splitLoader.getSetupImgLoader( 100 ).getFloatImage( timepoint, 1, false );
-			ImageJFunctions.show( splitLeftLevel1, "4. Corrected+Split LEFT (Level 1) - Setup 100" );
+		if (setupImgLoader.numMipmapLevels() > 1) {
+			System.out.println("Loading corrected + split (left half, level 1)...");
+			final RandomAccessibleInterval<FloatType> splitLeftLevel1 =
+				splitLoader.getSetupImgLoader(100).getFloatImage(timepoint, 1, false);
+			ImageJFunctions.show(splitLeftLevel1, "4. Corrected+Split LEFT (Level 1) - Setup 100");
 		}
 
 		// ========== Summary ==========
-		System.out.println( "\n=== VIEWERIMGLOADER CHAIN SUMMARY ===" );
-		System.out.println( "Layer 1 (innermost): " + correctedLoader.getWrappedImgLoader().getClass().getSimpleName() + " [ViewerImgLoader]" );
-		System.out.println( "Layer 2 (middle):    " + correctedLoader.getClass().getSimpleName() + " [ViewerImgLoader]" );
-		System.out.println( "Layer 3 (outermost): " + splitLoader.getClass().getSimpleName() + " [ViewerImgLoader]" );
-		System.out.println( "" );
-		System.out.println( "Flatfield correction is now configured in the XML!" );
-		System.out.println( "No manual setBrightImage()/setDarkImage() calls needed." );
-		System.out.println( "" );
-		System.out.println( "All layers maintain ViewerImgLoader compatibility:" );
-		System.out.println( "  - Cache control: delegated through chain" );
-		System.out.println( "  - Volatile images: supported at all levels" );
-		System.out.println( "  - Multi-resolution: " + setupImgLoader.numMipmapLevels() + " mipmap levels available" );
-		System.out.println( "" );
-		System.out.println( "Compare the images to verify:" );
-		System.out.println( "  - Image 1 vs 2: See flatfield correction effect" );
-		System.out.println( "  - Image 2 vs 3: Verify split region matches corrected full image" );
-		if ( setupImgLoader.numMipmapLevels() > 1 )
-			System.out.println( "  - Image 3 vs 4: Compare different mipmap levels" );
-		System.out.println( "" );
-		System.out.println( "Tip: Use Image > Adjust > Brightness/Contrast (Ctrl+Shift+C)" );
+		System.out.println("\n=== VIEWERIMGLOADER CHAIN SUMMARY ===");
+		System.out.println("Layer 1 (innermost): " + correctedLoader.getWrappedImgLoader().getClass().getSimpleName() + " [ViewerImgLoader]");
+		System.out.println("Layer 2 (middle):    " + correctedLoader.getClass().getSimpleName() + " [ViewerImgLoader]");
+		System.out.println("Layer 3 (outermost): " + splitLoader.getClass().getSimpleName() + " [ViewerImgLoader]");
+		System.out.println();
+		System.out.println("Flatfield correction is now configured in the XML!");
+		System.out.println("No manual setBrightImage()/setDarkImage() calls needed.");
+		System.out.println();
+		System.out.println("All layers maintain ViewerImgLoader compatibility:");
+		System.out.println("  - Cache control: delegated through chain");
+		System.out.println("  - Volatile images: supported at all levels");
+		System.out.println("  - Multi-resolution: " + setupImgLoader.numMipmapLevels() + " mipmap levels available");
+		System.out.println();
+		System.out.println("Compare the images to verify:");
+		System.out.println("  - Image 1 vs 2: See flatfield correction effect");
+		System.out.println("  - Image 2 vs 3: Verify split region matches corrected full image");
+		if (setupImgLoader.numMipmapLevels() > 1)
+			System.out.println("  - Image 3 vs 4: Compare different mipmap levels");
+		System.out.println();
+		System.out.println("Tip: Use Image > Adjust > Brightness/Contrast (Ctrl+Shift+C)");
 	}
 }

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/TestViewerFlatfieldCorrection.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/TestViewerFlatfieldCorrection.java
@@ -60,7 +60,7 @@ public class TestViewerFlatfieldCorrection {
 	public static void main(String[] args) throws SpimDataException {
 		// Paths
 		final String basePath = "/Users/innerbergerm/Projects/janelia/multiview-reconstruction/";
-		final String correctedXmlPath = basePath + "data/dataset_corrected_zarr.xml";
+		final String correctedXmlPath = basePath + "data/dataset_corrected_viewer_s3.xml";
 		final String uncorrectedXmlPath = basePath + "data/dataset.xml";
 
 		// Which setup to demonstrate (0-8)

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/TestViewerFlatfieldCorrection.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/TestViewerFlatfieldCorrection.java
@@ -60,7 +60,7 @@ public class TestViewerFlatfieldCorrection {
 	public static void main(String[] args) throws SpimDataException {
 		// Paths
 		final String basePath = "/Users/innerbergerm/Projects/janelia/multiview-reconstruction/";
-		final String correctedXmlPath = basePath + "data/dataset_corrected_viewer.xml";
+		final String correctedXmlPath = basePath + "data/dataset_corrected_zarr.xml";
 		final String uncorrectedXmlPath = basePath + "data/dataset.xml";
 
 		// Which setup to demonstrate (0-8)

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/ViewerFlatfieldCorrectionWrappedImgLoader.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/ViewerFlatfieldCorrectionWrappedImgLoader.java
@@ -31,15 +31,9 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import org.janelia.saalfeldlab.n5.N5Reader;
-import org.janelia.saalfeldlab.n5.imglib2.N5Utils;
-import org.janelia.saalfeldlab.n5.universe.StorageFormat;
-
 import bdv.ViewerImgLoader;
 import bdv.ViewerSetupImgLoader;
 import bdv.cache.CacheControl;
-import ij.IJ;
-import ij.ImagePlus;
 import mpicbg.spim.data.generic.sequence.ImgLoaderHint;
 import mpicbg.spim.data.generic.sequence.ImgLoaderHints;
 import mpicbg.spim.data.sequence.MultiResolutionImgLoader;
@@ -54,17 +48,14 @@ import net.imglib2.img.Img;
 import net.imglib2.img.ImgFactory;
 import net.imglib2.img.array.ArrayImgFactory;
 import net.imglib2.img.cell.CellImgFactory;
-import net.imglib2.img.display.imagej.ImageJFunctions;
 import net.imglib2.realtransform.AffineTransform3D;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.real.FloatType;
-import net.imglib2.util.Cast;
 import net.imglib2.util.Pair;
 import net.imglib2.util.ValuePair;
 import net.imglib2.view.Views;
 import net.preibisch.mvrecon.process.fusion.FusionTools;
-import util.URITools;
 
 /**
  * Flatfield correction wrapper for ViewerImgLoader.
@@ -83,17 +74,13 @@ import util.URITools;
  */
 public class ViewerFlatfieldCorrectionWrappedImgLoader
 		implements ViewerImgLoader, MultiResolutionImgLoader {
+
 	private final ViewerImgLoader wrappedImgLoader;
 	private boolean active;
 	private boolean cacheResult;
 
-	private static final Pair<URI, URI> NULL_PAIR = new ValuePair<>(null, null);
-
-	/** Maps ViewId to (brightUri, darkUri) pair */
-	protected final Map<ViewId, Pair<URI, URI>> uriMap;
-
-	/** Cached loaded correction images */
-	protected final Map<URI, RandomAccessibleInterval<FloatType>> raiMap;
+	/** Helper for loading flatfield images */
+	private final FlatfieldImageLoader imageLoader;
 
 	/** Downsampled bright/dark images for each mipmap level */
 	private final Map<Pair<URI, List<Integer>>, RandomAccessibleInterval<FloatType>> dsRaiMap;
@@ -106,26 +93,8 @@ public class ViewerFlatfieldCorrectionWrappedImgLoader
 		this.wrappedImgLoader = wrappedImgLoader;
 		this.active = true;
 		this.cacheResult = cacheResult;
-		this.uriMap = new HashMap<>();
-		this.raiMap = new HashMap<>();
+		this.imageLoader = new FlatfieldImageLoader();
 		this.dsRaiMap = new HashMap<>();
-	}
-
-	// ========== ViewerImgLoader interface ==========
-
-	@Override
-	public ViewerFlatfieldCorrectionWrappedSetupImgLoader<?, ?> getSetupImgLoader(final int setupId) {
-		return new ViewerFlatfieldCorrectionWrappedSetupImgLoader<>(setupId);
-	}
-
-	@Override
-	public CacheControl getCacheControl() {
-		return wrappedImgLoader.getCacheControl();
-	}
-
-	@Override
-	public void setNumFetcherThreads(final int n) {
-		wrappedImgLoader.setNumFetcherThreads(n);
 	}
 
 	// ========== Configuration methods ==========
@@ -151,107 +120,54 @@ public class ViewerFlatfieldCorrectionWrappedImgLoader
 	}
 
 	public void setBrightImage(final ViewId vId, final URI imgUri) {
-		final Pair<URI, URI> oldPair = uriMap.getOrDefault(vId, NULL_PAIR);
-		uriMap.put(vId, new ValuePair<>(imgUri, oldPair.getB()));
+		imageLoader.setBrightImage(vId, imgUri);
 	}
 
 	public void setDarkImage(final ViewId vId, final URI imgUri) {
-		final Pair<URI, URI> oldPair = uriMap.getOrDefault(vId, NULL_PAIR);
-		uriMap.put(vId, new ValuePair<>(oldPair.getA(), imgUri));
+		imageLoader.setDarkImage(vId, imgUri);
 	}
 
 	public void setBrightImage(final ViewId vId, final File imgFile) {
-		setBrightImage(vId, imgFile == null ? null : imgFile.toURI());
+		imageLoader.setBrightImage(vId, imgFile);
 	}
 
 	public void setDarkImage(final ViewId vId, final File imgFile) {
-		setDarkImage(vId, imgFile == null ? null : imgFile.toURI());
+		imageLoader.setDarkImage(vId, imgFile);
+	}
+
+	/**
+	 * Get the URI map for bright/dark images per view.
+	 * @return map from ViewId to (brightUri, darkUri) pair
+	 */
+	public Map<ViewId, Pair<URI, URI>> getUriMap() {
+		return imageLoader.getUriMap();
+	}
+
+	// ========== ViewerImgLoader interface ==========
+
+	@Override
+	public ViewerFlatfieldCorrectionWrappedSetupImgLoader<?, ?> getSetupImgLoader(final int setupId) {
+		return new ViewerFlatfieldCorrectionWrappedSetupImgLoader<>(setupId);
+	}
+
+	@Override
+	public CacheControl getCacheControl() {
+		return wrappedImgLoader.getCacheControl();
+	}
+
+	@Override
+	public void setNumFetcherThreads(final int n) {
+		wrappedImgLoader.setNumFetcherThreads(n);
 	}
 
 	// ========== Image loading helpers ==========
 
 	protected RandomAccessibleInterval<FloatType> getBrightImg(final ViewId vId) {
-		if (!uriMap.containsKey(vId))
-			return null;
-
-		final URI uriToLoad = uriMap.get(vId).getA();
-		if (uriToLoad == null)
-			return null;
-
-		loadImageIfNecessary(uriToLoad);
-		return raiMap.get(uriToLoad);
+		return imageLoader.getBrightImg(vId);
 	}
 
 	protected RandomAccessibleInterval<FloatType> getDarkImg(final ViewId vId) {
-		if (!uriMap.containsKey(vId))
-			return null;
-
-		final URI uriToLoad = uriMap.get(vId).getB();
-		if (uriToLoad == null)
-			return null;
-
-		loadImageIfNecessary(uriToLoad);
-		return raiMap.get(uriToLoad);
-	}
-
-	/**
-	 * Load an image from a URI. Supports:
-	 * - Local TIFF files (via ImageJ)
-	 * - Local/cloud Zarr v3 containers (via N5 API)
-	 * - Local/cloud N5 containers (via N5 API)
-	 */
-	protected void loadImageIfNecessary(final URI uri) {
-		if (raiMap.containsKey(uri))
-			return;
-
-		RandomAccessibleInterval<FloatType> img;
-
-		if (isChunkedFormat(uri)) {
-			// Use N5/Zarr API for chunked formats
-			final StorageFormat format = detectStorageFormat(uri);
-			final N5Reader reader = URITools.instantiateN5Reader(format, uri);
-			final RandomAccessibleInterval<?> raw = N5Utils.open(reader, "");
-			img = RealTypeConverters.convert(Cast.unchecked(raw), new FloatType());
-		} else {
-			// Legacy TIFF path via ImageJ
-			final File file = new File(uri);
-			final ImagePlus imp = IJ.openImage(file.getAbsolutePath());
-			if (imp == null)
-				throw new RuntimeException("Failed to load image from: " + uri);
-			img = ImageJFunctions.convertFloat(imp).copy();
-		}
-
-		raiMap.put(uri, img);
-	}
-
-	/**
-	 * Determine if the URI points to a chunked format (N5/Zarr) vs TIFF.
-	 */
-	private static boolean isChunkedFormat(final URI uri) {
-		final String scheme = uri.getScheme();
-		// Cloud URIs are always chunked format
-		if ("s3".equals(scheme) || "gs".equals(scheme))
-			return true;
-
-		// Check path for .zarr or .n5 extension
-		final String path = uri.getPath();
-		if (path == null)
-			return false;
-
-		final String lowerPath = path.toLowerCase();
-		return lowerPath.endsWith(".zarr") || lowerPath.endsWith(".n5")
-			|| lowerPath.contains(".zarr/") || lowerPath.contains(".n5/");
-	}
-
-	/**
-	 * Detect the storage format from the URI.
-	 */
-	private static StorageFormat detectStorageFormat(final URI uri) {
-		final String path = uri.getPath();
-		if (path != null && path.toLowerCase().contains(".n5"))
-			return StorageFormat.N5;
-		// Default to Zarr v3 for cloud and .zarr paths
-		return StorageFormat.ZARR;
+		return imageLoader.getDarkImg(vId);
 	}
 
 	protected RandomAccessibleInterval<FloatType> getOrCreateBrightImgDownsampled(
@@ -280,7 +196,7 @@ public class ViewerFlatfieldCorrectionWrappedImgLoader
 	) {
 		// Convert to a list here to have a proper hash code for the map key
 		List<Integer> dsFactorList = Arrays.stream(downsamplingFactors).boxed().collect(Collectors.toList());
-		final ValuePair<URI, List<Integer>> key = new ValuePair<>(uriSelector.apply(uriMap.get(vId)), dsFactorList);
+		final ValuePair<URI, List<Integer>> key = new ValuePair<>(uriSelector.apply(imageLoader.getUriMap().get(vId)), dsFactorList);
 
 		if (!dsRaiMap.containsKey(key)) {
 			final RandomAccessibleInterval<FloatType> img = imgGetter.apply(vId);
@@ -294,14 +210,6 @@ public class ViewerFlatfieldCorrectionWrappedImgLoader
 		}
 
 		return dsRaiMap.get(key);
-	}
-
-	/**
-	 * Get the URI map for bright/dark images per view.
-	 * @return map from ViewId to (brightUri, darkUri) pair
-	 */
-	public Map<ViewId, Pair<URI, URI>> getUriMap() {
-		return uriMap;
 	}
 
 	// ========== Inner class: ViewerSetupImgLoader implementation ==========

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/ViewerFlatfieldCorrectionWrappedImgLoader.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/ViewerFlatfieldCorrectionWrappedImgLoader.java
@@ -210,7 +210,7 @@ public class ViewerFlatfieldCorrectionWrappedImgLoader
 			// Use N5/Zarr API for chunked formats
 			final StorageFormat format = detectStorageFormat(uri);
 			final N5Reader reader = URITools.instantiateN5Reader(format, uri);
-			final RandomAccessibleInterval<?> raw = N5Utils.open(reader, "/");
+			final RandomAccessibleInterval<?> raw = N5Utils.open(reader, "");
 			img = RealTypeConverters.convert(Cast.unchecked(raw), new FloatType());
 		} else {
 			// Legacy TIFF path via ImageJ

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/ViewerFlatfieldCorrectionWrappedImgLoader.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/ViewerFlatfieldCorrectionWrappedImgLoader.java
@@ -22,8 +22,6 @@
  */
 package net.preibisch.mvrecon.fiji.spimdata.imgloaders.flatfield;
 
-import java.io.File;
-import java.net.URI;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -83,7 +81,7 @@ public class ViewerFlatfieldCorrectionWrappedImgLoader
 	private final FlatfieldImageLoader imageLoader;
 
 	/** Downsampled bright/dark images for each mipmap level */
-	private final Map<Pair<URI, List<Integer>>, RandomAccessibleInterval<FloatType>> dsRaiMap;
+	private final Map<Pair<FlatfieldImageInfo, List<Integer>>, RandomAccessibleInterval<FloatType>> dsRaiMap;
 
 	public ViewerFlatfieldCorrectionWrappedImgLoader(final ViewerImgLoader wrappedImgLoader) {
 		this(wrappedImgLoader, true);
@@ -119,28 +117,20 @@ public class ViewerFlatfieldCorrectionWrappedImgLoader
 		this.cacheResult = cached;
 	}
 
-	public void setBrightImage(final ViewId vId, final URI imgUri) {
-		imageLoader.setBrightImage(vId, imgUri);
+	public void setBrightImage(final ViewId vId, final FlatfieldImageInfo info) {
+		imageLoader.setBrightImage(vId, info);
 	}
 
-	public void setDarkImage(final ViewId vId, final URI imgUri) {
-		imageLoader.setDarkImage(vId, imgUri);
-	}
-
-	public void setBrightImage(final ViewId vId, final File imgFile) {
-		imageLoader.setBrightImage(vId, imgFile);
-	}
-
-	public void setDarkImage(final ViewId vId, final File imgFile) {
-		imageLoader.setDarkImage(vId, imgFile);
+	public void setDarkImage(final ViewId vId, final FlatfieldImageInfo info) {
+		imageLoader.setDarkImage(vId, info);
 	}
 
 	/**
-	 * Get the URI map for bright/dark images per view.
-	 * @return map from ViewId to (brightUri, darkUri) pair
+	 * Get the info map for bright/dark images per view.
+	 * @return map from ViewId to (brightInfo, darkInfo) pair
 	 */
-	public Map<ViewId, Pair<URI, URI>> getUriMap() {
-		return imageLoader.getUriMap();
+	public Map<ViewId, Pair<FlatfieldImageInfo, FlatfieldImageInfo>> getInfoMap() {
+		return imageLoader.getInfoMap();
 	}
 
 	// ========== ViewerImgLoader interface ==========
@@ -191,12 +181,12 @@ public class ViewerFlatfieldCorrectionWrappedImgLoader
 	private RandomAccessibleInterval<FloatType> getOrCreateDownsampledImg(
 			ViewId vId,
 			int[] downsamplingFactors,
-			Function<Pair<URI, URI>, URI> uriSelector,
+			Function<Pair<FlatfieldImageInfo, FlatfieldImageInfo>, FlatfieldImageInfo> infoSelector,
 			Function<ViewId, RandomAccessibleInterval<FloatType>> imgGetter
 	) {
 		// Convert to a list here to have a proper hash code for the map key
 		List<Integer> dsFactorList = Arrays.stream(downsamplingFactors).boxed().collect(Collectors.toList());
-		final ValuePair<URI, List<Integer>> key = new ValuePair<>(uriSelector.apply(imageLoader.getUriMap().get(vId)), dsFactorList);
+		final ValuePair<FlatfieldImageInfo, List<Integer>> key = new ValuePair<>(infoSelector.apply(imageLoader.getInfoMap().get(vId)), dsFactorList);
 
 		if (!dsRaiMap.containsKey(key)) {
 			final RandomAccessibleInterval<FloatType> img = imgGetter.apply(vId);

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/ViewerFlatfieldCorrectionWrappedImgLoader.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/ViewerFlatfieldCorrectionWrappedImgLoader.java
@@ -1,0 +1,522 @@
+/*-
+ * #%L
+ * Software for the reconstruction of multi-view microscopic acquisitions
+ * like Selective Plane Illumination Microscopy (SPIM) Data.
+ * %%
+ * Copyright (C) 2012 - 2025 Multiview Reconstruction developers.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+package net.preibisch.mvrecon.fiji.spimdata.imgloaders.flatfield;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import bdv.ViewerImgLoader;
+import bdv.ViewerSetupImgLoader;
+import bdv.cache.CacheControl;
+import ij.IJ;
+import ij.ImagePlus;
+import mpicbg.spim.data.generic.sequence.ImgLoaderHint;
+import mpicbg.spim.data.generic.sequence.ImgLoaderHints;
+import mpicbg.spim.data.sequence.MultiResolutionImgLoader;
+import mpicbg.spim.data.sequence.MultiResolutionSetupImgLoader;
+import mpicbg.spim.data.sequence.ViewId;
+import mpicbg.spim.data.sequence.VoxelDimensions;
+import net.imglib2.Dimensions;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.Volatile;
+import net.imglib2.converter.RealTypeConverters;
+import net.imglib2.img.Img;
+import net.imglib2.img.ImgFactory;
+import net.imglib2.img.array.ArrayImgFactory;
+import net.imglib2.img.cell.CellImgFactory;
+import net.imglib2.img.display.imagej.ImageJFunctions;
+import net.imglib2.realtransform.AffineTransform3D;
+import net.imglib2.type.NativeType;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.real.FloatType;
+import net.imglib2.util.Pair;
+import net.imglib2.util.ValuePair;
+import net.imglib2.view.Views;
+import net.preibisch.mvrecon.process.fusion.FusionTools;
+
+/**
+ * Flatfield correction wrapper for ViewerImgLoader.
+ *
+ * This class wraps a ViewerImgLoader and applies flatfield (bright/dark image) correction
+ * on-the-fly. It implements both ViewerImgLoader and MultiResolutionImgLoader interfaces,
+ * making it compatible with BigDataViewer's caching and async loading infrastructure.
+ *
+ * The correction formula is:
+ *   corrected = (source - dark) * mean(bright - dark) / (bright - dark)
+ *
+ * Usage in decorator chain:
+ *   N5ImageLoader (ViewerImgLoader)
+ *       -> ViewerFlatfieldCorrectionWrappedImgLoader (ViewerImgLoader)
+ *           -> SplitViewerImgLoader (ViewerImgLoader)
+ */
+public class ViewerFlatfieldCorrectionWrappedImgLoader
+		implements ViewerImgLoader, MultiResolutionImgLoader
+{
+	private final ViewerImgLoader wrappedImgLoader;
+	private boolean active;
+	private boolean cacheResult;
+
+	/** Maps ViewId to (brightFile, darkFile) pair */
+	protected final Map< ViewId, Pair< File, File > > fileMap;
+
+	/** Cached loaded correction images */
+	protected final Map< File, RandomAccessibleInterval< FloatType > > raiMap;
+
+	/** Downsampled bright/dark images for each mipmap level */
+	private final Map< Pair< File, List< Integer > >, RandomAccessibleInterval< FloatType > > dsRaiMap;
+
+	public ViewerFlatfieldCorrectionWrappedImgLoader( final ViewerImgLoader wrappedImgLoader )
+	{
+		this( wrappedImgLoader, true );
+	}
+
+	public ViewerFlatfieldCorrectionWrappedImgLoader( final ViewerImgLoader wrappedImgLoader, final boolean cacheResult )
+	{
+		this.wrappedImgLoader = wrappedImgLoader;
+		this.active = true;
+		this.cacheResult = cacheResult;
+		this.fileMap = new HashMap<>();
+		this.raiMap = new HashMap<>();
+		this.dsRaiMap = new HashMap<>();
+	}
+
+	// ========== ViewerImgLoader interface ==========
+
+	@Override
+	public ViewerFlatfieldCorrectionWrappedSetupImgLoader< ?, ? > getSetupImgLoader( final int setupId )
+	{
+		return new ViewerFlatfieldCorrectionWrappedSetupImgLoader<>( setupId );
+	}
+
+	@Override
+	public CacheControl getCacheControl()
+	{
+		return wrappedImgLoader.getCacheControl();
+	}
+
+	@Override
+	public void setNumFetcherThreads( final int n )
+	{
+		wrappedImgLoader.setNumFetcherThreads( n );
+	}
+
+	// ========== Configuration methods ==========
+
+	public ViewerImgLoader getWrappedImgLoader()
+	{
+		return wrappedImgLoader;
+	}
+
+	public void setActive( final boolean active )
+	{
+		this.active = active;
+	}
+
+	public boolean isActive()
+	{
+		return active;
+	}
+
+	public boolean isCached()
+	{
+		return cacheResult;
+	}
+
+	public void setCached( final boolean cached )
+	{
+		this.cacheResult = cached;
+	}
+
+	public void setBrightImage( final ViewId vId, final File imgFile )
+	{
+		if ( !fileMap.containsKey( vId ) )
+			fileMap.put( vId, new ValuePair<>( null, null ) );
+
+		final Pair< File, File > oldPair = fileMap.get( vId );
+		fileMap.put( vId, new ValuePair<>( imgFile, oldPair.getB() ) );
+	}
+
+	public void setDarkImage( final ViewId vId, final File imgFile )
+	{
+		if ( !fileMap.containsKey( vId ) )
+			fileMap.put( vId, new ValuePair<>( null, null ) );
+
+		final Pair< File, File > oldPair = fileMap.get( vId );
+		fileMap.put( vId, new ValuePair<>( oldPair.getA(), imgFile ) );
+	}
+
+	// ========== Image loading helpers ==========
+
+	protected RandomAccessibleInterval< FloatType > getBrightImg( final ViewId vId )
+	{
+		if ( !fileMap.containsKey( vId ) )
+			return null;
+
+		final File fileToLoad = fileMap.get( vId ).getA();
+		if ( fileToLoad == null )
+			return null;
+
+		loadFileIfNecessary( fileToLoad );
+		return raiMap.get( fileToLoad );
+	}
+
+	protected RandomAccessibleInterval< FloatType > getDarkImg( final ViewId vId )
+	{
+		if ( !fileMap.containsKey( vId ) )
+			return null;
+
+		final File fileToLoad = fileMap.get( vId ).getB();
+		if ( fileToLoad == null )
+			return null;
+
+		loadFileIfNecessary( fileToLoad );
+		return raiMap.get( fileToLoad );
+	}
+
+	protected void loadFileIfNecessary( final File file )
+	{
+		if ( raiMap.containsKey( file ) )
+			return;
+
+		final ImagePlus imp = IJ.openImage( file.getAbsolutePath() );
+		@SuppressWarnings("unchecked")
+		final RandomAccessibleInterval< FloatType > img =
+				(RandomAccessibleInterval< FloatType >) (RandomAccessibleInterval) ImageJFunctions.convertFloat( imp ).copy();
+
+		raiMap.put( file, img );
+	}
+
+	protected RandomAccessibleInterval< FloatType > getOrCreateBrightImgDownsampled(
+			final ViewId vId,
+			final int[] downsamplingFactors )
+	{
+		if ( !fileMap.containsKey( vId ) || fileMap.get( vId ).getA() == null )
+			return null;
+
+		final ArrayList< Integer > dsFactorList = new ArrayList<>();
+		for ( final int i : downsamplingFactors )
+			dsFactorList.add( i );
+
+		final ValuePair< File, List< Integer > > key = new ValuePair<>( fileMap.get( vId ).getA(), dsFactorList );
+
+		if ( !dsRaiMap.containsKey( key ) )
+		{
+			final RandomAccessibleInterval< FloatType > brightImg = getBrightImg( vId );
+
+			if ( brightImg == null )
+				return null;
+
+			// Add singleton z-dimension for downsampleHDF5 to work
+			final RandomAccessibleInterval< FloatType > downsampled =
+					MultiResolutionFlatfieldCorrectionWrappedImgLoader.downsampleHDF5(
+							Views.addDimension( brightImg, 0, 0 ), downsamplingFactors );
+			dsRaiMap.put( key, downsampled );
+		}
+
+		return dsRaiMap.get( key );
+	}
+
+	protected RandomAccessibleInterval< FloatType > getOrCreateDarkImgDownsampled(
+			final ViewId vId,
+			final int[] downsamplingFactors )
+	{
+		if ( !fileMap.containsKey( vId ) || fileMap.get( vId ).getB() == null )
+			return null;
+
+		final ArrayList< Integer > dsFactorList = new ArrayList<>();
+		for ( final int i : downsamplingFactors )
+			dsFactorList.add( i );
+
+		final ValuePair< File, List< Integer > > key = new ValuePair<>( fileMap.get( vId ).getB(), dsFactorList );
+
+		if ( !dsRaiMap.containsKey( key ) )
+		{
+			final RandomAccessibleInterval< FloatType > darkImg = getDarkImg( vId );
+
+			if ( darkImg == null )
+				return null;
+
+			// Add singleton z-dimension for downsampleHDF5 to work
+			final RandomAccessibleInterval< FloatType > downsampled =
+					MultiResolutionFlatfieldCorrectionWrappedImgLoader.downsampleHDF5(
+							Views.addDimension( darkImg, 0, 0 ), downsamplingFactors );
+			dsRaiMap.put( key, downsampled );
+		}
+
+		return dsRaiMap.get( key );
+	}
+
+	// ========== Inner class: ViewerSetupImgLoader implementation ==========
+
+	public class ViewerFlatfieldCorrectionWrappedSetupImgLoader< T extends RealType< T > & NativeType< T >, V extends Volatile< T > & RealType< V > & NativeType< V > >
+			implements ViewerSetupImgLoader< T, V >, MultiResolutionSetupImgLoader< T >
+	{
+		private final int setupId;
+
+		ViewerFlatfieldCorrectionWrappedSetupImgLoader( final int setupId )
+		{
+			this.setupId = setupId;
+		}
+
+		@SuppressWarnings("unchecked")
+		private ViewerSetupImgLoader< T, V > getUnderlyingViewerSetupImgLoader()
+		{
+			return (ViewerSetupImgLoader< T, V >) wrappedImgLoader.getSetupImgLoader( setupId );
+		}
+
+		@SuppressWarnings("unchecked")
+		private MultiResolutionSetupImgLoader< T > getUnderlyingMultiResSetupImgLoader()
+		{
+			// The wrapped ViewerImgLoader should also be a MultiResolutionImgLoader
+			return (MultiResolutionSetupImgLoader< T >) ((MultiResolutionImgLoader) wrappedImgLoader).getSetupImgLoader( setupId );
+		}
+
+		// ========== Regular image access ==========
+
+		@Override
+		public RandomAccessibleInterval< T > getImage( final int timepointId, final ImgLoaderHint... hints )
+		{
+			return getImage( timepointId, 0, hints );
+		}
+
+		@Override
+		public RandomAccessibleInterval< T > getImage( final int timepointId, final int level, final ImgLoaderHint... hints )
+		{
+			final ViewerSetupImgLoader< T, V > viewerSetupIL = getUnderlyingViewerSetupImgLoader();
+			final MultiResolutionSetupImgLoader< T > multiResSetupIL = getUnderlyingMultiResSetupImgLoader();
+
+			if ( !active )
+				return viewerSetupIL.getImage( timepointId, level, hints );
+
+			final int n = multiResSetupIL.getImageSize( timepointId ).numDimensions();
+
+			// Calculate downsampling factors for this mipmap level
+			final int[] dsFactors = new int[ n ];
+			final double[] dsD = viewerSetupIL.getMipmapResolutions()[ level ];
+			for ( int d = 0; d < n; d++ )
+				dsFactors[ d ] = (int) dsD[ d ];
+			// Don't downsample z for 2D correction images
+			dsFactors[ n - 1 ] = 1;
+
+			@SuppressWarnings("unchecked")
+			RandomAccessibleInterval< T > rai = FlatFieldCorrectedRandomAccessibleIntervals.create(
+					viewerSetupIL.getImage( timepointId, level, hints ),
+					getOrCreateBrightImgDownsampled( new ViewId( timepointId, setupId ), dsFactors ),
+					getOrCreateDarkImgDownsampled( new ViewId( timepointId, setupId ), dsFactors ) );
+
+			// Handle LOAD_COMPLETELY hint
+			boolean loadCompletelyRequested = false;
+			for ( final ImgLoaderHint hint : hints )
+				if ( hint == ImgLoaderHints.LOAD_COMPLETELY )
+					loadCompletelyRequested = true;
+
+			if ( loadCompletelyRequested )
+			{
+				long numPx = 1;
+				for ( int d = 0; d < rai.numDimensions(); d++ )
+					numPx *= rai.dimension( d );
+
+				final ImgFactory< T > imgFactory;
+				if ( Math.log( numPx ) / Math.log( 2 ) < 31 )
+					imgFactory = new ArrayImgFactory<>();
+				else
+					imgFactory = new CellImgFactory<>();
+
+				final Img< T > loadedImg = imgFactory.create( rai, getImageType() );
+				RealTypeConverters.copyFromTo( Views.extendZero( rai ), loadedImg );
+
+				rai = loadedImg;
+			}
+			else if ( cacheResult )
+			{
+				final int[] cellSize = new int[ rai.numDimensions() ];
+				Arrays.fill( cellSize, 1 );
+				for ( int d = 0; d < rai.numDimensions() - 1; d++ )
+					cellSize[ d ] = (int) rai.dimension( d );
+				rai = FusionTools.cacheRandomAccessibleInterval( rai, Long.MAX_VALUE,
+						Views.iterable( rai ).firstElement().createVariable(), cellSize );
+			}
+
+			return rai;
+		}
+
+		// ========== Volatile image access ==========
+
+		@Override
+		public RandomAccessibleInterval< V > getVolatileImage( final int timepointId, final int level, final ImgLoaderHint... hints )
+		{
+			final ViewerSetupImgLoader< T, V > viewerSetupIL = getUnderlyingViewerSetupImgLoader();
+			final MultiResolutionSetupImgLoader< T > multiResSetupIL = getUnderlyingMultiResSetupImgLoader();
+
+			if ( !active )
+				return viewerSetupIL.getVolatileImage( timepointId, level, hints );
+
+			final int n = multiResSetupIL.getImageSize( timepointId ).numDimensions();
+
+			// Calculate downsampling factors for this mipmap level
+			final int[] dsFactors = new int[ n ];
+			final double[] dsD = viewerSetupIL.getMipmapResolutions()[ level ];
+			for ( int d = 0; d < n; d++ )
+				dsFactors[ d ] = (int) dsD[ d ];
+			dsFactors[ n - 1 ] = 1;
+
+			// Apply correction to volatile image
+			// Note: The volatile validity flag propagation may not be perfect,
+			// but BDV will re-request invalid pixels automatically
+			@SuppressWarnings("unchecked")
+			final RandomAccessibleInterval< V > rai = FlatFieldCorrectedRandomAccessibleIntervals.create(
+					viewerSetupIL.getVolatileImage( timepointId, level, hints ),
+					getOrCreateBrightImgDownsampled( new ViewId( timepointId, setupId ), dsFactors ),
+					getOrCreateDarkImgDownsampled( new ViewId( timepointId, setupId ), dsFactors ),
+					getVolatileImageType() );
+
+			return rai;
+		}
+
+		// ========== Float image access ==========
+
+		@Override
+		public RandomAccessibleInterval< FloatType > getFloatImage( final int timepointId, final boolean normalize, final ImgLoaderHint... hints )
+		{
+			return getFloatImage( timepointId, 0, normalize, hints );
+		}
+
+		@Override
+		public RandomAccessibleInterval< FloatType > getFloatImage( final int timepointId, final int level, final boolean normalize, final ImgLoaderHint... hints )
+		{
+			final ViewerSetupImgLoader< T, V > viewerSetupIL = getUnderlyingViewerSetupImgLoader();
+			final MultiResolutionSetupImgLoader< T > multiResSetupIL = getUnderlyingMultiResSetupImgLoader();
+
+			if ( !active )
+				return multiResSetupIL.getFloatImage( timepointId, level, normalize, hints );
+
+			final int n = multiResSetupIL.getImageSize( timepointId ).numDimensions();
+
+			final int[] dsFactors = new int[ n ];
+			final double[] dsD = viewerSetupIL.getMipmapResolutions()[ level ];
+			for ( int d = 0; d < n; d++ )
+				dsFactors[ d ] = (int) dsD[ d ];
+			dsFactors[ n - 1 ] = 1;
+
+			RandomAccessibleInterval< FloatType > rai = FlatFieldCorrectedRandomAccessibleIntervals.create(
+					viewerSetupIL.getImage( timepointId, level, hints ),
+					getOrCreateBrightImgDownsampled( new ViewId( timepointId, setupId ), dsFactors ),
+					getOrCreateDarkImgDownsampled( new ViewId( timepointId, setupId ), dsFactors ),
+					new FloatType() );
+
+			if ( normalize )
+			{
+				rai = new VirtuallyNormalizedRandomAccessibleInterval<>( rai );
+			}
+
+			// Handle caching/loading
+			boolean loadCompletelyRequested = false;
+			for ( final ImgLoaderHint hint : hints )
+				if ( hint == ImgLoaderHints.LOAD_COMPLETELY )
+					loadCompletelyRequested = true;
+
+			if ( loadCompletelyRequested )
+			{
+				long numPx = 1;
+				for ( int d = 0; d < rai.numDimensions(); d++ )
+					numPx *= rai.dimension( d );
+
+				final ImgFactory< FloatType > imgFactory;
+				if ( Math.log( numPx ) / Math.log( 2 ) < 31 )
+					imgFactory = new ArrayImgFactory<>();
+				else
+					imgFactory = new CellImgFactory<>();
+
+				final Img< FloatType > loadedImg = imgFactory.create( rai, new FloatType() );
+				RealTypeConverters.copyFromTo( Views.extendZero( rai ), loadedImg );
+
+				rai = loadedImg;
+			}
+			else if ( cacheResult )
+			{
+				final int[] cellSize = new int[ rai.numDimensions() ];
+				Arrays.fill( cellSize, 1 );
+				for ( int d = 0; d < rai.numDimensions() - 1; d++ )
+					cellSize[ d ] = (int) rai.dimension( d );
+				rai = FusionTools.cacheRandomAccessibleInterval( rai, Long.MAX_VALUE,
+						new FloatType(), cellSize );
+			}
+
+			return rai;
+		}
+
+		// ========== Metadata delegation ==========
+
+		@Override
+		public T getImageType()
+		{
+			return getUnderlyingViewerSetupImgLoader().getImageType();
+		}
+
+		@Override
+		public V getVolatileImageType()
+		{
+			return getUnderlyingViewerSetupImgLoader().getVolatileImageType();
+		}
+
+		@Override
+		public double[][] getMipmapResolutions()
+		{
+			return getUnderlyingViewerSetupImgLoader().getMipmapResolutions();
+		}
+
+		@Override
+		public AffineTransform3D[] getMipmapTransforms()
+		{
+			return getUnderlyingViewerSetupImgLoader().getMipmapTransforms();
+		}
+
+		@Override
+		public int numMipmapLevels()
+		{
+			return getUnderlyingViewerSetupImgLoader().numMipmapLevels();
+		}
+
+		@Override
+		public Dimensions getImageSize( final int timepointId )
+		{
+			return getUnderlyingMultiResSetupImgLoader().getImageSize( timepointId );
+		}
+
+		@Override
+		public Dimensions getImageSize( final int timepointId, final int level )
+		{
+			return getUnderlyingMultiResSetupImgLoader().getImageSize( timepointId, level );
+		}
+
+		@Override
+		public VoxelDimensions getVoxelSize( final int timepointId )
+		{
+			return getUnderlyingMultiResSetupImgLoader().getVoxelSize( timepointId );
+		}
+	}
+}

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/ViewerFlatfieldCorrectionWrappedImgLoader.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/ViewerFlatfieldCorrectionWrappedImgLoader.java
@@ -28,6 +28,8 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import bdv.ViewerImgLoader;
 import bdv.ViewerSetupImgLoader;
@@ -192,54 +194,40 @@ public class ViewerFlatfieldCorrectionWrappedImgLoader
 
 	protected RandomAccessibleInterval<FloatType> getOrCreateBrightImgDownsampled(
 			final ViewId vId,
-			final int[] downsamplingFactors) {
-		if (!fileMap.containsKey(vId) || fileMap.get(vId).getA() == null)
-			return null;
-
-		final ArrayList<Integer> dsFactorList = new ArrayList<>();
-		for (final int i : downsamplingFactors)
-			dsFactorList.add(i);
-
-		final ValuePair<File, List<Integer>> key = new ValuePair<>(fileMap.get(vId).getA(), dsFactorList);
-
-		if (!dsRaiMap.containsKey(key)) {
-			final RandomAccessibleInterval<FloatType> brightImg = getBrightImg(vId);
-
-			if (brightImg == null)
-				return null;
-
-			// Add singleton z-dimension for downsampleHDF5 to work
-			final RandomAccessibleInterval<FloatType> downsampled =
-					MultiResolutionFlatfieldCorrectionWrappedImgLoader.downsampleHDF5(
-							Views.addDimension(brightImg, 0, 0), downsamplingFactors);
-			dsRaiMap.put(key, downsampled);
-		}
-
-		return dsRaiMap.get(key);
+			final int[] downsamplingFactors
+	) {
+		return getOrCreateDownsampledImg(vId, downsamplingFactors, Pair::getA, this::getBrightImg);
 	}
 
 	protected RandomAccessibleInterval<FloatType> getOrCreateDarkImgDownsampled(
 			final ViewId vId,
-			final int[] downsamplingFactors) {
-		if (!fileMap.containsKey(vId) || fileMap.get(vId).getB() == null)
-			return null;
+			final int[] downsamplingFactors
+	) {
+		return getOrCreateDownsampledImg(vId, downsamplingFactors, Pair::getB, this::getDarkImg);
+	}
 
-		final ArrayList<Integer> dsFactorList = new ArrayList<>();
-		for (final int i : downsamplingFactors)
-			dsFactorList.add(i);
-
-		final ValuePair<File, List<Integer>> key = new ValuePair<>(fileMap.get(vId).getB(), dsFactorList);
+	/**
+	 * Generic method to get a downsampled image or do downsampling on the fly. The bright image
+	 * is stored in the A element of the pair, the dark image in B.
+	 */
+	private RandomAccessibleInterval<FloatType> getOrCreateDownsampledImg(
+			ViewId vId,
+			int[] downsamplingFactors,
+			Function<Pair<File, File>, File> fileSelector,
+			Function<ViewId, RandomAccessibleInterval<FloatType>> imgGetter
+	) {
+		// Convert to a list here to have a proper hash code for the map key
+		List<Integer> dsFactorList = Arrays.stream(downsamplingFactors).boxed().collect(Collectors.toList());
+		final ValuePair<File, List<Integer>> key = new ValuePair<>(fileSelector.apply(fileMap.get(vId)), dsFactorList);
 
 		if (!dsRaiMap.containsKey(key)) {
-			final RandomAccessibleInterval<FloatType> darkImg = getDarkImg(vId);
+			final RandomAccessibleInterval<FloatType> img = imgGetter.apply(vId);
 
-			if (darkImg == null)
+			if (img == null)
 				return null;
 
-			// Add singleton z-dimension for downsampleHDF5 to work
 			final RandomAccessibleInterval<FloatType> downsampled =
-					MultiResolutionFlatfieldCorrectionWrappedImgLoader.downsampleHDF5(
-							Views.addDimension(darkImg, 0, 0), downsamplingFactors);
+					MultiResolutionFlatfieldCorrectionWrappedImgLoader.downsampleHDF5(img, downsamplingFactors);
 			dsRaiMap.put(key, downsampled);
 		}
 

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/ViewerFlatfieldCorrectionWrappedImgLoader.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/ViewerFlatfieldCorrectionWrappedImgLoader.java
@@ -74,28 +74,25 @@ import net.preibisch.mvrecon.process.fusion.FusionTools;
  *           -> SplitViewerImgLoader (ViewerImgLoader)
  */
 public class ViewerFlatfieldCorrectionWrappedImgLoader
-		implements ViewerImgLoader, MultiResolutionImgLoader
-{
+		implements ViewerImgLoader, MultiResolutionImgLoader {
 	private final ViewerImgLoader wrappedImgLoader;
 	private boolean active;
 	private boolean cacheResult;
 
 	/** Maps ViewId to (brightFile, darkFile) pair */
-	protected final Map< ViewId, Pair< File, File > > fileMap;
+	protected final Map<ViewId, Pair<File, File>> fileMap;
 
 	/** Cached loaded correction images */
-	protected final Map< File, RandomAccessibleInterval< FloatType > > raiMap;
+	protected final Map<File, RandomAccessibleInterval<FloatType>> raiMap;
 
 	/** Downsampled bright/dark images for each mipmap level */
-	private final Map< Pair< File, List< Integer > >, RandomAccessibleInterval< FloatType > > dsRaiMap;
+	private final Map<Pair<File, List<Integer>>, RandomAccessibleInterval<FloatType>> dsRaiMap;
 
-	public ViewerFlatfieldCorrectionWrappedImgLoader( final ViewerImgLoader wrappedImgLoader )
-	{
-		this( wrappedImgLoader, true );
+	public ViewerFlatfieldCorrectionWrappedImgLoader(final ViewerImgLoader wrappedImgLoader) {
+		this(wrappedImgLoader, true);
 	}
 
-	public ViewerFlatfieldCorrectionWrappedImgLoader( final ViewerImgLoader wrappedImgLoader, final boolean cacheResult )
-	{
+	public ViewerFlatfieldCorrectionWrappedImgLoader(final ViewerImgLoader wrappedImgLoader, final boolean cacheResult) {
 		this.wrappedImgLoader = wrappedImgLoader;
 		this.active = true;
 		this.cacheResult = cacheResult;
@@ -107,258 +104,229 @@ public class ViewerFlatfieldCorrectionWrappedImgLoader
 	// ========== ViewerImgLoader interface ==========
 
 	@Override
-	public ViewerFlatfieldCorrectionWrappedSetupImgLoader< ?, ? > getSetupImgLoader( final int setupId )
-	{
-		return new ViewerFlatfieldCorrectionWrappedSetupImgLoader<>( setupId );
+	public ViewerFlatfieldCorrectionWrappedSetupImgLoader<?, ?> getSetupImgLoader(final int setupId) {
+		return new ViewerFlatfieldCorrectionWrappedSetupImgLoader<>(setupId);
 	}
 
 	@Override
-	public CacheControl getCacheControl()
-	{
+	public CacheControl getCacheControl() {
 		return wrappedImgLoader.getCacheControl();
 	}
 
 	@Override
-	public void setNumFetcherThreads( final int n )
-	{
-		wrappedImgLoader.setNumFetcherThreads( n );
+	public void setNumFetcherThreads(final int n) {
+		wrappedImgLoader.setNumFetcherThreads(n);
 	}
 
 	// ========== Configuration methods ==========
 
-	public ViewerImgLoader getWrappedImgLoader()
-	{
+	public ViewerImgLoader getWrappedImgLoader() {
 		return wrappedImgLoader;
 	}
 
-	public void setActive( final boolean active )
-	{
+	public void setActive(final boolean active) {
 		this.active = active;
 	}
 
-	public boolean isActive()
-	{
+	public boolean isActive() {
 		return active;
 	}
 
-	public boolean isCached()
-	{
+	public boolean isCached() {
 		return cacheResult;
 	}
 
-	public void setCached( final boolean cached )
-	{
+	public void setCached(final boolean cached) {
 		this.cacheResult = cached;
 	}
 
-	public void setBrightImage( final ViewId vId, final File imgFile )
-	{
-		if ( !fileMap.containsKey( vId ) )
-			fileMap.put( vId, new ValuePair<>( null, null ) );
+	public void setBrightImage(final ViewId vId, final File imgFile) {
+		if (!fileMap.containsKey(vId))
+			fileMap.put(vId, new ValuePair<>(null, null));
 
-		final Pair< File, File > oldPair = fileMap.get( vId );
-		fileMap.put( vId, new ValuePair<>( imgFile, oldPair.getB() ) );
+        fileMap.compute(vId, (k, oldPair) -> new ValuePair<>(imgFile, oldPair.getB()));
 	}
 
-	public void setDarkImage( final ViewId vId, final File imgFile )
-	{
-		if ( !fileMap.containsKey( vId ) )
-			fileMap.put( vId, new ValuePair<>( null, null ) );
+	public void setDarkImage(final ViewId vId, final File imgFile) {
+		if (!fileMap.containsKey(vId))
+			fileMap.put(vId, new ValuePair<>(null, null));
 
-		final Pair< File, File > oldPair = fileMap.get( vId );
-		fileMap.put( vId, new ValuePair<>( oldPair.getA(), imgFile ) );
+        fileMap.compute(vId, (k, oldPair) -> new ValuePair<>(oldPair.getA(), imgFile));
 	}
 
 	// ========== Image loading helpers ==========
 
-	protected RandomAccessibleInterval< FloatType > getBrightImg( final ViewId vId )
-	{
-		if ( !fileMap.containsKey( vId ) )
+	protected RandomAccessibleInterval<FloatType> getBrightImg(final ViewId vId) {
+		if (!fileMap.containsKey(vId))
 			return null;
 
-		final File fileToLoad = fileMap.get( vId ).getA();
-		if ( fileToLoad == null )
+		final File fileToLoad = fileMap.get(vId).getA();
+		if (fileToLoad == null)
 			return null;
 
-		loadFileIfNecessary( fileToLoad );
-		return raiMap.get( fileToLoad );
+		loadFileIfNecessary(fileToLoad);
+		return raiMap.get(fileToLoad);
 	}
 
-	protected RandomAccessibleInterval< FloatType > getDarkImg( final ViewId vId )
-	{
-		if ( !fileMap.containsKey( vId ) )
+	protected RandomAccessibleInterval<FloatType> getDarkImg(final ViewId vId) {
+		if (!fileMap.containsKey(vId))
 			return null;
 
-		final File fileToLoad = fileMap.get( vId ).getB();
-		if ( fileToLoad == null )
+		final File fileToLoad = fileMap.get(vId).getB();
+		if (fileToLoad == null)
 			return null;
 
-		loadFileIfNecessary( fileToLoad );
-		return raiMap.get( fileToLoad );
+		loadFileIfNecessary(fileToLoad);
+		return raiMap.get(fileToLoad);
 	}
 
-	protected void loadFileIfNecessary( final File file )
-	{
-		if ( raiMap.containsKey( file ) )
+	protected void loadFileIfNecessary(final File file) {
+		if (raiMap.containsKey(file))
 			return;
 
-		final ImagePlus imp = IJ.openImage( file.getAbsolutePath() );
-		@SuppressWarnings("unchecked")
-		final RandomAccessibleInterval< FloatType > img =
-				(RandomAccessibleInterval< FloatType >) (RandomAccessibleInterval) ImageJFunctions.convertFloat( imp ).copy();
+		final ImagePlus imp = IJ.openImage(file.getAbsolutePath());
+		final RandomAccessibleInterval<FloatType> img = ImageJFunctions.convertFloat(imp).copy();
 
-		raiMap.put( file, img );
+		raiMap.put(file, img);
 	}
 
-	protected RandomAccessibleInterval< FloatType > getOrCreateBrightImgDownsampled(
+	protected RandomAccessibleInterval<FloatType> getOrCreateBrightImgDownsampled(
 			final ViewId vId,
-			final int[] downsamplingFactors )
-	{
-		if ( !fileMap.containsKey( vId ) || fileMap.get( vId ).getA() == null )
+			final int[] downsamplingFactors) {
+		if (!fileMap.containsKey(vId) || fileMap.get(vId).getA() == null)
 			return null;
 
-		final ArrayList< Integer > dsFactorList = new ArrayList<>();
-		for ( final int i : downsamplingFactors )
-			dsFactorList.add( i );
+		final ArrayList<Integer> dsFactorList = new ArrayList<>();
+		for (final int i : downsamplingFactors)
+			dsFactorList.add(i);
 
-		final ValuePair< File, List< Integer > > key = new ValuePair<>( fileMap.get( vId ).getA(), dsFactorList );
+		final ValuePair<File, List<Integer>> key = new ValuePair<>(fileMap.get(vId).getA(), dsFactorList);
 
-		if ( !dsRaiMap.containsKey( key ) )
-		{
-			final RandomAccessibleInterval< FloatType > brightImg = getBrightImg( vId );
+		if (!dsRaiMap.containsKey(key)) {
+			final RandomAccessibleInterval<FloatType> brightImg = getBrightImg(vId);
 
-			if ( brightImg == null )
+			if (brightImg == null)
 				return null;
 
 			// Add singleton z-dimension for downsampleHDF5 to work
-			final RandomAccessibleInterval< FloatType > downsampled =
+			final RandomAccessibleInterval<FloatType> downsampled =
 					MultiResolutionFlatfieldCorrectionWrappedImgLoader.downsampleHDF5(
-							Views.addDimension( brightImg, 0, 0 ), downsamplingFactors );
-			dsRaiMap.put( key, downsampled );
+							Views.addDimension(brightImg, 0, 0), downsamplingFactors);
+			dsRaiMap.put(key, downsampled);
 		}
 
-		return dsRaiMap.get( key );
+		return dsRaiMap.get(key);
 	}
 
-	protected RandomAccessibleInterval< FloatType > getOrCreateDarkImgDownsampled(
+	protected RandomAccessibleInterval<FloatType> getOrCreateDarkImgDownsampled(
 			final ViewId vId,
-			final int[] downsamplingFactors )
-	{
-		if ( !fileMap.containsKey( vId ) || fileMap.get( vId ).getB() == null )
+			final int[] downsamplingFactors) {
+		if (!fileMap.containsKey(vId) || fileMap.get(vId).getB() == null)
 			return null;
 
-		final ArrayList< Integer > dsFactorList = new ArrayList<>();
-		for ( final int i : downsamplingFactors )
-			dsFactorList.add( i );
+		final ArrayList<Integer> dsFactorList = new ArrayList<>();
+		for (final int i : downsamplingFactors)
+			dsFactorList.add(i);
 
-		final ValuePair< File, List< Integer > > key = new ValuePair<>( fileMap.get( vId ).getB(), dsFactorList );
+		final ValuePair<File, List<Integer>> key = new ValuePair<>(fileMap.get(vId).getB(), dsFactorList);
 
-		if ( !dsRaiMap.containsKey( key ) )
-		{
-			final RandomAccessibleInterval< FloatType > darkImg = getDarkImg( vId );
+		if (!dsRaiMap.containsKey(key)) {
+			final RandomAccessibleInterval<FloatType> darkImg = getDarkImg(vId);
 
-			if ( darkImg == null )
+			if (darkImg == null)
 				return null;
 
 			// Add singleton z-dimension for downsampleHDF5 to work
-			final RandomAccessibleInterval< FloatType > downsampled =
+			final RandomAccessibleInterval<FloatType> downsampled =
 					MultiResolutionFlatfieldCorrectionWrappedImgLoader.downsampleHDF5(
-							Views.addDimension( darkImg, 0, 0 ), downsamplingFactors );
-			dsRaiMap.put( key, downsampled );
+							Views.addDimension(darkImg, 0, 0), downsamplingFactors);
+			dsRaiMap.put(key, downsampled);
 		}
 
-		return dsRaiMap.get( key );
+		return dsRaiMap.get(key);
 	}
 
 	// ========== Inner class: ViewerSetupImgLoader implementation ==========
 
-	public class ViewerFlatfieldCorrectionWrappedSetupImgLoader< T extends RealType< T > & NativeType< T >, V extends Volatile< T > & RealType< V > & NativeType< V > >
-			implements ViewerSetupImgLoader< T, V >, MultiResolutionSetupImgLoader< T >
-	{
+	public class ViewerFlatfieldCorrectionWrappedSetupImgLoader<T extends RealType<T> & NativeType<T>, V extends Volatile<T> & RealType<V> & NativeType<V>>
+			implements ViewerSetupImgLoader<T, V>, MultiResolutionSetupImgLoader<T> {
 		private final int setupId;
 
-		ViewerFlatfieldCorrectionWrappedSetupImgLoader( final int setupId )
-		{
+		ViewerFlatfieldCorrectionWrappedSetupImgLoader(final int setupId) {
 			this.setupId = setupId;
 		}
 
 		@SuppressWarnings("unchecked")
-		private ViewerSetupImgLoader< T, V > getUnderlyingViewerSetupImgLoader()
-		{
-			return (ViewerSetupImgLoader< T, V >) wrappedImgLoader.getSetupImgLoader( setupId );
+		private ViewerSetupImgLoader<T, V> getUnderlyingViewerSetupImgLoader() {
+			return (ViewerSetupImgLoader<T, V>) wrappedImgLoader.getSetupImgLoader(setupId);
 		}
 
 		@SuppressWarnings("unchecked")
-		private MultiResolutionSetupImgLoader< T > getUnderlyingMultiResSetupImgLoader()
-		{
+		private MultiResolutionSetupImgLoader<T> getUnderlyingMultiResSetupImgLoader() {
 			// The wrapped ViewerImgLoader should also be a MultiResolutionImgLoader
-			return (MultiResolutionSetupImgLoader< T >) ((MultiResolutionImgLoader) wrappedImgLoader).getSetupImgLoader( setupId );
+			return (MultiResolutionSetupImgLoader<T>) ((MultiResolutionImgLoader) wrappedImgLoader).getSetupImgLoader(setupId);
 		}
 
 		// ========== Regular image access ==========
 
 		@Override
-		public RandomAccessibleInterval< T > getImage( final int timepointId, final ImgLoaderHint... hints )
-		{
-			return getImage( timepointId, 0, hints );
+		public RandomAccessibleInterval<T> getImage(final int timepointId, final ImgLoaderHint... hints) {
+			return getImage(timepointId, 0, hints);
 		}
 
 		@Override
-		public RandomAccessibleInterval< T > getImage( final int timepointId, final int level, final ImgLoaderHint... hints )
-		{
-			final ViewerSetupImgLoader< T, V > viewerSetupIL = getUnderlyingViewerSetupImgLoader();
-			final MultiResolutionSetupImgLoader< T > multiResSetupIL = getUnderlyingMultiResSetupImgLoader();
+		public RandomAccessibleInterval<T> getImage(final int timepointId, final int level, final ImgLoaderHint... hints) {
+			final ViewerSetupImgLoader<T, V> viewerSetupIL = getUnderlyingViewerSetupImgLoader();
+			final MultiResolutionSetupImgLoader<T> multiResSetupIL = getUnderlyingMultiResSetupImgLoader();
 
-			if ( !active )
-				return viewerSetupIL.getImage( timepointId, level, hints );
+			if (!active)
+				return viewerSetupIL.getImage(timepointId, level, hints);
 
-			final int n = multiResSetupIL.getImageSize( timepointId ).numDimensions();
+			final int n = multiResSetupIL.getImageSize(timepointId).numDimensions();
 
 			// Calculate downsampling factors for this mipmap level
-			final int[] dsFactors = new int[ n ];
-			final double[] dsD = viewerSetupIL.getMipmapResolutions()[ level ];
-			for ( int d = 0; d < n; d++ )
-				dsFactors[ d ] = (int) dsD[ d ];
+			final int[] dsFactors = new int[n];
+			final double[] dsD = viewerSetupIL.getMipmapResolutions()[level];
+			for (int d = 0; d < n; d++)
+				dsFactors[d] = (int) dsD[d];
 			// Don't downsample z for 2D correction images
-			dsFactors[ n - 1 ] = 1;
+			dsFactors[n - 1] = 1;
 
-			@SuppressWarnings("unchecked")
-			RandomAccessibleInterval< T > rai = FlatFieldCorrectedRandomAccessibleIntervals.create(
-					viewerSetupIL.getImage( timepointId, level, hints ),
-					getOrCreateBrightImgDownsampled( new ViewId( timepointId, setupId ), dsFactors ),
-					getOrCreateDarkImgDownsampled( new ViewId( timepointId, setupId ), dsFactors ) );
+			RandomAccessibleInterval<T> rai = FlatFieldCorrectedRandomAccessibleIntervals.create(
+					viewerSetupIL.getImage(timepointId, level, hints),
+					getOrCreateBrightImgDownsampled(new ViewId(timepointId, setupId), dsFactors),
+					getOrCreateDarkImgDownsampled(new ViewId(timepointId, setupId), dsFactors));
 
 			// Handle LOAD_COMPLETELY hint
 			boolean loadCompletelyRequested = false;
-			for ( final ImgLoaderHint hint : hints )
-				if ( hint == ImgLoaderHints.LOAD_COMPLETELY )
-					loadCompletelyRequested = true;
+			for (final ImgLoaderHint hint : hints)
+                if (hint == ImgLoaderHints.LOAD_COMPLETELY) {
+                    loadCompletelyRequested = true;
+                    break;
+                }
 
-			if ( loadCompletelyRequested )
-			{
+			if (loadCompletelyRequested) {
 				long numPx = 1;
-				for ( int d = 0; d < rai.numDimensions(); d++ )
-					numPx *= rai.dimension( d );
+				for (int d = 0; d < rai.numDimensions(); d++)
+					numPx *= rai.dimension(d);
 
-				final ImgFactory< T > imgFactory;
-				if ( Math.log( numPx ) / Math.log( 2 ) < 31 )
+				final ImgFactory<T> imgFactory;
+				if (Math.log(numPx) / Math.log(2) < 31)
 					imgFactory = new ArrayImgFactory<>();
 				else
 					imgFactory = new CellImgFactory<>();
 
-				final Img< T > loadedImg = imgFactory.create( rai, getImageType() );
-				RealTypeConverters.copyFromTo( Views.extendZero( rai ), loadedImg );
+				final Img<T> loadedImg = imgFactory.create(rai, getImageType());
+				RealTypeConverters.copyFromTo(Views.extendZero(rai), loadedImg);
 
 				rai = loadedImg;
-			}
-			else if ( cacheResult )
-			{
-				final int[] cellSize = new int[ rai.numDimensions() ];
-				Arrays.fill( cellSize, 1 );
-				for ( int d = 0; d < rai.numDimensions() - 1; d++ )
-					cellSize[ d ] = (int) rai.dimension( d );
-				rai = FusionTools.cacheRandomAccessibleInterval( rai, Long.MAX_VALUE,
-						Views.iterable( rai ).firstElement().createVariable(), cellSize );
+			} else if (cacheResult) {
+				final int[] cellSize = new int[rai.numDimensions()];
+				Arrays.fill(cellSize, 1);
+				for (int d = 0; d < rai.numDimensions() - 1; d++)
+					cellSize[d] = (int) rai.dimension(d);
+				rai = FusionTools.cacheRandomAccessibleInterval(rai, Long.MAX_VALUE,
+						Views.iterable(rai).firstElement().createVariable(), cellSize);
 			}
 
 			return rai;
@@ -367,103 +335,95 @@ public class ViewerFlatfieldCorrectionWrappedImgLoader
 		// ========== Volatile image access ==========
 
 		@Override
-		public RandomAccessibleInterval< V > getVolatileImage( final int timepointId, final int level, final ImgLoaderHint... hints )
-		{
-			final ViewerSetupImgLoader< T, V > viewerSetupIL = getUnderlyingViewerSetupImgLoader();
-			final MultiResolutionSetupImgLoader< T > multiResSetupIL = getUnderlyingMultiResSetupImgLoader();
+		public RandomAccessibleInterval<V> getVolatileImage(final int timepointId, final int level, final ImgLoaderHint... hints) {
+			final ViewerSetupImgLoader<T, V> viewerSetupIL = getUnderlyingViewerSetupImgLoader();
+			final MultiResolutionSetupImgLoader<T> multiResSetupIL = getUnderlyingMultiResSetupImgLoader();
 
-			if ( !active )
-				return viewerSetupIL.getVolatileImage( timepointId, level, hints );
+			if (!active)
+				return viewerSetupIL.getVolatileImage(timepointId, level, hints);
 
-			final int n = multiResSetupIL.getImageSize( timepointId ).numDimensions();
+			final int n = multiResSetupIL.getImageSize(timepointId).numDimensions();
 
 			// Calculate downsampling factors for this mipmap level
-			final int[] dsFactors = new int[ n ];
-			final double[] dsD = viewerSetupIL.getMipmapResolutions()[ level ];
-			for ( int d = 0; d < n; d++ )
-				dsFactors[ d ] = (int) dsD[ d ];
-			dsFactors[ n - 1 ] = 1;
+			final int[] dsFactors = new int[n];
+			final double[] dsD = viewerSetupIL.getMipmapResolutions()[level];
+			for (int d = 0; d < n; d++)
+				dsFactors[d] = (int) dsD[d];
+			dsFactors[n - 1] = 1;
 
 			// Apply correction to volatile image
 			// Note: The volatile validity flag propagation may not be perfect,
 			// but BDV will re-request invalid pixels automatically
-			@SuppressWarnings("unchecked")
-			final RandomAccessibleInterval< V > rai = FlatFieldCorrectedRandomAccessibleIntervals.create(
-					viewerSetupIL.getVolatileImage( timepointId, level, hints ),
-					getOrCreateBrightImgDownsampled( new ViewId( timepointId, setupId ), dsFactors ),
-					getOrCreateDarkImgDownsampled( new ViewId( timepointId, setupId ), dsFactors ),
-					getVolatileImageType() );
-
-			return rai;
+            return FlatFieldCorrectedRandomAccessibleIntervals.create(
+                    viewerSetupIL.getVolatileImage(timepointId, level, hints),
+                    getOrCreateBrightImgDownsampled(new ViewId(timepointId, setupId), dsFactors),
+                    getOrCreateDarkImgDownsampled(new ViewId(timepointId, setupId), dsFactors),
+                    getVolatileImageType());
 		}
 
 		// ========== Float image access ==========
 
 		@Override
-		public RandomAccessibleInterval< FloatType > getFloatImage( final int timepointId, final boolean normalize, final ImgLoaderHint... hints )
-		{
-			return getFloatImage( timepointId, 0, normalize, hints );
+		public RandomAccessibleInterval<FloatType> getFloatImage(final int timepointId, final boolean normalize, final ImgLoaderHint... hints) {
+			return getFloatImage(timepointId, 0, normalize, hints);
 		}
 
 		@Override
-		public RandomAccessibleInterval< FloatType > getFloatImage( final int timepointId, final int level, final boolean normalize, final ImgLoaderHint... hints )
-		{
-			final ViewerSetupImgLoader< T, V > viewerSetupIL = getUnderlyingViewerSetupImgLoader();
-			final MultiResolutionSetupImgLoader< T > multiResSetupIL = getUnderlyingMultiResSetupImgLoader();
+		public RandomAccessibleInterval<FloatType> getFloatImage(final int timepointId, final int level, final boolean normalize, final ImgLoaderHint... hints) {
+			final ViewerSetupImgLoader<T, V> viewerSetupIL = getUnderlyingViewerSetupImgLoader();
+			final MultiResolutionSetupImgLoader<T> multiResSetupIL = getUnderlyingMultiResSetupImgLoader();
 
-			if ( !active )
-				return multiResSetupIL.getFloatImage( timepointId, level, normalize, hints );
+			if (!active)
+				return multiResSetupIL.getFloatImage(timepointId, level, normalize, hints);
 
-			final int n = multiResSetupIL.getImageSize( timepointId ).numDimensions();
+			final int n = multiResSetupIL.getImageSize(timepointId).numDimensions();
 
-			final int[] dsFactors = new int[ n ];
-			final double[] dsD = viewerSetupIL.getMipmapResolutions()[ level ];
-			for ( int d = 0; d < n; d++ )
-				dsFactors[ d ] = (int) dsD[ d ];
-			dsFactors[ n - 1 ] = 1;
+			final int[] dsFactors = new int[n];
+			final double[] dsD = viewerSetupIL.getMipmapResolutions()[level];
+			for (int d = 0; d < n; d++)
+				dsFactors[d] = (int) dsD[d];
+			dsFactors[n - 1] = 1;
 
-			RandomAccessibleInterval< FloatType > rai = FlatFieldCorrectedRandomAccessibleIntervals.create(
-					viewerSetupIL.getImage( timepointId, level, hints ),
-					getOrCreateBrightImgDownsampled( new ViewId( timepointId, setupId ), dsFactors ),
-					getOrCreateDarkImgDownsampled( new ViewId( timepointId, setupId ), dsFactors ),
-					new FloatType() );
+			RandomAccessibleInterval<FloatType> rai = FlatFieldCorrectedRandomAccessibleIntervals.create(
+					viewerSetupIL.getImage(timepointId, level, hints),
+					getOrCreateBrightImgDownsampled(new ViewId(timepointId, setupId), dsFactors),
+					getOrCreateDarkImgDownsampled(new ViewId(timepointId, setupId), dsFactors),
+					new FloatType());
 
-			if ( normalize )
-			{
-				rai = new VirtuallyNormalizedRandomAccessibleInterval<>( rai );
+			if (normalize) {
+				rai = new VirtuallyNormalizedRandomAccessibleInterval<>(rai);
 			}
 
 			// Handle caching/loading
 			boolean loadCompletelyRequested = false;
-			for ( final ImgLoaderHint hint : hints )
-				if ( hint == ImgLoaderHints.LOAD_COMPLETELY )
-					loadCompletelyRequested = true;
+			for (final ImgLoaderHint hint : hints)
+                if (hint == ImgLoaderHints.LOAD_COMPLETELY) {
+                    loadCompletelyRequested = true;
+                    break;
+                }
 
-			if ( loadCompletelyRequested )
-			{
+			if (loadCompletelyRequested) {
 				long numPx = 1;
-				for ( int d = 0; d < rai.numDimensions(); d++ )
-					numPx *= rai.dimension( d );
+				for (int d = 0; d < rai.numDimensions(); d++)
+					numPx *= rai.dimension(d);
 
-				final ImgFactory< FloatType > imgFactory;
-				if ( Math.log( numPx ) / Math.log( 2 ) < 31 )
+				final ImgFactory<FloatType> imgFactory;
+				if (Math.log(numPx) / Math.log(2) < 31)
 					imgFactory = new ArrayImgFactory<>();
 				else
 					imgFactory = new CellImgFactory<>();
 
-				final Img< FloatType > loadedImg = imgFactory.create( rai, new FloatType() );
-				RealTypeConverters.copyFromTo( Views.extendZero( rai ), loadedImg );
+				final Img<FloatType> loadedImg = imgFactory.create(rai, new FloatType());
+				RealTypeConverters.copyFromTo(Views.extendZero(rai), loadedImg);
 
 				rai = loadedImg;
-			}
-			else if ( cacheResult )
-			{
-				final int[] cellSize = new int[ rai.numDimensions() ];
-				Arrays.fill( cellSize, 1 );
-				for ( int d = 0; d < rai.numDimensions() - 1; d++ )
-					cellSize[ d ] = (int) rai.dimension( d );
-				rai = FusionTools.cacheRandomAccessibleInterval( rai, Long.MAX_VALUE,
-						new FloatType(), cellSize );
+			} else if (cacheResult) {
+				final int[] cellSize = new int[rai.numDimensions()];
+				Arrays.fill(cellSize, 1);
+				for (int d = 0; d < rai.numDimensions() - 1; d++)
+					cellSize[d] = (int) rai.dimension(d);
+				rai = FusionTools.cacheRandomAccessibleInterval(rai, Long.MAX_VALUE,
+						new FloatType(), cellSize);
 			}
 
 			return rai;
@@ -472,51 +432,43 @@ public class ViewerFlatfieldCorrectionWrappedImgLoader
 		// ========== Metadata delegation ==========
 
 		@Override
-		public T getImageType()
-		{
+		public T getImageType() {
 			return getUnderlyingViewerSetupImgLoader().getImageType();
 		}
 
 		@Override
-		public V getVolatileImageType()
-		{
+		public V getVolatileImageType() {
 			return getUnderlyingViewerSetupImgLoader().getVolatileImageType();
 		}
 
 		@Override
-		public double[][] getMipmapResolutions()
-		{
+		public double[][] getMipmapResolutions() {
 			return getUnderlyingViewerSetupImgLoader().getMipmapResolutions();
 		}
 
 		@Override
-		public AffineTransform3D[] getMipmapTransforms()
-		{
+		public AffineTransform3D[] getMipmapTransforms() {
 			return getUnderlyingViewerSetupImgLoader().getMipmapTransforms();
 		}
 
 		@Override
-		public int numMipmapLevels()
-		{
+		public int numMipmapLevels() {
 			return getUnderlyingViewerSetupImgLoader().numMipmapLevels();
 		}
 
 		@Override
-		public Dimensions getImageSize( final int timepointId )
-		{
-			return getUnderlyingMultiResSetupImgLoader().getImageSize( timepointId );
+		public Dimensions getImageSize(final int timepointId) {
+			return getUnderlyingMultiResSetupImgLoader().getImageSize(timepointId);
 		}
 
 		@Override
-		public Dimensions getImageSize( final int timepointId, final int level )
-		{
-			return getUnderlyingMultiResSetupImgLoader().getImageSize( timepointId, level );
+		public Dimensions getImageSize(final int timepointId, final int level) {
+			return getUnderlyingMultiResSetupImgLoader().getImageSize(timepointId, level);
 		}
 
 		@Override
-		public VoxelDimensions getVoxelSize( final int timepointId )
-		{
-			return getUnderlyingMultiResSetupImgLoader().getVoxelSize( timepointId );
+		public VoxelDimensions getVoxelSize(final int timepointId) {
+			return getUnderlyingMultiResSetupImgLoader().getVoxelSize(timepointId);
 		}
 	}
 }

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/ViewerFlatfieldCorrectionWrappedImgLoader.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/ViewerFlatfieldCorrectionWrappedImgLoader.java
@@ -23,7 +23,6 @@
 package net.preibisch.mvrecon.fiji.spimdata.imgloaders.flatfield;
 
 import java.io.File;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -80,6 +79,8 @@ public class ViewerFlatfieldCorrectionWrappedImgLoader
 	private final ViewerImgLoader wrappedImgLoader;
 	private boolean active;
 	private boolean cacheResult;
+
+	private static final Pair<File, File> NULL_PAIR = new ValuePair<>(null, null);
 
 	/** Maps ViewId to (brightFile, darkFile) pair */
 	protected final Map<ViewId, Pair<File, File>> fileMap;
@@ -143,17 +144,13 @@ public class ViewerFlatfieldCorrectionWrappedImgLoader
 	}
 
 	public void setBrightImage(final ViewId vId, final File imgFile) {
-		if (!fileMap.containsKey(vId))
-			fileMap.put(vId, new ValuePair<>(null, null));
-
-        fileMap.compute(vId, (k, oldPair) -> new ValuePair<>(imgFile, oldPair.getB()));
+		final Pair<File, File> oldPair = fileMap.getOrDefault(vId, NULL_PAIR);
+		fileMap.put(vId, new ValuePair<>(imgFile, oldPair.getB()));
 	}
 
 	public void setDarkImage(final ViewId vId, final File imgFile) {
-		if (!fileMap.containsKey(vId))
-			fileMap.put(vId, new ValuePair<>(null, null));
-
-        fileMap.compute(vId, (k, oldPair) -> new ValuePair<>(oldPair.getA(), imgFile));
+		final Pair<File, File> oldPair = fileMap.getOrDefault(vId, NULL_PAIR);
+		fileMap.put(vId, new ValuePair<>(oldPair.getA(), imgFile));
 	}
 
 	// ========== Image loading helpers ==========
@@ -299,12 +296,13 @@ public class ViewerFlatfieldCorrectionWrappedImgLoader
 					numPx *= rai.dimension(d);
 
 				final ImgFactory<T> imgFactory;
-				if (Math.log(numPx) / Math.log(2) < 31)
-					imgFactory = new ArrayImgFactory<>();
-				else
-					imgFactory = new CellImgFactory<>();
+				if (Math.log(numPx) / Math.log(2) < 31) {
+					imgFactory = new ArrayImgFactory<>(getImageType());
+				} else {
+					imgFactory = new CellImgFactory<>(getImageType());
+				}
 
-				final Img<T> loadedImg = imgFactory.create(rai, getImageType());
+				final Img<T> loadedImg = imgFactory.create(rai);
 				RealTypeConverters.copyFromTo(Views.extendZero(rai), loadedImg);
 
 				rai = loadedImg;
@@ -313,8 +311,8 @@ public class ViewerFlatfieldCorrectionWrappedImgLoader
 				Arrays.fill(cellSize, 1);
 				for (int d = 0; d < rai.numDimensions() - 1; d++)
 					cellSize[d] = (int) rai.dimension(d);
-				rai = FusionTools.cacheRandomAccessibleInterval(rai, Long.MAX_VALUE,
-						Views.iterable(rai).firstElement().createVariable(), cellSize);
+				rai = FusionTools.cacheRandomAccessibleInterval(
+						rai, Long.MAX_VALUE, rai.firstElement().createVariable(), cellSize);
 			}
 
 			return rai;
@@ -397,11 +395,11 @@ public class ViewerFlatfieldCorrectionWrappedImgLoader
 
 				final ImgFactory<FloatType> imgFactory;
 				if (Math.log(numPx) / Math.log(2) < 31)
-					imgFactory = new ArrayImgFactory<>();
+					imgFactory = new ArrayImgFactory<>(new FloatType());
 				else
-					imgFactory = new CellImgFactory<>();
+					imgFactory = new CellImgFactory<>(new FloatType());
 
-				final Img<FloatType> loadedImg = imgFactory.create(rai, new FloatType());
+				final Img<FloatType> loadedImg = imgFactory.create(rai);
 				RealTypeConverters.copyFromTo(Views.extendZero(rai), loadedImg);
 
 				rai = loadedImg;

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/ViewerFlatfieldCorrectionWrappedImgLoader.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/ViewerFlatfieldCorrectionWrappedImgLoader.java
@@ -23,12 +23,17 @@
 package net.preibisch.mvrecon.fiji.spimdata.imgloaders.flatfield;
 
 import java.io.File;
+import java.net.URI;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+
+import org.janelia.saalfeldlab.n5.N5Reader;
+import org.janelia.saalfeldlab.n5.imglib2.N5Utils;
+import org.janelia.saalfeldlab.n5.universe.StorageFormat;
 
 import bdv.ViewerImgLoader;
 import bdv.ViewerSetupImgLoader;
@@ -54,10 +59,12 @@ import net.imglib2.realtransform.AffineTransform3D;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.real.FloatType;
+import net.imglib2.util.Cast;
 import net.imglib2.util.Pair;
 import net.imglib2.util.ValuePair;
 import net.imglib2.view.Views;
 import net.preibisch.mvrecon.process.fusion.FusionTools;
+import util.URITools;
 
 /**
  * Flatfield correction wrapper for ViewerImgLoader.
@@ -80,16 +87,16 @@ public class ViewerFlatfieldCorrectionWrappedImgLoader
 	private boolean active;
 	private boolean cacheResult;
 
-	private static final Pair<File, File> NULL_PAIR = new ValuePair<>(null, null);
+	private static final Pair<URI, URI> NULL_PAIR = new ValuePair<>(null, null);
 
-	/** Maps ViewId to (brightFile, darkFile) pair */
-	protected final Map<ViewId, Pair<File, File>> fileMap;
+	/** Maps ViewId to (brightUri, darkUri) pair */
+	protected final Map<ViewId, Pair<URI, URI>> uriMap;
 
 	/** Cached loaded correction images */
-	protected final Map<File, RandomAccessibleInterval<FloatType>> raiMap;
+	protected final Map<URI, RandomAccessibleInterval<FloatType>> raiMap;
 
 	/** Downsampled bright/dark images for each mipmap level */
-	private final Map<Pair<File, List<Integer>>, RandomAccessibleInterval<FloatType>> dsRaiMap;
+	private final Map<Pair<URI, List<Integer>>, RandomAccessibleInterval<FloatType>> dsRaiMap;
 
 	public ViewerFlatfieldCorrectionWrappedImgLoader(final ViewerImgLoader wrappedImgLoader) {
 		this(wrappedImgLoader, true);
@@ -99,7 +106,7 @@ public class ViewerFlatfieldCorrectionWrappedImgLoader
 		this.wrappedImgLoader = wrappedImgLoader;
 		this.active = true;
 		this.cacheResult = cacheResult;
-		this.fileMap = new HashMap<>();
+		this.uriMap = new HashMap<>();
 		this.raiMap = new HashMap<>();
 		this.dsRaiMap = new HashMap<>();
 	}
@@ -143,50 +150,108 @@ public class ViewerFlatfieldCorrectionWrappedImgLoader
 		this.cacheResult = cached;
 	}
 
+	public void setBrightImage(final ViewId vId, final URI imgUri) {
+		final Pair<URI, URI> oldPair = uriMap.getOrDefault(vId, NULL_PAIR);
+		uriMap.put(vId, new ValuePair<>(imgUri, oldPair.getB()));
+	}
+
+	public void setDarkImage(final ViewId vId, final URI imgUri) {
+		final Pair<URI, URI> oldPair = uriMap.getOrDefault(vId, NULL_PAIR);
+		uriMap.put(vId, new ValuePair<>(oldPair.getA(), imgUri));
+	}
+
 	public void setBrightImage(final ViewId vId, final File imgFile) {
-		final Pair<File, File> oldPair = fileMap.getOrDefault(vId, NULL_PAIR);
-		fileMap.put(vId, new ValuePair<>(imgFile, oldPair.getB()));
+		setBrightImage(vId, imgFile == null ? null : imgFile.toURI());
 	}
 
 	public void setDarkImage(final ViewId vId, final File imgFile) {
-		final Pair<File, File> oldPair = fileMap.getOrDefault(vId, NULL_PAIR);
-		fileMap.put(vId, new ValuePair<>(oldPair.getA(), imgFile));
+		setDarkImage(vId, imgFile == null ? null : imgFile.toURI());
 	}
 
 	// ========== Image loading helpers ==========
 
 	protected RandomAccessibleInterval<FloatType> getBrightImg(final ViewId vId) {
-		if (!fileMap.containsKey(vId))
+		if (!uriMap.containsKey(vId))
 			return null;
 
-		final File fileToLoad = fileMap.get(vId).getA();
-		if (fileToLoad == null)
+		final URI uriToLoad = uriMap.get(vId).getA();
+		if (uriToLoad == null)
 			return null;
 
-		loadFileIfNecessary(fileToLoad);
-		return raiMap.get(fileToLoad);
+		loadImageIfNecessary(uriToLoad);
+		return raiMap.get(uriToLoad);
 	}
 
 	protected RandomAccessibleInterval<FloatType> getDarkImg(final ViewId vId) {
-		if (!fileMap.containsKey(vId))
+		if (!uriMap.containsKey(vId))
 			return null;
 
-		final File fileToLoad = fileMap.get(vId).getB();
-		if (fileToLoad == null)
+		final URI uriToLoad = uriMap.get(vId).getB();
+		if (uriToLoad == null)
 			return null;
 
-		loadFileIfNecessary(fileToLoad);
-		return raiMap.get(fileToLoad);
+		loadImageIfNecessary(uriToLoad);
+		return raiMap.get(uriToLoad);
 	}
 
-	protected void loadFileIfNecessary(final File file) {
-		if (raiMap.containsKey(file))
+	/**
+	 * Load an image from a URI. Supports:
+	 * - Local TIFF files (via ImageJ)
+	 * - Local/cloud Zarr v3 containers (via N5 API)
+	 * - Local/cloud N5 containers (via N5 API)
+	 */
+	protected void loadImageIfNecessary(final URI uri) {
+		if (raiMap.containsKey(uri))
 			return;
 
-		final ImagePlus imp = IJ.openImage(file.getAbsolutePath());
-		final RandomAccessibleInterval<FloatType> img = ImageJFunctions.convertFloat(imp).copy();
+		RandomAccessibleInterval<FloatType> img;
 
-		raiMap.put(file, img);
+		if (isChunkedFormat(uri)) {
+			// Use N5/Zarr API for chunked formats
+			final StorageFormat format = detectStorageFormat(uri);
+			final N5Reader reader = URITools.instantiateN5Reader(format, uri);
+			final RandomAccessibleInterval<?> raw = N5Utils.open(reader, "/");
+			img = RealTypeConverters.convert(Cast.unchecked(raw), new FloatType());
+		} else {
+			// Legacy TIFF path via ImageJ
+			final File file = new File(uri);
+			final ImagePlus imp = IJ.openImage(file.getAbsolutePath());
+			if (imp == null)
+				throw new RuntimeException("Failed to load image from: " + uri);
+			img = ImageJFunctions.convertFloat(imp).copy();
+		}
+
+		raiMap.put(uri, img);
+	}
+
+	/**
+	 * Determine if the URI points to a chunked format (N5/Zarr) vs TIFF.
+	 */
+	private static boolean isChunkedFormat(final URI uri) {
+		final String scheme = uri.getScheme();
+		// Cloud URIs are always chunked format
+		if ("s3".equals(scheme) || "gs".equals(scheme))
+			return true;
+
+		// Check path for .zarr or .n5 extension
+		final String path = uri.getPath();
+		if (path == null)
+			return false;
+
+		final String lowerPath = path.toLowerCase();
+		return lowerPath.endsWith(".zarr") || lowerPath.endsWith(".n5")
+			|| lowerPath.contains(".zarr/") || lowerPath.contains(".n5/");
+	}
+
+	/**
+	 * Detect the storage format from the URI.
+	 */
+	private static StorageFormat detectStorageFormat(final URI uri) {
+		final String path = uri.getPath();
+		if (path != null && path.toLowerCase().contains(".n5"))
+			return StorageFormat.N5;
+		// Default to Zarr v3 for cloud and .zarr paths
+		return StorageFormat.ZARR;
 	}
 
 	protected RandomAccessibleInterval<FloatType> getOrCreateBrightImgDownsampled(
@@ -210,12 +275,12 @@ public class ViewerFlatfieldCorrectionWrappedImgLoader
 	private RandomAccessibleInterval<FloatType> getOrCreateDownsampledImg(
 			ViewId vId,
 			int[] downsamplingFactors,
-			Function<Pair<File, File>, File> fileSelector,
+			Function<Pair<URI, URI>, URI> uriSelector,
 			Function<ViewId, RandomAccessibleInterval<FloatType>> imgGetter
 	) {
 		// Convert to a list here to have a proper hash code for the map key
 		List<Integer> dsFactorList = Arrays.stream(downsamplingFactors).boxed().collect(Collectors.toList());
-		final ValuePair<File, List<Integer>> key = new ValuePair<>(fileSelector.apply(fileMap.get(vId)), dsFactorList);
+		final ValuePair<URI, List<Integer>> key = new ValuePair<>(uriSelector.apply(uriMap.get(vId)), dsFactorList);
 
 		if (!dsRaiMap.containsKey(key)) {
 			final RandomAccessibleInterval<FloatType> img = imgGetter.apply(vId);
@@ -229,6 +294,14 @@ public class ViewerFlatfieldCorrectionWrappedImgLoader
 		}
 
 		return dsRaiMap.get(key);
+	}
+
+	/**
+	 * Get the URI map for bright/dark images per view.
+	 * @return map from ViewId to (brightUri, darkUri) pair
+	 */
+	public Map<ViewId, Pair<URI, URI>> getUriMap() {
+		return uriMap;
 	}
 
 	// ========== Inner class: ViewerSetupImgLoader implementation ==========

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/XmlIoFlatfieldCorrectedWrappedImgLoader.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/XmlIoFlatfieldCorrectedWrappedImgLoader.java
@@ -26,6 +26,10 @@ import static mpicbg.spim.data.XmlKeys.IMGLOADER_FORMAT_ATTRIBUTE_NAME;
 import static mpicbg.spim.data.XmlKeys.IMGLOADER_TAG;
 import static mpicbg.spim.data.XmlKeys.TIMEPOINTS_TIMEPOINT_TAG;
 import static mpicbg.spim.data.XmlKeys.VIEWSETUP_TAG;
+import static net.preibisch.mvrecon.fiji.spimdata.imgloaders.flatfield.XmlIoViewerFlatfieldCorrectionWrappedImgLoader.FORMAT_ATTR;
+import static net.preibisch.mvrecon.fiji.spimdata.imgloaders.flatfield.XmlIoViewerFlatfieldCorrectionWrappedImgLoader.DATASET_ATTR;
+import static net.preibisch.mvrecon.fiji.spimdata.imgloaders.flatfield.XmlIoViewerFlatfieldCorrectionWrappedImgLoader.parseFlatfieldImageInfo;
+import static net.preibisch.mvrecon.fiji.spimdata.imgloaders.flatfield.XmlIoViewerFlatfieldCorrectionWrappedImgLoader.createFlatfieldImageElement;
 
 import java.io.File;
 import java.net.URI;
@@ -35,7 +39,6 @@ import org.jdom2.DataConversionException;
 import org.jdom2.Element;
 
 import mpicbg.spim.data.SpimDataInstantiationException;
-import mpicbg.spim.data.XmlHelpers;
 import mpicbg.spim.data.generic.sequence.AbstractSequenceDescription;
 import mpicbg.spim.data.generic.sequence.BasicImgLoader;
 import mpicbg.spim.data.generic.sequence.ImgLoaderIo;
@@ -112,10 +115,15 @@ public class XmlIoFlatfieldCorrectedWrappedImgLoader
 		{
 			int tp = Integer.parseInt(flatfield.getAttributeValue(TIMEPOINTS_TIMEPOINT_TAG));
 			int vs = Integer.parseInt(flatfield.getAttributeValue(VIEWSETUP_TAG));
-			URI brightImg = XmlHelpers.loadPathURI(flatfield, BRIGHTIMG_TAG, basePathURI);
-			URI darkImg = XmlHelpers.loadPathURI(flatfield, DARKIMG_TAG, basePathURI);
-			res.setBrightImage(new ViewId(tp, vs), brightImg);
-			res.setDarkImage(new ViewId(tp, vs), darkImg);
+			ViewId viewId = new ViewId(tp, vs);
+
+			FlatfieldImageInfo brightInfo = parseFlatfieldImageInfo(flatfield, BRIGHTIMG_TAG, basePathURI);
+			FlatfieldImageInfo darkInfo = parseFlatfieldImageInfo(flatfield, DARKIMG_TAG, basePathURI);
+
+			if (brightInfo != null)
+				res.setBrightImage(viewId, brightInfo);
+			if (darkInfo != null)
+				res.setDarkImage(viewId, darkInfo);
 		}
 
 		res.setActive(active);
@@ -131,7 +139,8 @@ public class XmlIoFlatfieldCorrectedWrappedImgLoader
 	@Override
 	public Element toXml(FlatfieldCorrectionWrappedImgLoader<? extends ImgLoader> imgLoader, URI basePathURI)
 	{
-		final Map<ViewId, Pair<URI, URI>> uriMap = ((LazyLoadingFlatFieldCorrectionMap<? extends ImgLoader>) imgLoader).getUriMap();
+		final Map<ViewId, Pair<FlatfieldImageInfo, FlatfieldImageInfo>> infoMap =
+				((LazyLoadingFlatFieldCorrectionMap<? extends ImgLoader>) imgLoader).getInfoMap();
 
 		final Element wholeElem = new Element(IMGLOADER_TAG);
 		wholeElem.setAttribute(IMGLOADER_FORMAT_ATTRIBUTE_NAME,
@@ -157,20 +166,20 @@ public class XmlIoFlatfieldCorrectedWrappedImgLoader
 
 		final Element elFlatfields = new Element(FLATFIELDS_TAG);
 
-		for (ViewId vid : uriMap.keySet())
+		for (ViewId vid : infoMap.keySet())
 		{
-			final Pair<URI, URI> uris = uriMap.get(vid);
-			if (uris == null || (uris.getA() == null && uris.getB() == null))
+			final Pair<FlatfieldImageInfo, FlatfieldImageInfo> infos = infoMap.get(vid);
+			if (infos == null || (infos.getA() == null && infos.getB() == null))
 				continue;
 
 			final Element elFlatfield = new Element(FLATFIELD_TAG);
 			elFlatfield.setAttribute(TIMEPOINTS_TIMEPOINT_TAG, Integer.toString(vid.getTimePointId()));
 			elFlatfield.setAttribute(VIEWSETUP_TAG, Integer.toString(vid.getViewSetupId()));
 
-			if (uris.getA() != null)
-				elFlatfield.addContent(XmlHelpers.pathElementURI(BRIGHTIMG_TAG, uris.getA(), basePathURI));
-			if (uris.getB() != null)
-				elFlatfield.addContent(XmlHelpers.pathElementURI(DARKIMG_TAG, uris.getB(), basePathURI));
+			if (infos.getA() != null)
+				elFlatfield.addContent(createFlatfieldImageElement(BRIGHTIMG_TAG, infos.getA(), basePathURI));
+			if (infos.getB() != null)
+				elFlatfield.addContent(createFlatfieldImageElement(DARKIMG_TAG, infos.getB(), basePathURI));
 
 			elFlatfields.addContent(elFlatfield);
 		}

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/XmlIoFlatfieldCorrectedWrappedImgLoader.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/XmlIoFlatfieldCorrectedWrappedImgLoader.java
@@ -9,12 +9,12 @@
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
@@ -28,6 +28,7 @@ import static mpicbg.spim.data.XmlKeys.TIMEPOINTS_TIMEPOINT_TAG;
 import static mpicbg.spim.data.XmlKeys.VIEWSETUP_TAG;
 
 import java.io.File;
+import java.net.URI;
 import java.util.Map;
 
 import org.jdom2.DataConversionException;
@@ -44,12 +45,11 @@ import mpicbg.spim.data.sequence.ImgLoader;
 import mpicbg.spim.data.sequence.MultiResolutionImgLoader;
 import mpicbg.spim.data.sequence.ViewId;
 import net.imglib2.util.Pair;
-import net.preibisch.legacy.io.IOFunctions;
 
 
 @ImgLoaderIo(format = "spimreconstruction.wrapped.flatfield.default", type = DefaultFlatfieldCorrectionWrappedImgLoader.class)
 public class XmlIoFlatfieldCorrectedWrappedImgLoader
-		implements XmlIoBasicImgLoader< FlatfieldCorrectionWrappedImgLoader< ? extends ImgLoader > >
+		implements XmlIoBasicImgLoader<FlatfieldCorrectionWrappedImgLoader<? extends ImgLoader>>
 {
 	public final static String WRAPPED_IMGLOADER_TAG = "WrappedImgLoader";
 	public final static String FLATFIELDS_TAG = "FlatFields";
@@ -60,17 +60,24 @@ public class XmlIoFlatfieldCorrectedWrappedImgLoader
 	public final static String CACHED_TAG = "Cached";
 
 	@Override
-	public FlatfieldCorrectionWrappedImgLoader< ? extends ImgLoader > fromXml(Element elem, File basePath,
-			AbstractSequenceDescription< ?, ?, ? > sequenceDescription)
+	public FlatfieldCorrectionWrappedImgLoader<? extends ImgLoader> fromXml(Element elem, File basePath,
+			AbstractSequenceDescription<?, ?, ?> sequenceDescription)
 	{
-		Element wrappedImgLoaderEl = elem.getChild( WRAPPED_IMGLOADER_TAG ).getChild( IMGLOADER_TAG );
-		XmlIoBasicImgLoader< ? > xmlIoWrapped = null;
+		return fromXml(elem, basePath == null ? null : basePath.toURI(), sequenceDescription);
+	}
+
+	@Override
+	public FlatfieldCorrectionWrappedImgLoader<? extends ImgLoader> fromXml(Element elem, URI basePathURI,
+			AbstractSequenceDescription<?, ?, ?> sequenceDescription)
+	{
+		Element wrappedImgLoaderEl = elem.getChild(WRAPPED_IMGLOADER_TAG).getChild(IMGLOADER_TAG);
+		XmlIoBasicImgLoader<?> xmlIoWrapped = null;
 		try
 		{
 			xmlIoWrapped = ImgLoaders
-					.createXmlIoForFormat( wrappedImgLoaderEl.getAttributeValue( IMGLOADER_FORMAT_ATTRIBUTE_NAME ) );
+					.createXmlIoForFormat(wrappedImgLoaderEl.getAttributeValue(IMGLOADER_FORMAT_ATTRIBUTE_NAME));
 		}
-		catch ( SpimDataInstantiationException e )
+		catch (SpimDataInstantiationException e)
 		{
 			e.printStackTrace();
 			return null;
@@ -80,92 +87,96 @@ public class XmlIoFlatfieldCorrectedWrappedImgLoader
 		boolean active = false;
 		try
 		{
-			cached = elem.getAttribute( CACHED_TAG ).getBooleanValue();
-			active = elem.getAttribute( ACTIVE_TAG ).getBooleanValue();
+			cached = elem.getAttribute(CACHED_TAG).getBooleanValue();
+			active = elem.getAttribute(ACTIVE_TAG).getBooleanValue();
 		}
-		catch ( DataConversionException e )
+		catch (DataConversionException e)
 		{
 			e.printStackTrace();
 		}
 
-		BasicImgLoader wrappedImgLoader = xmlIoWrapped.fromXml( wrappedImgLoaderEl, basePath, sequenceDescription );
+		BasicImgLoader wrappedImgLoader = xmlIoWrapped.fromXml(wrappedImgLoaderEl, basePathURI, sequenceDescription);
 
-		FlatfieldCorrectionWrappedImgLoader< ? extends ImgLoader > res = null;
+		FlatfieldCorrectionWrappedImgLoader<? extends ImgLoader> res = null;
 
-		if ( MultiResolutionImgLoader.class.isInstance( wrappedImgLoader ) )
-			res = new MultiResolutionFlatfieldCorrectionWrappedImgLoader( (MultiResolutionImgLoader) wrappedImgLoader,
-					cached );
-		else if ( ImgLoader.class.isInstance( wrappedImgLoader ) )
-			res = new DefaultFlatfieldCorrectionWrappedImgLoader( (ImgLoader) wrappedImgLoader, cached );
+		if (MultiResolutionImgLoader.class.isInstance(wrappedImgLoader))
+			res = new MultiResolutionFlatfieldCorrectionWrappedImgLoader((MultiResolutionImgLoader) wrappedImgLoader,
+					cached);
+		else if (ImgLoader.class.isInstance(wrappedImgLoader))
+			res = new DefaultFlatfieldCorrectionWrappedImgLoader((ImgLoader) wrappedImgLoader, cached);
 		else
 			return null;
 
-		Element flatfields = elem.getChild( FLATFIELDS_TAG );
-		for ( Element flatfield : flatfields.getChildren() )
+		Element flatfields = elem.getChild(FLATFIELDS_TAG);
+		for (Element flatfield : flatfields.getChildren())
 		{
-			int tp = Integer.parseInt( flatfield.getAttributeValue( TIMEPOINTS_TIMEPOINT_TAG ) );
-			int vs = Integer.parseInt( flatfield.getAttributeValue( VIEWSETUP_TAG ) );
-			File brightImg = XmlHelpers.loadPath( flatfield, BRIGHTIMG_TAG, basePath );
-			File darkImg = XmlHelpers.loadPath( flatfield, DARKIMG_TAG, basePath );
-			res.setBrightImage( new ViewId( tp, vs ), brightImg );
-			res.setDarkImage( new ViewId( tp, vs ), darkImg );
+			int tp = Integer.parseInt(flatfield.getAttributeValue(TIMEPOINTS_TIMEPOINT_TAG));
+			int vs = Integer.parseInt(flatfield.getAttributeValue(VIEWSETUP_TAG));
+			URI brightImg = XmlHelpers.loadPathURI(flatfield, BRIGHTIMG_TAG, basePathURI);
+			URI darkImg = XmlHelpers.loadPathURI(flatfield, DARKIMG_TAG, basePathURI);
+			res.setBrightImage(new ViewId(tp, vs), brightImg);
+			res.setDarkImage(new ViewId(tp, vs), darkImg);
 		}
 
-		res.setActive( active );
+		res.setActive(active);
 		return res;
 	}
 
 	@Override
-	public Element toXml(FlatfieldCorrectionWrappedImgLoader< ? extends ImgLoader > imgLoader, File basePath)
+	public Element toXml(FlatfieldCorrectionWrappedImgLoader<? extends ImgLoader> imgLoader, File basePath)
 	{
+		return toXml(imgLoader, basePath == null ? null : basePath.toURI());
+	}
 
-		final Map< ViewId, Pair< File, File > > fileMap = ( (LazyLoadingFlatFieldCorrectionMap< ? extends ImgLoader >) imgLoader ).fileMap;
+	@Override
+	public Element toXml(FlatfieldCorrectionWrappedImgLoader<? extends ImgLoader> imgLoader, URI basePathURI)
+	{
+		final Map<ViewId, Pair<URI, URI>> uriMap = ((LazyLoadingFlatFieldCorrectionMap<? extends ImgLoader>) imgLoader).getUriMap();
 
-		final Element wholeElem = new Element( IMGLOADER_TAG );
-		wholeElem.setAttribute( IMGLOADER_FORMAT_ATTRIBUTE_NAME,
-				this.getClass().getAnnotation( ImgLoaderIo.class ).format() );
-		final Element wrappedIL = new Element( WRAPPED_IMGLOADER_TAG );
+		final Element wholeElem = new Element(IMGLOADER_TAG);
+		wholeElem.setAttribute(IMGLOADER_FORMAT_ATTRIBUTE_NAME,
+				this.getClass().getAnnotation(ImgLoaderIo.class).format());
+		final Element wrappedIL = new Element(WRAPPED_IMGLOADER_TAG);
 
-		wholeElem.setAttribute( ACTIVE_TAG, Boolean.toString( imgLoader.isActive() ) );
-		wholeElem.setAttribute( CACHED_TAG, Boolean.toString( imgLoader.isCached() ) );
+		wholeElem.setAttribute(ACTIVE_TAG, Boolean.toString(imgLoader.isActive()));
+		wholeElem.setAttribute(CACHED_TAG, Boolean.toString(imgLoader.isCached()));
 
 		try
 		{
-			XmlIoBasicImgLoader< ImgLoader > loaderIO = (XmlIoBasicImgLoader< ImgLoader >) ImgLoaders
-					.createXmlIoForImgLoaderClass( imgLoader.getWrappedImgLoder().getClass() );
-			Element wrappedInner = loaderIO.toXml( (ImgLoader) imgLoader.getWrappedImgLoder(), basePath );
-			wrappedIL.addContent( wrappedInner );
-
+			@SuppressWarnings("unchecked")
+			XmlIoBasicImgLoader<ImgLoader> loaderIO = (XmlIoBasicImgLoader<ImgLoader>) ImgLoaders
+					.createXmlIoForImgLoaderClass(imgLoader.getWrappedImgLoder().getClass());
+			Element wrappedInner = loaderIO.toXml((ImgLoader) imgLoader.getWrappedImgLoder(), basePathURI);
+			wrappedIL.addContent(wrappedInner);
 		}
-		catch ( SpimDataInstantiationException e )
+		catch (SpimDataInstantiationException e)
 		{
 			e.printStackTrace();
 			return null;
 		}
 
-		final Element elFlatfields = new Element( FLATFIELDS_TAG );
+		final Element elFlatfields = new Element(FLATFIELDS_TAG);
 
-		for ( ViewId vid : fileMap.keySet() )
+		for (ViewId vid : uriMap.keySet())
 		{
-			final Pair< File, File > files = fileMap.get( vid );
-			if ( files == null || ( files.getA() == null && files.getB() == null ) )
+			final Pair<URI, URI> uris = uriMap.get(vid);
+			if (uris == null || (uris.getA() == null && uris.getB() == null))
 				continue;
 
-			final Element elFlatfield = new Element( FLATFIELD_TAG );
-			elFlatfield.setAttribute( TIMEPOINTS_TIMEPOINT_TAG, Integer.toString( vid.getTimePointId() ) );
-			elFlatfield.setAttribute( VIEWSETUP_TAG, Integer.toString( vid.getViewSetupId() ) );
+			final Element elFlatfield = new Element(FLATFIELD_TAG);
+			elFlatfield.setAttribute(TIMEPOINTS_TIMEPOINT_TAG, Integer.toString(vid.getTimePointId()));
+			elFlatfield.setAttribute(VIEWSETUP_TAG, Integer.toString(vid.getViewSetupId()));
 
-			if ( files.getA() != null )
-				elFlatfield.addContent( XmlHelpers.pathElement( BRIGHTIMG_TAG, files.getA(), basePath ) );
-			if ( files.getB() != null )
-				elFlatfield.addContent( XmlHelpers.pathElement( DARKIMG_TAG, files.getB(), basePath ) );
+			if (uris.getA() != null)
+				elFlatfield.addContent(XmlHelpers.pathElementURI(BRIGHTIMG_TAG, uris.getA(), basePathURI));
+			if (uris.getB() != null)
+				elFlatfield.addContent(XmlHelpers.pathElementURI(DARKIMG_TAG, uris.getB(), basePathURI));
 
-			elFlatfields.addContent( elFlatfield );
+			elFlatfields.addContent(elFlatfield);
 		}
 
-		wholeElem.addContent( wrappedIL );
-		wholeElem.addContent( elFlatfields );
+		wholeElem.addContent(wrappedIL);
+		wholeElem.addContent(elFlatfields);
 		return wholeElem;
 	}
-
 }

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/XmlIoViewerFlatfieldCorrectionWrappedImgLoader.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/XmlIoViewerFlatfieldCorrectionWrappedImgLoader.java
@@ -31,6 +31,7 @@ import java.io.File;
 import java.net.URI;
 import java.util.Map;
 
+import org.janelia.saalfeldlab.n5.universe.StorageFormat;
 import org.jdom2.DataConversionException;
 import org.jdom2.Element;
 
@@ -61,6 +62,8 @@ public class XmlIoViewerFlatfieldCorrectionWrappedImgLoader
 	public final static String DARKIMG_TAG = "DarkImg";
 	public final static String ACTIVE_TAG = "Active";
 	public final static String CACHED_TAG = "Cached";
+	public final static String FORMAT_ATTR = "format";
+	public final static String DATASET_ATTR = "dataset";
 
 	@Override
 	public ViewerFlatfieldCorrectionWrappedImgLoader fromXml(Element elem, File basePath,
@@ -106,10 +109,15 @@ public class XmlIoViewerFlatfieldCorrectionWrappedImgLoader
 		for (Element flatfield : flatfields.getChildren()) {
 			int tp = Integer.parseInt(flatfield.getAttributeValue(TIMEPOINTS_TIMEPOINT_TAG));
 			int vs = Integer.parseInt(flatfield.getAttributeValue(VIEWSETUP_TAG));
-			URI brightImg = XmlHelpers.loadPathURI(flatfield, BRIGHTIMG_TAG, basePathURI);
-			URI darkImg = XmlHelpers.loadPathURI(flatfield, DARKIMG_TAG, basePathURI);
-			res.setBrightImage(new ViewId(tp, vs), brightImg);
-			res.setDarkImage(new ViewId(tp, vs), darkImg);
+			ViewId viewId = new ViewId(tp, vs);
+
+			FlatfieldImageInfo brightInfo = parseFlatfieldImageInfo(flatfield, BRIGHTIMG_TAG, basePathURI);
+			FlatfieldImageInfo darkInfo = parseFlatfieldImageInfo(flatfield, DARKIMG_TAG, basePathURI);
+
+			if (brightInfo != null)
+				res.setBrightImage(viewId, brightInfo);
+			if (darkInfo != null)
+				res.setDarkImage(viewId, darkInfo);
 		}
 
 		res.setActive(active);
@@ -123,7 +131,7 @@ public class XmlIoViewerFlatfieldCorrectionWrappedImgLoader
 
 	@Override
 	public Element toXml(ViewerFlatfieldCorrectionWrappedImgLoader imgLoader, URI basePathURI) {
-		final Map<ViewId, Pair<URI, URI>> uriMap = imgLoader.getUriMap();
+		final Map<ViewId, Pair<FlatfieldImageInfo, FlatfieldImageInfo>> infoMap = imgLoader.getInfoMap();
 
 		final Element wholeElem = new Element(IMGLOADER_TAG);
 		wholeElem.setAttribute(IMGLOADER_FORMAT_ATTRIBUTE_NAME,
@@ -147,19 +155,19 @@ public class XmlIoViewerFlatfieldCorrectionWrappedImgLoader
 
 		final Element elFlatfields = new Element(FLATFIELDS_TAG);
 
-		for (ViewId vid : uriMap.keySet()) {
-			final Pair<URI, URI> uris = uriMap.get(vid);
-			if (uris == null || (uris.getA() == null && uris.getB() == null))
+		for (ViewId vid : infoMap.keySet()) {
+			final Pair<FlatfieldImageInfo, FlatfieldImageInfo> infos = infoMap.get(vid);
+			if (infos == null || (infos.getA() == null && infos.getB() == null))
 				continue;
 
 			final Element elFlatfield = new Element(FLATFIELD_TAG);
 			elFlatfield.setAttribute(TIMEPOINTS_TIMEPOINT_TAG, Integer.toString(vid.getTimePointId()));
 			elFlatfield.setAttribute(VIEWSETUP_TAG, Integer.toString(vid.getViewSetupId()));
 
-			if (uris.getA() != null)
-				elFlatfield.addContent(XmlHelpers.pathElementURI(BRIGHTIMG_TAG, uris.getA(), basePathURI));
-			if (uris.getB() != null)
-				elFlatfield.addContent(XmlHelpers.pathElementURI(DARKIMG_TAG, uris.getB(), basePathURI));
+			if (infos.getA() != null)
+				elFlatfield.addContent(createFlatfieldImageElement(BRIGHTIMG_TAG, infos.getA(), basePathURI));
+			if (infos.getB() != null)
+				elFlatfield.addContent(createFlatfieldImageElement(DARKIMG_TAG, infos.getB(), basePathURI));
 
 			elFlatfields.addContent(elFlatfield);
 		}
@@ -167,5 +175,45 @@ public class XmlIoViewerFlatfieldCorrectionWrappedImgLoader
 		wholeElem.addContent(wrappedIL);
 		wholeElem.addContent(elFlatfields);
 		return wholeElem;
+	}
+
+	/**
+	 * Parse a flatfield image element (BrightImg or DarkImg) into a FlatfieldImageInfo.
+	 *
+	 * @param parent parent element containing the image element
+	 * @param tag the tag name (BRIGHTIMG_TAG or DARKIMG_TAG)
+	 * @param basePathURI base path for resolving relative URIs
+	 * @return FlatfieldImageInfo, or null if element doesn't exist
+	 */
+	protected static FlatfieldImageInfo parseFlatfieldImageInfo(Element parent, String tag, URI basePathURI) {
+		Element imgElement = parent.getChild(tag);
+		if (imgElement == null)
+			return null;
+
+		URI uri = XmlHelpers.loadPathURI(parent, tag, basePathURI);
+		if (uri == null)
+			return null;
+
+		String formatStr = imgElement.getAttributeValue(FORMAT_ATTR);
+		String dataset = imgElement.getAttributeValue(DATASET_ATTR);
+
+		StorageFormat format = FlatfieldImageLoader.parseFormat(formatStr);
+		return new FlatfieldImageInfo(uri, format, dataset);
+	}
+
+	/**
+	 * Create an XML element for a flatfield image with format and dataset attributes.
+	 *
+	 * @param tag the tag name (BRIGHTIMG_TAG or DARKIMG_TAG)
+	 * @param info the flatfield image info
+	 * @param basePathURI base path for creating relative URIs
+	 * @return the XML element
+	 */
+	protected static Element createFlatfieldImageElement(String tag, FlatfieldImageInfo info, URI basePathURI) {
+		Element el = XmlHelpers.pathElementURI(tag, info.getUri(), basePathURI);
+		el.setAttribute(FORMAT_ATTR, FlatfieldImageLoader.formatToString(info.getFormat()));
+		if (info.getDataset() != null && !info.getDataset().isEmpty())
+			el.setAttribute(DATASET_ATTR, info.getDataset());
+		return el;
 	}
 }

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/XmlIoViewerFlatfieldCorrectionWrappedImgLoader.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/XmlIoViewerFlatfieldCorrectionWrappedImgLoader.java
@@ -1,0 +1,175 @@
+/*-
+ * #%L
+ * Software for the reconstruction of multi-view microscopic acquisitions
+ * like Selective Plane Illumination Microscopy (SPIM) Data.
+ * %%
+ * Copyright (C) 2012 - 2025 Multiview Reconstruction developers.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+package net.preibisch.mvrecon.fiji.spimdata.imgloaders.flatfield;
+
+import static mpicbg.spim.data.XmlKeys.IMGLOADER_FORMAT_ATTRIBUTE_NAME;
+import static mpicbg.spim.data.XmlKeys.IMGLOADER_TAG;
+import static mpicbg.spim.data.XmlKeys.TIMEPOINTS_TIMEPOINT_TAG;
+import static mpicbg.spim.data.XmlKeys.VIEWSETUP_TAG;
+
+import java.io.File;
+import java.util.Map;
+
+import org.jdom2.DataConversionException;
+import org.jdom2.Element;
+
+import bdv.ViewerImgLoader;
+import mpicbg.spim.data.SpimDataInstantiationException;
+import mpicbg.spim.data.XmlHelpers;
+import mpicbg.spim.data.generic.sequence.AbstractSequenceDescription;
+import mpicbg.spim.data.generic.sequence.BasicImgLoader;
+import mpicbg.spim.data.generic.sequence.ImgLoaderIo;
+import mpicbg.spim.data.generic.sequence.ImgLoaders;
+import mpicbg.spim.data.generic.sequence.XmlIoBasicImgLoader;
+import mpicbg.spim.data.sequence.ImgLoader;
+import mpicbg.spim.data.sequence.ViewId;
+import net.imglib2.util.Pair;
+
+/**
+ * XML I/O handler for ViewerFlatfieldCorrectionWrappedImgLoader.
+ *
+ * Registers format "spimreconstruction.wrapped.flatfield.viewer" for
+ * ViewerImgLoader-based flatfield correction wrappers.
+ */
+@ImgLoaderIo(format = "spimreconstruction.wrapped.flatfield.viewer", type = ViewerFlatfieldCorrectionWrappedImgLoader.class)
+public class XmlIoViewerFlatfieldCorrectionWrappedImgLoader
+		implements XmlIoBasicImgLoader< ViewerFlatfieldCorrectionWrappedImgLoader >
+{
+	public final static String WRAPPED_IMGLOADER_TAG = "WrappedImgLoader";
+	public final static String FLATFIELDS_TAG = "FlatFields";
+	public final static String FLATFIELD_TAG = "FlatField";
+	public final static String BRIGHTIMG_TAG = "BrightImg";
+	public final static String DARKIMG_TAG = "DarkImg";
+	public final static String ACTIVE_TAG = "Active";
+	public final static String CACHED_TAG = "Cached";
+
+	@Override
+	public ViewerFlatfieldCorrectionWrappedImgLoader fromXml(Element elem, File basePath,
+			AbstractSequenceDescription< ?, ?, ? > sequenceDescription)
+	{
+		Element wrappedImgLoaderEl = elem.getChild( WRAPPED_IMGLOADER_TAG ).getChild( IMGLOADER_TAG );
+		XmlIoBasicImgLoader< ? > xmlIoWrapped = null;
+		try
+		{
+			xmlIoWrapped = ImgLoaders
+					.createXmlIoForFormat( wrappedImgLoaderEl.getAttributeValue( IMGLOADER_FORMAT_ATTRIBUTE_NAME ) );
+		}
+		catch ( SpimDataInstantiationException e )
+		{
+			e.printStackTrace();
+			return null;
+		}
+
+		boolean cached = false;
+		boolean active = false;
+		try
+		{
+			cached = elem.getAttribute( CACHED_TAG ).getBooleanValue();
+			active = elem.getAttribute( ACTIVE_TAG ).getBooleanValue();
+		}
+		catch ( DataConversionException e )
+		{
+			e.printStackTrace();
+		}
+
+		BasicImgLoader wrappedImgLoader = xmlIoWrapped.fromXml( wrappedImgLoaderEl, basePath, sequenceDescription );
+
+		// Verify wrapped loader is a ViewerImgLoader
+		if ( !( wrappedImgLoader instanceof ViewerImgLoader ) )
+		{
+			System.err.println( "ViewerFlatfieldCorrectionWrappedImgLoader requires a ViewerImgLoader, but got: "
+					+ wrappedImgLoader.getClass().getName() );
+			return null;
+		}
+
+		ViewerFlatfieldCorrectionWrappedImgLoader res =
+				new ViewerFlatfieldCorrectionWrappedImgLoader( (ViewerImgLoader) wrappedImgLoader, cached );
+
+		Element flatfields = elem.getChild( FLATFIELDS_TAG );
+		for ( Element flatfield : flatfields.getChildren() )
+		{
+			int tp = Integer.parseInt( flatfield.getAttributeValue( TIMEPOINTS_TIMEPOINT_TAG ) );
+			int vs = Integer.parseInt( flatfield.getAttributeValue( VIEWSETUP_TAG ) );
+			File brightImg = XmlHelpers.loadPath( flatfield, BRIGHTIMG_TAG, basePath );
+			File darkImg = XmlHelpers.loadPath( flatfield, DARKIMG_TAG, basePath );
+			res.setBrightImage( new ViewId( tp, vs ), brightImg );
+			res.setDarkImage( new ViewId( tp, vs ), darkImg );
+		}
+
+		res.setActive( active );
+		return res;
+	}
+
+	@Override
+	public Element toXml(ViewerFlatfieldCorrectionWrappedImgLoader imgLoader, File basePath)
+	{
+		final Map< ViewId, Pair< File, File > > fileMap = imgLoader.fileMap;
+
+		final Element wholeElem = new Element( IMGLOADER_TAG );
+		wholeElem.setAttribute( IMGLOADER_FORMAT_ATTRIBUTE_NAME,
+				this.getClass().getAnnotation( ImgLoaderIo.class ).format() );
+		final Element wrappedIL = new Element( WRAPPED_IMGLOADER_TAG );
+
+		wholeElem.setAttribute( ACTIVE_TAG, Boolean.toString( imgLoader.isActive() ) );
+		wholeElem.setAttribute( CACHED_TAG, Boolean.toString( imgLoader.isCached() ) );
+
+		try
+		{
+			@SuppressWarnings({ "unchecked", "rawtypes" })
+			XmlIoBasicImgLoader loaderIO = ImgLoaders
+					.createXmlIoForImgLoaderClass( imgLoader.getWrappedImgLoader().getClass() );
+			@SuppressWarnings("unchecked")
+			Element wrappedInner = loaderIO.toXml( imgLoader.getWrappedImgLoader(), basePath );
+			wrappedIL.addContent( wrappedInner );
+		}
+		catch ( SpimDataInstantiationException e )
+		{
+			e.printStackTrace();
+			return null;
+		}
+
+		final Element elFlatfields = new Element( FLATFIELDS_TAG );
+
+		for ( ViewId vid : fileMap.keySet() )
+		{
+			final Pair< File, File > files = fileMap.get( vid );
+			if ( files == null || ( files.getA() == null && files.getB() == null ) )
+				continue;
+
+			final Element elFlatfield = new Element( FLATFIELD_TAG );
+			elFlatfield.setAttribute( TIMEPOINTS_TIMEPOINT_TAG, Integer.toString( vid.getTimePointId() ) );
+			elFlatfield.setAttribute( VIEWSETUP_TAG, Integer.toString( vid.getViewSetupId() ) );
+
+			if ( files.getA() != null )
+				elFlatfield.addContent( XmlHelpers.pathElement( BRIGHTIMG_TAG, files.getA(), basePath ) );
+			if ( files.getB() != null )
+				elFlatfield.addContent( XmlHelpers.pathElement( DARKIMG_TAG, files.getB(), basePath ) );
+
+			elFlatfields.addContent( elFlatfield );
+		}
+
+		wholeElem.addContent( wrappedIL );
+		wholeElem.addContent( elFlatfields );
+		return wholeElem;
+	}
+}

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/XmlIoViewerFlatfieldCorrectionWrappedImgLoader.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/XmlIoViewerFlatfieldCorrectionWrappedImgLoader.java
@@ -28,6 +28,7 @@ import static mpicbg.spim.data.XmlKeys.TIMEPOINTS_TIMEPOINT_TAG;
 import static mpicbg.spim.data.XmlKeys.VIEWSETUP_TAG;
 
 import java.io.File;
+import java.net.URI;
 import java.util.Map;
 
 import org.jdom2.DataConversionException;
@@ -64,6 +65,12 @@ public class XmlIoViewerFlatfieldCorrectionWrappedImgLoader
 	@Override
 	public ViewerFlatfieldCorrectionWrappedImgLoader fromXml(Element elem, File basePath,
 			AbstractSequenceDescription<?, ?, ?> sequenceDescription) {
+		return fromXml(elem, basePath == null ? null : basePath.toURI(), sequenceDescription);
+	}
+
+	@Override
+	public ViewerFlatfieldCorrectionWrappedImgLoader fromXml(Element elem, URI basePathURI,
+			AbstractSequenceDescription<?, ?, ?> sequenceDescription) {
 		Element wrappedImgLoaderEl = elem.getChild(WRAPPED_IMGLOADER_TAG).getChild(IMGLOADER_TAG);
 		XmlIoBasicImgLoader<?> xmlIoWrapped;
 		try {
@@ -83,7 +90,7 @@ public class XmlIoViewerFlatfieldCorrectionWrappedImgLoader
 			e.printStackTrace();
 		}
 
-		BasicImgLoader wrappedImgLoader = xmlIoWrapped.fromXml(wrappedImgLoaderEl, basePath, sequenceDescription);
+		BasicImgLoader wrappedImgLoader = xmlIoWrapped.fromXml(wrappedImgLoaderEl, basePathURI, sequenceDescription);
 
 		// Verify wrapped loader is a ViewerImgLoader
 		if (!(wrappedImgLoader instanceof ViewerImgLoader)) {
@@ -99,8 +106,8 @@ public class XmlIoViewerFlatfieldCorrectionWrappedImgLoader
 		for (Element flatfield : flatfields.getChildren()) {
 			int tp = Integer.parseInt(flatfield.getAttributeValue(TIMEPOINTS_TIMEPOINT_TAG));
 			int vs = Integer.parseInt(flatfield.getAttributeValue(VIEWSETUP_TAG));
-			File brightImg = XmlHelpers.loadPath(flatfield, BRIGHTIMG_TAG, basePath);
-			File darkImg = XmlHelpers.loadPath(flatfield, DARKIMG_TAG, basePath);
+			URI brightImg = XmlHelpers.loadPathURI(flatfield, BRIGHTIMG_TAG, basePathURI);
+			URI darkImg = XmlHelpers.loadPathURI(flatfield, DARKIMG_TAG, basePathURI);
 			res.setBrightImage(new ViewId(tp, vs), brightImg);
 			res.setDarkImage(new ViewId(tp, vs), darkImg);
 		}
@@ -111,7 +118,12 @@ public class XmlIoViewerFlatfieldCorrectionWrappedImgLoader
 
 	@Override
 	public Element toXml(ViewerFlatfieldCorrectionWrappedImgLoader imgLoader, File basePath) {
-		final Map<ViewId, Pair<File, File>> fileMap = imgLoader.fileMap;
+		return toXml(imgLoader, basePath == null ? null : basePath.toURI());
+	}
+
+	@Override
+	public Element toXml(ViewerFlatfieldCorrectionWrappedImgLoader imgLoader, URI basePathURI) {
+		final Map<ViewId, Pair<URI, URI>> uriMap = imgLoader.getUriMap();
 
 		final Element wholeElem = new Element(IMGLOADER_TAG);
 		wholeElem.setAttribute(IMGLOADER_FORMAT_ATTRIBUTE_NAME,
@@ -126,7 +138,7 @@ public class XmlIoViewerFlatfieldCorrectionWrappedImgLoader
 			XmlIoBasicImgLoader loaderIO = ImgLoaders
 					.createXmlIoForImgLoaderClass(imgLoader.getWrappedImgLoader().getClass());
 			@SuppressWarnings("unchecked")
-			Element wrappedInner = loaderIO.toXml(imgLoader.getWrappedImgLoader(), basePath);
+			Element wrappedInner = loaderIO.toXml(imgLoader.getWrappedImgLoader(), basePathURI);
 			wrappedIL.addContent(wrappedInner);
 		} catch (SpimDataInstantiationException e) {
 			e.printStackTrace();
@@ -135,19 +147,19 @@ public class XmlIoViewerFlatfieldCorrectionWrappedImgLoader
 
 		final Element elFlatfields = new Element(FLATFIELDS_TAG);
 
-		for (ViewId vid : fileMap.keySet()) {
-			final Pair<File, File> files = fileMap.get(vid);
-			if (files == null || (files.getA() == null && files.getB() == null))
+		for (ViewId vid : uriMap.keySet()) {
+			final Pair<URI, URI> uris = uriMap.get(vid);
+			if (uris == null || (uris.getA() == null && uris.getB() == null))
 				continue;
 
 			final Element elFlatfield = new Element(FLATFIELD_TAG);
 			elFlatfield.setAttribute(TIMEPOINTS_TIMEPOINT_TAG, Integer.toString(vid.getTimePointId()));
 			elFlatfield.setAttribute(VIEWSETUP_TAG, Integer.toString(vid.getViewSetupId()));
 
-			if (files.getA() != null)
-				elFlatfield.addContent(XmlHelpers.pathElement(BRIGHTIMG_TAG, files.getA(), basePath));
-			if (files.getB() != null)
-				elFlatfield.addContent(XmlHelpers.pathElement(DARKIMG_TAG, files.getB(), basePath));
+			if (uris.getA() != null)
+				elFlatfield.addContent(XmlHelpers.pathElementURI(BRIGHTIMG_TAG, uris.getA(), basePathURI));
+			if (uris.getB() != null)
+				elFlatfield.addContent(XmlHelpers.pathElementURI(DARKIMG_TAG, uris.getB(), basePathURI));
 
 			elFlatfields.addContent(elFlatfield);
 		}

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/XmlIoViewerFlatfieldCorrectionWrappedImgLoader.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/flatfield/XmlIoViewerFlatfieldCorrectionWrappedImgLoader.java
@@ -41,7 +41,6 @@ import mpicbg.spim.data.generic.sequence.BasicImgLoader;
 import mpicbg.spim.data.generic.sequence.ImgLoaderIo;
 import mpicbg.spim.data.generic.sequence.ImgLoaders;
 import mpicbg.spim.data.generic.sequence.XmlIoBasicImgLoader;
-import mpicbg.spim.data.sequence.ImgLoader;
 import mpicbg.spim.data.sequence.ViewId;
 import net.imglib2.util.Pair;
 
@@ -53,8 +52,7 @@ import net.imglib2.util.Pair;
  */
 @ImgLoaderIo(format = "spimreconstruction.wrapped.flatfield.viewer", type = ViewerFlatfieldCorrectionWrappedImgLoader.class)
 public class XmlIoViewerFlatfieldCorrectionWrappedImgLoader
-		implements XmlIoBasicImgLoader< ViewerFlatfieldCorrectionWrappedImgLoader >
-{
+		implements XmlIoBasicImgLoader<ViewerFlatfieldCorrectionWrappedImgLoader> {
 	public final static String WRAPPED_IMGLOADER_TAG = "WrappedImgLoader";
 	public final static String FLATFIELDS_TAG = "FlatFields";
 	public final static String FLATFIELD_TAG = "FlatField";
@@ -65,111 +63,97 @@ public class XmlIoViewerFlatfieldCorrectionWrappedImgLoader
 
 	@Override
 	public ViewerFlatfieldCorrectionWrappedImgLoader fromXml(Element elem, File basePath,
-			AbstractSequenceDescription< ?, ?, ? > sequenceDescription)
-	{
-		Element wrappedImgLoaderEl = elem.getChild( WRAPPED_IMGLOADER_TAG ).getChild( IMGLOADER_TAG );
-		XmlIoBasicImgLoader< ? > xmlIoWrapped = null;
-		try
-		{
+			AbstractSequenceDescription<?, ?, ?> sequenceDescription) {
+		Element wrappedImgLoaderEl = elem.getChild(WRAPPED_IMGLOADER_TAG).getChild(IMGLOADER_TAG);
+		XmlIoBasicImgLoader<?> xmlIoWrapped;
+		try {
 			xmlIoWrapped = ImgLoaders
-					.createXmlIoForFormat( wrappedImgLoaderEl.getAttributeValue( IMGLOADER_FORMAT_ATTRIBUTE_NAME ) );
-		}
-		catch ( SpimDataInstantiationException e )
-		{
+					.createXmlIoForFormat(wrappedImgLoaderEl.getAttributeValue(IMGLOADER_FORMAT_ATTRIBUTE_NAME));
+		} catch (SpimDataInstantiationException e) {
 			e.printStackTrace();
 			return null;
 		}
 
 		boolean cached = false;
 		boolean active = false;
-		try
-		{
-			cached = elem.getAttribute( CACHED_TAG ).getBooleanValue();
-			active = elem.getAttribute( ACTIVE_TAG ).getBooleanValue();
-		}
-		catch ( DataConversionException e )
-		{
+		try {
+			cached = elem.getAttribute(CACHED_TAG).getBooleanValue();
+			active = elem.getAttribute(ACTIVE_TAG).getBooleanValue();
+		} catch (DataConversionException e) {
 			e.printStackTrace();
 		}
 
-		BasicImgLoader wrappedImgLoader = xmlIoWrapped.fromXml( wrappedImgLoaderEl, basePath, sequenceDescription );
+		BasicImgLoader wrappedImgLoader = xmlIoWrapped.fromXml(wrappedImgLoaderEl, basePath, sequenceDescription);
 
 		// Verify wrapped loader is a ViewerImgLoader
-		if ( !( wrappedImgLoader instanceof ViewerImgLoader ) )
-		{
-			System.err.println( "ViewerFlatfieldCorrectionWrappedImgLoader requires a ViewerImgLoader, but got: "
-					+ wrappedImgLoader.getClass().getName() );
+		if (!(wrappedImgLoader instanceof ViewerImgLoader)) {
+			System.err.println("ViewerFlatfieldCorrectionWrappedImgLoader requires a ViewerImgLoader, but got: "
+					+ wrappedImgLoader.getClass().getName());
 			return null;
 		}
 
 		ViewerFlatfieldCorrectionWrappedImgLoader res =
-				new ViewerFlatfieldCorrectionWrappedImgLoader( (ViewerImgLoader) wrappedImgLoader, cached );
+				new ViewerFlatfieldCorrectionWrappedImgLoader((ViewerImgLoader) wrappedImgLoader, cached);
 
-		Element flatfields = elem.getChild( FLATFIELDS_TAG );
-		for ( Element flatfield : flatfields.getChildren() )
-		{
-			int tp = Integer.parseInt( flatfield.getAttributeValue( TIMEPOINTS_TIMEPOINT_TAG ) );
-			int vs = Integer.parseInt( flatfield.getAttributeValue( VIEWSETUP_TAG ) );
-			File brightImg = XmlHelpers.loadPath( flatfield, BRIGHTIMG_TAG, basePath );
-			File darkImg = XmlHelpers.loadPath( flatfield, DARKIMG_TAG, basePath );
-			res.setBrightImage( new ViewId( tp, vs ), brightImg );
-			res.setDarkImage( new ViewId( tp, vs ), darkImg );
+		Element flatfields = elem.getChild(FLATFIELDS_TAG);
+		for (Element flatfield : flatfields.getChildren()) {
+			int tp = Integer.parseInt(flatfield.getAttributeValue(TIMEPOINTS_TIMEPOINT_TAG));
+			int vs = Integer.parseInt(flatfield.getAttributeValue(VIEWSETUP_TAG));
+			File brightImg = XmlHelpers.loadPath(flatfield, BRIGHTIMG_TAG, basePath);
+			File darkImg = XmlHelpers.loadPath(flatfield, DARKIMG_TAG, basePath);
+			res.setBrightImage(new ViewId(tp, vs), brightImg);
+			res.setDarkImage(new ViewId(tp, vs), darkImg);
 		}
 
-		res.setActive( active );
+		res.setActive(active);
 		return res;
 	}
 
 	@Override
-	public Element toXml(ViewerFlatfieldCorrectionWrappedImgLoader imgLoader, File basePath)
-	{
-		final Map< ViewId, Pair< File, File > > fileMap = imgLoader.fileMap;
+	public Element toXml(ViewerFlatfieldCorrectionWrappedImgLoader imgLoader, File basePath) {
+		final Map<ViewId, Pair<File, File>> fileMap = imgLoader.fileMap;
 
-		final Element wholeElem = new Element( IMGLOADER_TAG );
-		wholeElem.setAttribute( IMGLOADER_FORMAT_ATTRIBUTE_NAME,
-				this.getClass().getAnnotation( ImgLoaderIo.class ).format() );
-		final Element wrappedIL = new Element( WRAPPED_IMGLOADER_TAG );
+		final Element wholeElem = new Element(IMGLOADER_TAG);
+		wholeElem.setAttribute(IMGLOADER_FORMAT_ATTRIBUTE_NAME,
+				this.getClass().getAnnotation(ImgLoaderIo.class).format());
+		final Element wrappedIL = new Element(WRAPPED_IMGLOADER_TAG);
 
-		wholeElem.setAttribute( ACTIVE_TAG, Boolean.toString( imgLoader.isActive() ) );
-		wholeElem.setAttribute( CACHED_TAG, Boolean.toString( imgLoader.isCached() ) );
+		wholeElem.setAttribute(ACTIVE_TAG, Boolean.toString(imgLoader.isActive()));
+		wholeElem.setAttribute(CACHED_TAG, Boolean.toString(imgLoader.isCached()));
 
-		try
-		{
-			@SuppressWarnings({ "unchecked", "rawtypes" })
+		try {
+			@SuppressWarnings({"rawtypes"})
 			XmlIoBasicImgLoader loaderIO = ImgLoaders
-					.createXmlIoForImgLoaderClass( imgLoader.getWrappedImgLoader().getClass() );
+					.createXmlIoForImgLoaderClass(imgLoader.getWrappedImgLoader().getClass());
 			@SuppressWarnings("unchecked")
-			Element wrappedInner = loaderIO.toXml( imgLoader.getWrappedImgLoader(), basePath );
-			wrappedIL.addContent( wrappedInner );
-		}
-		catch ( SpimDataInstantiationException e )
-		{
+			Element wrappedInner = loaderIO.toXml(imgLoader.getWrappedImgLoader(), basePath);
+			wrappedIL.addContent(wrappedInner);
+		} catch (SpimDataInstantiationException e) {
 			e.printStackTrace();
 			return null;
 		}
 
-		final Element elFlatfields = new Element( FLATFIELDS_TAG );
+		final Element elFlatfields = new Element(FLATFIELDS_TAG);
 
-		for ( ViewId vid : fileMap.keySet() )
-		{
-			final Pair< File, File > files = fileMap.get( vid );
-			if ( files == null || ( files.getA() == null && files.getB() == null ) )
+		for (ViewId vid : fileMap.keySet()) {
+			final Pair<File, File> files = fileMap.get(vid);
+			if (files == null || (files.getA() == null && files.getB() == null))
 				continue;
 
-			final Element elFlatfield = new Element( FLATFIELD_TAG );
-			elFlatfield.setAttribute( TIMEPOINTS_TIMEPOINT_TAG, Integer.toString( vid.getTimePointId() ) );
-			elFlatfield.setAttribute( VIEWSETUP_TAG, Integer.toString( vid.getViewSetupId() ) );
+			final Element elFlatfield = new Element(FLATFIELD_TAG);
+			elFlatfield.setAttribute(TIMEPOINTS_TIMEPOINT_TAG, Integer.toString(vid.getTimePointId()));
+			elFlatfield.setAttribute(VIEWSETUP_TAG, Integer.toString(vid.getViewSetupId()));
 
-			if ( files.getA() != null )
-				elFlatfield.addContent( XmlHelpers.pathElement( BRIGHTIMG_TAG, files.getA(), basePath ) );
-			if ( files.getB() != null )
-				elFlatfield.addContent( XmlHelpers.pathElement( DARKIMG_TAG, files.getB(), basePath ) );
+			if (files.getA() != null)
+				elFlatfield.addContent(XmlHelpers.pathElement(BRIGHTIMG_TAG, files.getA(), basePath));
+			if (files.getB() != null)
+				elFlatfield.addContent(XmlHelpers.pathElement(DARKIMG_TAG, files.getB(), basePath));
 
-			elFlatfields.addContent( elFlatfield );
+			elFlatfields.addContent(elFlatfield);
 		}
 
-		wholeElem.addContent( wrappedIL );
-		wholeElem.addContent( elFlatfields );
+		wholeElem.addContent(wrappedIL);
+		wholeElem.addContent(elFlatfields);
 		return wholeElem;
 	}
 }

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/splitting/SplitMultiResolutionSetupImgLoader.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/splitting/SplitMultiResolutionSetupImgLoader.java
@@ -170,7 +170,11 @@ public class SplitMultiResolutionSetupImgLoader< T > implements MultiResolutionS
 	public RandomAccessibleInterval< FloatType > getFloatImage( int timepointId,
 			int level, boolean normalize, ImgLoaderHint... hints )
 	{
-		throw new RuntimeException( "not supported." );
+		final RandomAccessibleInterval< FloatType > full = underlyingSetupImgLoader.getFloatImage( timepointId, level, normalize, hints );
+
+		updateScaledIntervals( this.scaledIntervals, level, n, full );
+
+		return Views.zeroMin( Views.interval( full, scaledIntervals[ level ] ) );
 	}
 
 	@Override

--- a/src/test/java/net/preibisch/mvrecon/tests/BenchmarkFlatfieldFusion.java
+++ b/src/test/java/net/preibisch/mvrecon/tests/BenchmarkFlatfieldFusion.java
@@ -26,20 +26,27 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 
 import mpicbg.spim.data.SpimDataException;
 import mpicbg.spim.data.sequence.ViewId;
 import net.imglib2.FinalInterval;
 import net.imglib2.Interval;
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.algorithm.blocks.BlockSupplier;
 import net.imglib2.realtransform.AffineTransform3D;
+import net.imglib2.type.numeric.real.FloatType;
 import net.imglib2.type.numeric.integer.UnsignedShortType;
+import net.imglib2.util.Pair;
 import net.preibisch.mvrecon.fiji.plugin.fusion.FusionGUI.FusionType;
 import net.preibisch.mvrecon.fiji.spimdata.SpimData2;
 import net.preibisch.mvrecon.fiji.spimdata.XmlIoSpimData2;
 import net.preibisch.mvrecon.fiji.spimdata.boundingbox.BoundingBox;
 import net.preibisch.mvrecon.fiji.spimdata.imgloaders.flatfield.FlatfieldCorrectionWrappedImgLoader;
+import net.preibisch.mvrecon.fiji.spimdata.imgloaders.flatfield.FlatfieldCorrectionBlockSupplier;
+import net.preibisch.mvrecon.fiji.spimdata.imgloaders.flatfield.FlatfieldImageInfo;
+import net.preibisch.mvrecon.fiji.spimdata.imgloaders.flatfield.FlatfieldImageLoader;
 import net.preibisch.mvrecon.fiji.spimdata.imgloaders.flatfield.ViewerFlatfieldCorrectionWrappedImgLoader;
 import net.preibisch.mvrecon.process.boundingbox.BoundingBoxMaximal;
 import net.preibisch.mvrecon.process.fusion.FusionTools;
@@ -221,6 +228,129 @@ public class BenchmarkFlatfieldFusion {
 
 		System.out.println();
 		System.out.printf("Overhead: %+d ms (%+.1f%%)%n", overhead, overheadPercent);
+		System.out.println("============================================================");
+
+		// Run BlockSupplier comparison if we have a ViewerFlatfieldCorrectionWrappedImgLoader
+		if (viewerFfLoader != null) {
+			System.out.println();
+			runBlockSupplierBenchmark(spimData, viewerFfLoader, viewIds.get(0), boundingBoxFusion);
+		}
+	}
+
+	/**
+	 * Benchmark comparing RandomAccess-based vs BlockSupplier-based flatfield correction.
+	 */
+	private static void runBlockSupplierBenchmark(
+			final SpimData2 spimData,
+			final ViewerFlatfieldCorrectionWrappedImgLoader viewerFfLoader,
+			final ViewId viewId,
+			final Interval boundingBox) {
+		System.out.println("============================================================");
+		System.out.println("BlockSupplier vs RandomAccess Flatfield Correction Benchmark");
+		System.out.println("============================================================");
+		System.out.println();
+
+		// Get bright/dark info for this view
+		final Map<ViewId, Pair<FlatfieldImageInfo, FlatfieldImageInfo>> infoMap = viewerFfLoader.getInfoMap();
+		final Pair<FlatfieldImageInfo, FlatfieldImageInfo> ffInfo = infoMap.get(viewId);
+
+		if (ffInfo == null) {
+			System.out.println("No flatfield info for view " + viewId + ", skipping BlockSupplier benchmark.");
+			return;
+		}
+
+		// Load bright/dark images
+		final FlatfieldImageLoader loader = new FlatfieldImageLoader();
+		loader.setBrightImage(viewId, ffInfo.getA());
+		loader.setDarkImage(viewId, ffInfo.getB());
+
+		final RandomAccessibleInterval<FloatType> brightImg = loader.getBrightImg(viewId);
+		final RandomAccessibleInterval<FloatType> darkImg = loader.getDarkImg(viewId);
+
+		if (brightImg == null || darkImg == null) {
+			System.out.println("Could not load bright/dark images, skipping BlockSupplier benchmark.");
+			return;
+		}
+
+		// Get raw source image (without flatfield correction)
+		viewerFfLoader.setActive(false);
+		@SuppressWarnings("unchecked")
+		final RandomAccessibleInterval<UnsignedShortType> sourceImg =
+				(RandomAccessibleInterval<UnsignedShortType>) viewerFfLoader.getSetupImgLoader(viewId.getViewSetupId())
+						.getImage(viewId.getTimePointId());
+
+		System.out.println("Testing single view: " + viewId);
+		System.out.println("Source dimensions: " + sourceImg.dimension(0) + " x " + sourceImg.dimension(1) + " x " + sourceImg.dimension(2));
+		System.out.println("Bright dimensions: " + brightImg.dimension(0) + " x " + brightImg.dimension(1));
+		System.out.println();
+
+		// Create interval to test (use full XY, limited Z for faster testing)
+		final long[] min = new long[] {sourceImg.min(0), sourceImg.min(1), sourceImg.min(2)};
+		final long[] max = new long[] {sourceImg.max(0), sourceImg.max(1), Math.min(sourceImg.min(2) + 31, sourceImg.max(2))};
+		final FinalInterval testInterval = new FinalInterval(min, max);
+
+		System.out.println("Test interval: [" + min[0] + "-" + max[0] + ", " + min[1] + "-" + max[1] + ", " + min[2] + "-" + max[2] + "]");
+		System.out.println();
+
+		// Create BlockSupplier for comparison
+		final BlockSupplier<FloatType> blockSupplier = FlatfieldCorrectionBlockSupplier.of(sourceImg, brightImg, darkImg);
+
+		// Allocate output array
+		final int len = (int) ((max[0] - min[0] + 1) * (max[1] - min[1] + 1) * (max[2] - min[2] + 1));
+		final float[] output = new float[len];
+
+		// Warmup
+		System.out.println("--- Warmup ---");
+		for (int i = 0; i < 5; i++) {
+			blockSupplier.copy(testInterval, output);
+		}
+
+		// Benchmark BlockSupplier
+		System.out.println("--- BlockSupplier Benchmark ---");
+		final long[] timesBlock = new long[20];
+		for (int i = 0; i < timesBlock.length; i++) {
+			final long start = System.currentTimeMillis();
+			blockSupplier.copy(testInterval, output);
+			timesBlock[i] = System.currentTimeMillis() - start;
+			System.out.println("  Iteration " + (i + 1) + ": " + timesBlock[i] + " ms");
+		}
+
+		// Benchmark RandomAccess-based (via fusion with single view)
+		System.out.println();
+		System.out.println("--- RandomAccess Benchmark (via single-view fusion) ---");
+		viewerFfLoader.setActive(true);
+
+		final long[] timesRA = new long[20];
+		for (int i = 0; i < timesRA.length; i++) {
+			// Re-get the image with correction enabled
+			@SuppressWarnings("unchecked")
+			final RandomAccessibleInterval<UnsignedShortType> correctedImg =
+					(RandomAccessibleInterval<UnsignedShortType>) viewerFfLoader.getSetupImgLoader(viewId.getViewSetupId())
+							.getImage(viewId.getTimePointId());
+
+			final long start = System.currentTimeMillis();
+			// Force computation by copying to array via BlockSupplier
+			final BlockSupplier<FloatType> raBlocks = BlockSupplier
+					.of(net.imglib2.view.Views.extendBorder(correctedImg))
+					.andThen(net.imglib2.algorithm.blocks.convert.Convert.convert(new FloatType()));
+			raBlocks.copy(testInterval, output);
+			timesRA[i] = System.currentTimeMillis() - start;
+			System.out.println("  Iteration " + (i + 1) + ": " + timesRA[i] + " ms");
+		}
+
+		// Calculate and report statistics
+		final Stats statsBlock = calculateStats(timesBlock);
+		final Stats statsRA = calculateStats(timesRA);
+
+		System.out.println();
+		System.out.println("--- Results ---");
+		System.out.printf("BlockSupplier:  avg %d ms (min %d, max %d, stddev %.1f)%n",
+				statsBlock.avg, statsBlock.min, statsBlock.max, statsBlock.stddev);
+		System.out.printf("RandomAccess:   avg %d ms (min %d, max %d, stddev %.1f)%n",
+				statsRA.avg, statsRA.min, statsRA.max, statsRA.stddev);
+
+		final double speedup = (double) statsRA.avg / statsBlock.avg;
+		System.out.printf("%nSpeedup: %.2fx%n", speedup);
 		System.out.println("============================================================");
 	}
 

--- a/src/test/java/net/preibisch/mvrecon/tests/BenchmarkFlatfieldFusion.java
+++ b/src/test/java/net/preibisch/mvrecon/tests/BenchmarkFlatfieldFusion.java
@@ -26,27 +26,20 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.function.Consumer;
 
 import mpicbg.spim.data.SpimDataException;
 import mpicbg.spim.data.sequence.ViewId;
 import net.imglib2.FinalInterval;
 import net.imglib2.Interval;
-import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.algorithm.blocks.BlockSupplier;
 import net.imglib2.realtransform.AffineTransform3D;
-import net.imglib2.type.numeric.real.FloatType;
 import net.imglib2.type.numeric.integer.UnsignedShortType;
-import net.imglib2.util.Pair;
 import net.preibisch.mvrecon.fiji.plugin.fusion.FusionGUI.FusionType;
 import net.preibisch.mvrecon.fiji.spimdata.SpimData2;
 import net.preibisch.mvrecon.fiji.spimdata.XmlIoSpimData2;
 import net.preibisch.mvrecon.fiji.spimdata.boundingbox.BoundingBox;
 import net.preibisch.mvrecon.fiji.spimdata.imgloaders.flatfield.FlatfieldCorrectionWrappedImgLoader;
-import net.preibisch.mvrecon.fiji.spimdata.imgloaders.flatfield.FlatfieldCorrectionBlockSupplier;
-import net.preibisch.mvrecon.fiji.spimdata.imgloaders.flatfield.FlatfieldImageInfo;
-import net.preibisch.mvrecon.fiji.spimdata.imgloaders.flatfield.FlatfieldImageLoader;
 import net.preibisch.mvrecon.fiji.spimdata.imgloaders.flatfield.ViewerFlatfieldCorrectionWrappedImgLoader;
 import net.preibisch.mvrecon.process.boundingbox.BoundingBoxMaximal;
 import net.preibisch.mvrecon.process.fusion.FusionTools;
@@ -228,129 +221,6 @@ public class BenchmarkFlatfieldFusion {
 
 		System.out.println();
 		System.out.printf("Overhead: %+d ms (%+.1f%%)%n", overhead, overheadPercent);
-		System.out.println("============================================================");
-
-		// Run BlockSupplier comparison if we have a ViewerFlatfieldCorrectionWrappedImgLoader
-		if (viewerFfLoader != null) {
-			System.out.println();
-			runBlockSupplierBenchmark(spimData, viewerFfLoader, viewIds.get(0), boundingBoxFusion);
-		}
-	}
-
-	/**
-	 * Benchmark comparing RandomAccess-based vs BlockSupplier-based flatfield correction.
-	 */
-	private static void runBlockSupplierBenchmark(
-			final SpimData2 spimData,
-			final ViewerFlatfieldCorrectionWrappedImgLoader viewerFfLoader,
-			final ViewId viewId,
-			final Interval boundingBox) {
-		System.out.println("============================================================");
-		System.out.println("BlockSupplier vs RandomAccess Flatfield Correction Benchmark");
-		System.out.println("============================================================");
-		System.out.println();
-
-		// Get bright/dark info for this view
-		final Map<ViewId, Pair<FlatfieldImageInfo, FlatfieldImageInfo>> infoMap = viewerFfLoader.getInfoMap();
-		final Pair<FlatfieldImageInfo, FlatfieldImageInfo> ffInfo = infoMap.get(viewId);
-
-		if (ffInfo == null) {
-			System.out.println("No flatfield info for view " + viewId + ", skipping BlockSupplier benchmark.");
-			return;
-		}
-
-		// Load bright/dark images
-		final FlatfieldImageLoader loader = new FlatfieldImageLoader();
-		loader.setBrightImage(viewId, ffInfo.getA());
-		loader.setDarkImage(viewId, ffInfo.getB());
-
-		final RandomAccessibleInterval<FloatType> brightImg = loader.getBrightImg(viewId);
-		final RandomAccessibleInterval<FloatType> darkImg = loader.getDarkImg(viewId);
-
-		if (brightImg == null || darkImg == null) {
-			System.out.println("Could not load bright/dark images, skipping BlockSupplier benchmark.");
-			return;
-		}
-
-		// Get raw source image (without flatfield correction)
-		viewerFfLoader.setActive(false);
-		@SuppressWarnings("unchecked")
-		final RandomAccessibleInterval<UnsignedShortType> sourceImg =
-				(RandomAccessibleInterval<UnsignedShortType>) viewerFfLoader.getSetupImgLoader(viewId.getViewSetupId())
-						.getImage(viewId.getTimePointId());
-
-		System.out.println("Testing single view: " + viewId);
-		System.out.println("Source dimensions: " + sourceImg.dimension(0) + " x " + sourceImg.dimension(1) + " x " + sourceImg.dimension(2));
-		System.out.println("Bright dimensions: " + brightImg.dimension(0) + " x " + brightImg.dimension(1));
-		System.out.println();
-
-		// Create interval to test (use full XY, limited Z for faster testing)
-		final long[] min = new long[] {sourceImg.min(0), sourceImg.min(1), sourceImg.min(2)};
-		final long[] max = new long[] {sourceImg.max(0), sourceImg.max(1), Math.min(sourceImg.min(2) + 31, sourceImg.max(2))};
-		final FinalInterval testInterval = new FinalInterval(min, max);
-
-		System.out.println("Test interval: [" + min[0] + "-" + max[0] + ", " + min[1] + "-" + max[1] + ", " + min[2] + "-" + max[2] + "]");
-		System.out.println();
-
-		// Create BlockSupplier for comparison
-		final BlockSupplier<FloatType> blockSupplier = FlatfieldCorrectionBlockSupplier.of(sourceImg, brightImg, darkImg);
-
-		// Allocate output array
-		final int len = (int) ((max[0] - min[0] + 1) * (max[1] - min[1] + 1) * (max[2] - min[2] + 1));
-		final float[] output = new float[len];
-
-		// Warmup
-		System.out.println("--- Warmup ---");
-		for (int i = 0; i < 5; i++) {
-			blockSupplier.copy(testInterval, output);
-		}
-
-		// Benchmark BlockSupplier
-		System.out.println("--- BlockSupplier Benchmark ---");
-		final long[] timesBlock = new long[20];
-		for (int i = 0; i < timesBlock.length; i++) {
-			final long start = System.currentTimeMillis();
-			blockSupplier.copy(testInterval, output);
-			timesBlock[i] = System.currentTimeMillis() - start;
-			System.out.println("  Iteration " + (i + 1) + ": " + timesBlock[i] + " ms");
-		}
-
-		// Benchmark RandomAccess-based (via fusion with single view)
-		System.out.println();
-		System.out.println("--- RandomAccess Benchmark (via single-view fusion) ---");
-		viewerFfLoader.setActive(true);
-
-		final long[] timesRA = new long[20];
-		for (int i = 0; i < timesRA.length; i++) {
-			// Re-get the image with correction enabled
-			@SuppressWarnings("unchecked")
-			final RandomAccessibleInterval<UnsignedShortType> correctedImg =
-					(RandomAccessibleInterval<UnsignedShortType>) viewerFfLoader.getSetupImgLoader(viewId.getViewSetupId())
-							.getImage(viewId.getTimePointId());
-
-			final long start = System.currentTimeMillis();
-			// Force computation by copying to array via BlockSupplier
-			final BlockSupplier<FloatType> raBlocks = BlockSupplier
-					.of(net.imglib2.view.Views.extendBorder(correctedImg))
-					.andThen(net.imglib2.algorithm.blocks.convert.Convert.convert(new FloatType()));
-			raBlocks.copy(testInterval, output);
-			timesRA[i] = System.currentTimeMillis() - start;
-			System.out.println("  Iteration " + (i + 1) + ": " + timesRA[i] + " ms");
-		}
-
-		// Calculate and report statistics
-		final Stats statsBlock = calculateStats(timesBlock);
-		final Stats statsRA = calculateStats(timesRA);
-
-		System.out.println();
-		System.out.println("--- Results ---");
-		System.out.printf("BlockSupplier:  avg %d ms (min %d, max %d, stddev %.1f)%n",
-				statsBlock.avg, statsBlock.min, statsBlock.max, statsBlock.stddev);
-		System.out.printf("RandomAccess:   avg %d ms (min %d, max %d, stddev %.1f)%n",
-				statsRA.avg, statsRA.min, statsRA.max, statsRA.stddev);
-
-		final double speedup = (double) statsRA.avg / statsBlock.avg;
-		System.out.printf("%nSpeedup: %.2fx%n", speedup);
 		System.out.println("============================================================");
 	}
 

--- a/src/test/java/net/preibisch/mvrecon/tests/BenchmarkFlatfieldFusion.java
+++ b/src/test/java/net/preibisch/mvrecon/tests/BenchmarkFlatfieldFusion.java
@@ -1,0 +1,291 @@
+/*-
+ * #%L
+ * Software for the reconstruction of multi-view microscopic acquisitions
+ * like Selective Plane Illumination Microscopy (SPIM) Data.
+ * %%
+ * Copyright (C) 2012 - 2025 Multiview Reconstruction developers.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+package net.preibisch.mvrecon.tests;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.function.Consumer;
+
+import mpicbg.spim.data.SpimDataException;
+import mpicbg.spim.data.sequence.ViewId;
+import net.imglib2.FinalInterval;
+import net.imglib2.Interval;
+import net.imglib2.algorithm.blocks.BlockSupplier;
+import net.imglib2.realtransform.AffineTransform3D;
+import net.imglib2.type.numeric.integer.UnsignedShortType;
+import net.preibisch.mvrecon.fiji.plugin.fusion.FusionGUI.FusionType;
+import net.preibisch.mvrecon.fiji.spimdata.SpimData2;
+import net.preibisch.mvrecon.fiji.spimdata.XmlIoSpimData2;
+import net.preibisch.mvrecon.fiji.spimdata.boundingbox.BoundingBox;
+import net.preibisch.mvrecon.fiji.spimdata.imgloaders.flatfield.FlatfieldCorrectionWrappedImgLoader;
+import net.preibisch.mvrecon.fiji.spimdata.imgloaders.flatfield.ViewerFlatfieldCorrectionWrappedImgLoader;
+import net.preibisch.mvrecon.process.boundingbox.BoundingBoxMaximal;
+import net.preibisch.mvrecon.process.fusion.FusionTools;
+import net.preibisch.mvrecon.process.fusion.blk.BlkAffineFusion;
+import net.preibisch.mvrecon.process.fusion.transformed.TransformVirtual;
+import util.BlockSupplierUtils;
+
+/**
+ * Benchmark to measure the performance overhead of lazy flatfield correction during multi-view fusion.
+ *
+ * This benchmark:
+ * 1. Loads a dataset with flatfield correction configured (data/dataset_corrected_viewer.xml)
+ * 2. Toggles flatfield correction on/off using setActive()
+ * 3. Runs fusion with and without correction
+ * 4. Measures and reports timing comparison
+ *
+ * Run with: mvn compile exec:java -Dexec.mainClass="net.preibisch.mvrecon.tests.BenchmarkFlatfieldFusion"
+ * Or run from IDE as a Java application.
+ */
+public class BenchmarkFlatfieldFusion {
+	// Benchmark configuration
+	private static final double DOWNSAMPLING = 4.0;
+	private static final double ANISOTROPY_FACTOR = 3.0; // matches dataset's 1x1x3 voxel size
+	private static final int WARMUP_ITERATIONS = 10;
+	private static final int BENCHMARK_ITERATIONS = 50;
+	private static final FusionType FUSION_TYPE = FusionType.AVG_BLEND;
+	private static final int[] BLOCK_SIZE = new int[] {64, 64, 64};
+
+	public static void main(String[] args) {
+		// Path to dataset with flatfield correction
+		final File xmlFile = new File("data/dataset_corrected_viewer.xml");
+
+		if (!xmlFile.exists()) {
+			System.err.println("Dataset not found: " + xmlFile.getAbsolutePath());
+			System.err.println("Please ensure data/dataset_corrected_viewer.xml exists.");
+			System.exit(1);
+		}
+
+		try {
+			runBenchmark(xmlFile);
+		} catch (Exception e) {
+			System.err.println("Benchmark failed: " + e.getMessage());
+			e.printStackTrace();
+			System.exit(1);
+		}
+	}
+
+	private static void runBenchmark(final File xmlFile) throws SpimDataException {
+		System.out.println("============================================================");
+		System.out.println("Flatfield Correction Benchmark During Fusion");
+		System.out.println("============================================================");
+		System.out.println();
+
+		// Load the dataset
+		System.out.println("Loading dataset: " + xmlFile.getAbsolutePath());
+		final SpimData2 spimData = new XmlIoSpimData2().load(xmlFile.toURI());
+
+		// Get the flatfield-wrapped image loader
+		// Support both FlatfieldCorrectionWrappedImgLoader (interface) and ViewerFlatfieldCorrectionWrappedImgLoader (class)
+		final FlatfieldCorrectionWrappedImgLoader<?> ffLoader;
+		final ViewerFlatfieldCorrectionWrappedImgLoader viewerFfLoader;
+
+		if (spimData.getSequenceDescription().getImgLoader() instanceof FlatfieldCorrectionWrappedImgLoader) {
+			ffLoader = (FlatfieldCorrectionWrappedImgLoader<?>) spimData.getSequenceDescription().getImgLoader();
+			viewerFfLoader = null;
+		} else if (spimData.getSequenceDescription().getImgLoader() instanceof ViewerFlatfieldCorrectionWrappedImgLoader) {
+			ffLoader = null;
+			viewerFfLoader = (ViewerFlatfieldCorrectionWrappedImgLoader) spimData.getSequenceDescription().getImgLoader();
+		} else {
+			System.err.println("Dataset does not have a flatfield correction image loader.");
+			System.err.println("ImgLoader type: " + spimData.getSequenceDescription().getImgLoader().getClass().getName());
+			return;
+		}
+
+		// Create a lambda to toggle flatfield correction for either loader type
+		final Consumer<Boolean> setActive = (active) -> {
+			if (ffLoader != null)
+				ffLoader.setActive(active);
+			else
+				viewerFfLoader.setActive(active);
+		};
+
+		// Get all views
+		final List<ViewId> viewIds = new ArrayList<>();
+		viewIds.addAll(spimData.getSequenceDescription().getViewDescriptions().values());
+		SpimData2.filterMissingViews(spimData, viewIds);
+
+		System.out.println();
+		System.out.println("Dataset Information:");
+		System.out.println("  Views: " + viewIds.size());
+		System.out.println("  Downsampling: " + DOWNSAMPLING + ", Anisotropy: " + ANISOTROPY_FACTOR);
+		System.out.println("  Fusion type: " + FUSION_TYPE);
+		System.out.println("  Block size: " + BLOCK_SIZE[0] + "x" + BLOCK_SIZE[1] + "x" + BLOCK_SIZE[2]);
+		System.out.println("  Warmup iterations: " + WARMUP_ITERATIONS + ", Benchmark iterations: " + BENCHMARK_ITERATIONS);
+
+		// Compute bounding box
+		final BoundingBox bb = new BoundingBoxMaximal(viewIds, spimData).estimate("benchmark");
+		System.out.println("  Bounding box: [" + bb.getMin()[0] + ", " + bb.getMin()[1] + ", " + bb.getMin()[2] +
+				"] to [" + bb.getMax()[0] + ", " + bb.getMax()[1] + ", " + bb.getMax()[2] + "]");
+
+		// Apply anisotropy and downsampling to bounding box
+		Interval boundingBoxFusion = FusionTools.createAnisotropicBoundingBox(bb, ANISOTROPY_FACTOR).getA();
+		boundingBoxFusion = FusionTools.createDownsampledBoundingBox(boundingBoxFusion, DOWNSAMPLING).getA();
+
+		final long[] dims = boundingBoxFusion.dimensionsAsLongArray();
+		System.out.println("  Fusion dimensions: " + dims[0] + " x " + dims[1] + " x " + dims[2]);
+		System.out.println();
+
+		// Adjust view registrations for anisotropy and downsampling
+		final HashMap<ViewId, AffineTransform3D> registrations =
+				TransformVirtual.adjustAllTransforms(
+						viewIds,
+						spimData.getViewRegistrations().getViewRegistrations(),
+						ANISOTROPY_FACTOR,
+						DOWNSAMPLING);
+
+		// Warmup runs
+		System.out.println("--- Warmup Phase ---");
+
+		for (int i = 0; i < WARMUP_ITERATIONS; i++) {
+			System.out.print("  Warmup WITHOUT FF (" + (i + 1) + "/" + WARMUP_ITERATIONS + ")... ");
+			setActive.accept(false);
+			runFusion(spimData, viewIds, registrations, boundingBoxFusion);
+			System.out.println("done");
+		}
+
+		for (int i = 0; i < WARMUP_ITERATIONS; i++) {
+			System.out.print("  Warmup WITH FF (" + (i + 1) + "/" + WARMUP_ITERATIONS + ")... ");
+			setActive.accept(true);
+			runFusion(spimData, viewIds, registrations, boundingBoxFusion);
+			System.out.println("done");
+		}
+
+		System.out.println();
+
+		// Benchmark WITHOUT flatfield correction
+		System.out.println("--- Benchmark Phase ---");
+		System.out.println("Running WITHOUT flatfield correction...");
+		setActive.accept(false);
+		final long[] timesWithout = new long[BENCHMARK_ITERATIONS];
+
+		for (int i = 0; i < BENCHMARK_ITERATIONS; i++) {
+			System.out.print("  Iteration " + (i + 1) + "/" + BENCHMARK_ITERATIONS + ": ");
+			final long start = System.currentTimeMillis();
+			runFusion(spimData, viewIds, registrations, boundingBoxFusion);
+			timesWithout[i] = System.currentTimeMillis() - start;
+			System.out.println(timesWithout[i] + " ms");
+		}
+
+		System.out.println();
+
+		// Benchmark WITH flatfield correction
+		System.out.println("Running WITH flatfield correction...");
+		setActive.accept(true);
+		final long[] timesWith = new long[BENCHMARK_ITERATIONS];
+
+		for (int i = 0; i < BENCHMARK_ITERATIONS; i++) {
+			System.out.print("  Iteration " + (i + 1) + "/" + BENCHMARK_ITERATIONS + ": ");
+			final long start = System.currentTimeMillis();
+			runFusion(spimData, viewIds, registrations, boundingBoxFusion);
+			timesWith[i] = System.currentTimeMillis() - start;
+			System.out.println(timesWith[i] + " ms");
+		}
+
+		System.out.println();
+
+		// Calculate and report statistics
+		final Stats statsWithout = calculateStats(timesWithout);
+		final Stats statsWith = calculateStats(timesWith);
+
+		System.out.println("--- Benchmark Results ---");
+		System.out.printf("Without FF: avg %d ms (min %d, max %d, stddev %.1f)%n",
+				statsWithout.avg, statsWithout.min, statsWithout.max, statsWithout.stddev);
+		System.out.printf("With FF:    avg %d ms (min %d, max %d, stddev %.1f)%n",
+				statsWith.avg, statsWith.min, statsWith.max, statsWith.stddev);
+
+		final long overhead = statsWith.avg - statsWithout.avg;
+		final double overheadPercent = 100.0 * overhead / statsWithout.avg;
+
+		System.out.println();
+		System.out.printf("Overhead: %+d ms (%+.1f%%)%n", overhead, overheadPercent);
+		System.out.println("============================================================");
+	}
+
+	/**
+	 * Run fusion and force full computation by copying to ArrayImg.
+	 */
+	private static void runFusion(
+			final SpimData2 spimData,
+			final List<ViewId> viewIds,
+			final HashMap<ViewId, AffineTransform3D> registrations,
+			final Interval boundingBoxFusion) {
+		// Create fusion BlockSupplier
+		final BlockSupplier<UnsignedShortType> blocks = BlkAffineFusion.init(
+				(i, o) -> o.set(Math.round(i.get())),
+				spimData.getSequenceDescription().getImgLoader(),
+				viewIds,
+				registrations,
+				spimData.getSequenceDescription().getViewDescriptions(),
+				FUSION_TYPE,
+				ANISOTROPY_FACTOR,
+				1, // interpolation: linear
+				null, // no intensity adjustments
+				boundingBoxFusion,
+				new UnsignedShortType(),
+				BLOCK_SIZE);
+
+		// Force full computation by copying to ArrayImg (not lazy CellImg)
+		// This ensures all flatfield calculations are performed
+		BlockSupplierUtils.arrayImg(blocks, new FinalInterval(boundingBoxFusion.dimensionsAsLongArray()));
+	}
+
+	private static Stats calculateStats(final long[] times) {
+		long sum = 0;
+		long min = Long.MAX_VALUE;
+		long max = Long.MIN_VALUE;
+
+		for (final long t : times) {
+			sum += t;
+			min = Math.min(min, t);
+			max = Math.max(max, t);
+		}
+
+		final long avg = sum / times.length;
+
+		double variance = 0;
+		for (final long t : times) {
+			variance += (t - avg) * (t - avg);
+		}
+		variance /= times.length;
+		final double stddev = Math.sqrt(variance);
+
+		return new Stats(avg, min, max, stddev);
+	}
+
+	private static class Stats {
+		final long avg;
+		final long min;
+		final long max;
+		final double stddev;
+
+		Stats(long avg, long min, long max, double stddev) {
+			this.avg = avg;
+			this.min = min;
+			this.max = max;
+			this.stddev = stddev;
+		}
+	}
+}


### PR DESCRIPTION
This PR aims to update the lazy flatfield correction code in `net.preibisch.mvrecon.fiji.spimdata.imgloaders.flatfield` in several ways:

- add an image loader that implements the `ViewerImgLoader` interface
- use improved downsampling code for on-the-fly downsampling of flatfields
- use the N5 api to load the flatfields to also be able to work with chunked / cloud storage

This is still a draft as more features will likely still be added.