### PR TITLE
New n5 writer being opened for every viewId (save Interest Points)

### DIFF
--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/XmlIoSpimData2.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/XmlIoSpimData2.java
@@ -35,6 +35,8 @@ import java.util.stream.Collectors;
 import mpicbg.spim.data.sequence.ViewId;
 
 import org.janelia.saalfeldlab.n5.N5FSWriter;
+import org.janelia.saalfeldlab.n5.N5Writer;
+import org.janelia.saalfeldlab.n5.universe.StorageFormat;
 import org.jdom2.Element;
 
 import mpicbg.spim.data.SpimDataException;
@@ -140,11 +142,11 @@ public class XmlIoSpimData2 extends XmlIoAbstractSpimData< SequenceDescription, 
 
 		try
 		{
-			XmlIoSpimData2.saveInterestPointsInParallel( spimData );
+			XmlIoSpimData2.saveInterestPointsSharedWriter( spimData );
 		}
 		catch ( Exception e )
 		{
-			throw new SpimDataException( "Could not interest points for '" + lastURI() + "' in paralell: " + e );
+			throw new SpimDataException( "Could not save interest points for '" + lastURI() + "': " + e );
 		}
 
 		try
@@ -316,43 +318,11 @@ public class XmlIoSpimData2 extends XmlIoAbstractSpimData< SequenceDescription, 
 		}
 	}
 
+	/** @deprecated Use {@link #saveInterestPointsSharedWriter(SpimData2)} instead. */
+	@Deprecated
 	public static void saveInterestPointsInParallel( final SpimData2 spimData )
 	{
-		final int numThreads = Threads.numThreads();
-		IOFunctions.println( "Saving interest points multi-threaded (" + numThreads + " threads) ... " );
-
-		// collect first to avoid nested parallel streams
-		final ArrayList< InterestPoints > allIPs = new ArrayList<>();
-
-		spimData.getViewInterestPoints().getViewInterestPoints().values().forEach( vipl ->
-			allIPs.addAll( vipl.getHashMap().values() ) );
-
-		final ForkJoinPool pool = new ForkJoinPool( numThreads );
-		try
-		{
-			pool.submit( () ->
-				allIPs.parallelStream().forEach( ipl ->
-				{
-					try
-					{
-						ipl.saveInterestPoints( false );
-						ipl.saveCorrespondingInterestPoints( false );
-					}
-					catch ( Exception e )
-					{
-						IOFunctions.println( "Could not save interest points for (trying to skip): " + ipl.getXMLRepresentation()  );
-					}
-				})
-			).get();
-		}
-		catch ( final Exception e )
-		{
-			throw new RuntimeException( "Failed to save interest points in parallel", e );
-		}
-		finally
-		{
-			pool.shutdown();
-		}
+		saveInterestPointsSharedWriter( spimData );
 	}
 
 	// ==================== Spark-Compatible Methods ====================
@@ -393,16 +363,27 @@ public class XmlIoSpimData2 extends XmlIoAbstractSpimData< SequenceDescription, 
 		return allData;
 	}
 
-	/**
-	 * Save interest points using static methods (suitable for Spark).
-	 * This method saves both interest points and correspondences using the static API.
-	 *
-	 * @param spimData The SpimData2
-	 */
+	/** @deprecated Use {@link #saveInterestPointsSharedWriter(SpimData2)} instead. */
+	@Deprecated
 	public static void saveInterestPointsInParallelStatic( final SpimData2 spimData )
 	{
-		final int numThreads = Threads.numThreads();
-		IOFunctions.println( "Saving interest points (static) multi-threaded (" + numThreads + " threads) ... " );
+		saveInterestPointsSharedWriter( spimData );
+	}
+
+	/**
+	 * Save all interest points using a single shared N5Writer, avoiding the per-view
+	 * open/close overhead. Intended for use in BigStitcher-Spark after batch interest
+	 * point detection, where many views are saved sequentially on a single executor.
+	 *
+	 * Unlike {@link #saveInterestPointsInParallelStatic(SpimData2)}, this method is
+	 * sequential and safe to call even when the N5Writer implementation is not
+	 * thread-safe for concurrent writes.
+	 *
+	 * @param spimData the SpimData2 object whose interest points should be saved
+	 */
+	public static void saveInterestPointsSharedWriter( final SpimData2 spimData )
+	{
+		IOFunctions.println( "Saving interest points with shared N5Writer ... " );
 
 		final URI baseDir = spimData.getBasePathURI();
 		final List< InterestPointData > allData = collectInterestPointData( spimData, true );
@@ -412,27 +393,20 @@ public class XmlIoSpimData2 extends XmlIoAbstractSpimData< SequenceDescription, 
 		if ( allData.isEmpty() )
 			return;
 
-		final ForkJoinPool pool = new ForkJoinPool( numThreads );
-		try
+		try ( final N5Writer n5Writer = URITools.instantiateN5Writer( StorageFormat.N5, URITools.toURI( URITools.appendName( baseDir, InterestPointsN5.baseN5 ) ) ) )
 		{
-			pool.submit( () ->
-				allData.parallelStream().forEach( data ->
+			for ( final InterestPointData data : allData )
+			{
+				if ( !InterestPointsN5.saveInterestPointDataStatic( n5Writer, data ) )
 				{
-					if ( !InterestPointsN5.saveInterestPointDataStatic( baseDir, data ) )
-					{
-						IOFunctions.println( "ERROR: Could not save interest points for tp=" +
-								data.timepointId + ", setup=" + data.setupId + ", label=" + data.label );
-					}
-				})
-			).get();
+					IOFunctions.println( "ERROR: Could not save interest points for tp=" +
+							data.timepointId + ", setup=" + data.setupId + ", label=" + data.label );
+				}
+			}
 		}
 		catch ( final Exception e )
 		{
-			throw new RuntimeException( "Failed to save interest points in parallel (static)", e );
-		}
-		finally
-		{
-			pool.shutdown();
+			throw new RuntimeException( "Failed to save interest points with shared writer", e );
 		}
 	}
 }

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/XmlIoSpimData2.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/XmlIoSpimData2.java
@@ -371,42 +371,64 @@ public class XmlIoSpimData2 extends XmlIoAbstractSpimData< SequenceDescription, 
 	}
 
 	/**
-	 * Save all interest points using a single shared N5Writer, avoiding the per-view
-	 * open/close overhead. Intended for use in BigStitcher-Spark after batch interest
-	 * point detection, where many views are saved sequentially on a single executor.
-	 *
-	 * Unlike {@link #saveInterestPointsInParallelStatic(SpimData2)}, this method is
-	 * sequential and safe to call even when the N5Writer implementation is not
-	 * thread-safe for concurrent writes.
+	 * Save all interest points using a single shared N5Writer with parallel writes.
+	 * Opens the N5Writer once and reuses it across all views, avoiding per-view
+	 * open/close overhead while preserving parallel write performance.
+	 * Each view writes to an independent dataset path so concurrent writes are safe.
+	 * Modified flags are cleared on each InterestPoints instance after a successful save,
+	 * so subsequent XML serialization does not trigger a redundant second save.
 	 *
 	 * @param spimData the SpimData2 object whose interest points should be saved
 	 */
 	public static void saveInterestPointsSharedWriter( final SpimData2 spimData )
 	{
-		IOFunctions.println( "Saving interest points with shared N5Writer ... " );
+		final int numThreads = Threads.numThreads();
+		IOFunctions.println( "Saving interest points with shared N5Writer (" + numThreads + " threads) ... " );
 
 		final URI baseDir = spimData.getBasePathURI();
-		final List< InterestPointData > allData = collectInterestPointData( spimData, true );
 
-		IOFunctions.println( "Collected " + allData.size() + " interest point sets to save." );
+		// collect first to avoid nested parallel streams
+		final ArrayList< InterestPoints > allIPs = new ArrayList<>();
+		spimData.getViewInterestPoints().getViewInterestPoints().values().forEach( vipl ->
+			allIPs.addAll( vipl.getHashMap().values() ) );
 
-		if ( allData.isEmpty() )
+		if ( allIPs.isEmpty() )
 			return;
 
+		final ForkJoinPool pool = new ForkJoinPool( numThreads );
 		try ( final N5Writer n5Writer = URITools.instantiateN5Writer( StorageFormat.N5, URITools.toURI( URITools.appendName( baseDir, InterestPointsN5.baseN5 ) ) ) )
 		{
-			for ( final InterestPointData data : allData )
-			{
-				if ( !InterestPointsN5.saveInterestPointDataStatic( n5Writer, data ) )
+			pool.submit( () ->
+				allIPs.parallelStream().forEach( ipl ->
 				{
-					IOFunctions.println( "ERROR: Could not save interest points for tp=" +
-							data.timepointId + ", setup=" + data.setupId + ", label=" + data.label );
-				}
-			}
+					try
+					{
+						if ( ipl instanceof InterestPointsN5 )
+						{
+							final InterestPointsN5 ipsN5 = (InterestPointsN5) ipl;
+							ipsN5.saveInterestPoints( false, n5Writer );
+							ipsN5.saveCorrespondingInterestPoints( false, n5Writer );
+						}
+						else
+						{
+							ipl.saveInterestPoints( false );
+							ipl.saveCorrespondingInterestPoints( false );
+						}
+					}
+					catch ( Exception e )
+					{
+						IOFunctions.println( "Could not save interest points for (trying to skip): " + ipl.getXMLRepresentation() );
+					}
+				})
+			).get();
 		}
 		catch ( final Exception e )
 		{
 			throw new RuntimeException( "Failed to save interest points with shared writer", e );
+		}
+		finally
+		{
+			pool.shutdown();
 		}
 	}
 }

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/XmlIoSpimData2.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/XmlIoSpimData2.java
@@ -142,7 +142,7 @@ public class XmlIoSpimData2 extends XmlIoAbstractSpimData< SequenceDescription, 
 
 		try
 		{
-			XmlIoSpimData2.saveInterestPointsSharedWriter( spimData );
+			XmlIoSpimData2.saveInterestPointsInParallel( spimData );
 		}
 		catch ( Exception e )
 		{
@@ -318,58 +318,6 @@ public class XmlIoSpimData2 extends XmlIoAbstractSpimData< SequenceDescription, 
 		}
 	}
 
-	/** @deprecated Use {@link #saveInterestPointsSharedWriter(SpimData2)} instead. */
-	@Deprecated
-	public static void saveInterestPointsInParallel( final SpimData2 spimData )
-	{
-		saveInterestPointsSharedWriter( spimData );
-	}
-
-	// ==================== Spark-Compatible Methods ====================
-
-	/**
-	 * Collect all modified interest points as serializable InterestPointData objects.
-	 * This method is useful for Spark-based parallel saving.
-	 *
-	 * @param spimData The SpimData2
-	 * @param modifiedOnly If true, only include interest points that have been modified
-	 * @return List of InterestPointData suitable for Spark RDD operations
-	 */
-	public static List< InterestPointData > collectInterestPointData( final SpimData2 spimData, final boolean modifiedOnly )
-	{
-		final List< InterestPointData > allData = new ArrayList<>();
-
-		for ( final Entry< ViewId, ViewInterestPointLists > entry : spimData.getViewInterestPoints().getViewInterestPoints().entrySet() )
-		{
-			final ViewId viewId = entry.getKey();
-			final ViewInterestPointLists vipl = entry.getValue();
-
-			for ( final Entry< String, InterestPoints > labelEntry : vipl.getHashMap().entrySet() )
-			{
-				final String label = labelEntry.getKey();
-				final InterestPoints ips = labelEntry.getValue();
-
-				// Only include if modified (or if modifiedOnly is false)
-				if ( !modifiedOnly || ips.hasModifiedInterestPoints() || ips.hasModifiedCorrespondingInterestPoints() )
-				{
-					if ( !( ips instanceof InterestPointsN5 ) )
-						throw new RuntimeException( "InterestPointData.from() requires InterestPointsN5, got: " + ips.getClass().getName() );
-
-					allData.add( InterestPointData.from( viewId, label, (InterestPointsN5) ips ) );
-				}
-			}
-		}
-
-		return allData;
-	}
-
-	/** @deprecated Use {@link #saveInterestPointsSharedWriter(SpimData2)} instead. */
-	@Deprecated
-	public static void saveInterestPointsInParallelStatic( final SpimData2 spimData )
-	{
-		saveInterestPointsSharedWriter( spimData );
-	}
-
 	/**
 	 * Save all interest points using a single shared N5Writer with parallel writes.
 	 * Opens the N5Writer once and reuses it across all views, avoiding per-view
@@ -380,10 +328,10 @@ public class XmlIoSpimData2 extends XmlIoAbstractSpimData< SequenceDescription, 
 	 *
 	 * @param spimData the SpimData2 object whose interest points should be saved
 	 */
-	public static void saveInterestPointsSharedWriter( final SpimData2 spimData )
+	public static void saveInterestPointsInParallel( final SpimData2 spimData )
 	{
 		final int numThreads = Threads.numThreads();
-		IOFunctions.println( "Saving interest points with shared N5Writer (" + numThreads + " threads) ... " );
+		IOFunctions.println( "Saving interest points multi-threaded (" + numThreads + " threads) ... " );
 
 		final URI baseDir = spimData.getBasePathURI();
 
@@ -424,11 +372,56 @@ public class XmlIoSpimData2 extends XmlIoAbstractSpimData< SequenceDescription, 
 		}
 		catch ( final Exception e )
 		{
-			throw new RuntimeException( "Failed to save interest points with shared writer", e );
+			throw new RuntimeException( "Failed to save interest points in parallel", e );
 		}
 		finally
 		{
 			pool.shutdown();
 		}
+	}
+
+	// ==================== Spark-Compatible Methods ====================
+
+	/**
+	 * Collect all modified interest points as serializable InterestPointData objects.
+	 * This method is useful for Spark-based parallel saving.
+	 *
+	 * @param spimData The SpimData2
+	 * @param modifiedOnly If true, only include interest points that have been modified
+	 * @return List of InterestPointData suitable for Spark RDD operations
+	 */
+	public static List< InterestPointData > collectInterestPointData( final SpimData2 spimData, final boolean modifiedOnly )
+	{
+		final List< InterestPointData > allData = new ArrayList<>();
+
+		for ( final Entry< ViewId, ViewInterestPointLists > entry : spimData.getViewInterestPoints().getViewInterestPoints().entrySet() )
+		{
+			final ViewId viewId = entry.getKey();
+			final ViewInterestPointLists vipl = entry.getValue();
+
+			for ( final Entry< String, InterestPoints > labelEntry : vipl.getHashMap().entrySet() )
+			{
+				final String label = labelEntry.getKey();
+				final InterestPoints ips = labelEntry.getValue();
+
+				// Only include if modified (or if modifiedOnly is false)
+				if ( !modifiedOnly || ips.hasModifiedInterestPoints() || ips.hasModifiedCorrespondingInterestPoints() )
+				{
+					if ( !( ips instanceof InterestPointsN5 ) )
+						throw new RuntimeException( "InterestPointData.from() requires InterestPointsN5, got: " + ips.getClass().getName() );
+
+					allData.add( InterestPointData.from( viewId, label, (InterestPointsN5) ips ) );
+				}
+			}
+		}
+
+		return allData;
+	}
+
+	/** @deprecated Use {@link #saveInterestPointsInParallel(SpimData2)} instead. */
+	@Deprecated
+	public static void saveInterestPointsInParallelStatic( final SpimData2 spimData )
+	{
+		saveInterestPointsInParallel( spimData );
 	}
 }

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/interestpoints/InterestPointsN5.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/interestpoints/InterestPointsN5.java
@@ -733,17 +733,19 @@ public class InterestPointsN5 extends InterestPoints
 	}
 
 	/**
-	 * Core static method for saving interest points to N5.
-	 * Used by both instance method and Spark-compatible API.
+	 * Core static method for saving interest points to N5 using an already-open N5Writer.
+	 * The caller is responsible for opening and closing the writer.
+	 * Use this overload when saving many views to avoid the per-view open/close overhead
+	 * (e.g. in BigStitcher-Spark interest point detection).
 	 *
-	 * @param baseDir Base URI for N5 storage (parent of interestpoints.n5)
+	 * @param n5Writer an already-open N5Writer for interestpoints.n5
 	 * @param n5path Relative path within interestpoints.n5 (e.g., "tpId_0_viewSetupId_1/beads")
 	 * @param ids Array of detection IDs
 	 * @param locations Array of coordinates (numPoints x numDimensions)
 	 * @return true if successful
 	 */
 	public static boolean saveInterestPointsStatic(
-			final URI baseDir,
+			final N5Writer n5Writer,
 			final String n5path,
 			final int[] ids,
 			final double[][] locations )
@@ -752,8 +754,6 @@ public class InterestPointsN5 extends InterestPoints
 
 		try
 		{
-			final N5Writer n5Writer = URITools.instantiateN5Writer( StorageFormat.N5, URITools.toURI( URITools.appendName( baseDir, baseN5 ) ) );
-
 			if ( n5Writer.exists( dataset ) )
 				n5Writer.remove( dataset );
 
@@ -782,7 +782,7 @@ public class InterestPointsN5 extends InterestPoints
 						DataType.FLOAT64,
 						new GzipCompression() );
 
-				IOFunctions.println( "Saved: " + URITools.appendName( baseDir, baseN5 ) + "/" + dataset + " (was empty)" );
+				IOFunctions.println( "Saved: " + n5path + "/" + dataset + " (was empty)" );
 			}
 			else
 			{
@@ -811,14 +811,44 @@ public class InterestPointsN5 extends InterestPoints
 				N5Utils.save( idData, n5Writer, idDataset, new int[] { 1, defaultBlockSize }, new GzipCompression() );
 				N5Utils.save( locData, n5Writer, locDataset, new int[] { (int) locData.dimension( 0 ), defaultBlockSize }, new GzipCompression() );
 
-				IOFunctions.println( "Saved: " + URITools.appendName( baseDir, baseN5 ) + "/" + dataset );
+				IOFunctions.println( "Saved: " + n5path + "/" + dataset );
 			}
 
-			n5Writer.close();
 			return true;
 		}
 		catch ( Exception e )
 		{
+			IOFunctions.println( "Couldn't write interestpoints to N5 '" + n5path + "/" + dataset + "': " + e );
+			e.printStackTrace();
+			return false;
+		}
+	}
+
+	/**
+	 * Core static method for saving interest points to N5.
+	 * Opens and closes its own N5Writer. For saving many views, prefer
+	 * {@link #saveInterestPointsStatic(N5Writer, String, int[], double[][])} with a
+	 * shared writer to avoid the per-view open/close overhead.
+	 *
+	 * @param baseDir Base URI for N5 storage (parent of interestpoints.n5)
+	 * @param n5path Relative path within interestpoints.n5 (e.g., "tpId_0_viewSetupId_1/beads")
+	 * @param ids Array of detection IDs
+	 * @param locations Array of coordinates (numPoints x numDimensions)
+	 * @return true if successful
+	 */
+	public static boolean saveInterestPointsStatic(
+			final URI baseDir,
+			final String n5path,
+			final int[] ids,
+			final double[][] locations )
+	{
+		try ( final N5Writer n5Writer = URITools.instantiateN5Writer( StorageFormat.N5, URITools.toURI( URITools.appendName( baseDir, baseN5 ) ) ) )
+		{
+			return saveInterestPointsStatic( n5Writer, n5path, ids, locations );
+		}
+		catch ( Exception e )
+		{
+			final String dataset = new File( n5path, "interestpoints" ).getPath();
 			IOFunctions.println( "Couldn't write interestpoints to N5 '" + URITools.appendName( baseDir, baseN5 ) + "/" + dataset + "': " + e );
 			e.printStackTrace();
 			return false;
@@ -843,17 +873,18 @@ public class InterestPointsN5 extends InterestPoints
 	}
 
 	/**
-	 * Core static method for saving correspondences to N5.
-	 * Works directly with List&lt;CorrespondingInterestPoints&gt; (the native internal format).
-	 * Used by both instance method and Spark-compatible API.
+	 * Core static method for saving correspondences to N5 using an already-open N5Writer.
+	 * The caller is responsible for opening and closing the writer.
+	 * Use this overload when saving many views to avoid the per-view open/close overhead
+	 * (e.g. in BigStitcher-Spark interest point detection).
 	 *
-	 * @param baseDir Base URI for N5 storage (parent of interestpoints.n5)
+	 * @param n5Writer an already-open N5Writer for interestpoints.n5
 	 * @param n5path Relative path within interestpoints.n5 (e.g., "tpId_0_viewSetupId_1/beads")
 	 * @param list List of corresponding interest points (can be empty, not null)
 	 * @return true if successful
 	 */
 	public static boolean saveCorrespondencesStatic(
-			final URI baseDir,
+			final N5Writer n5Writer,
 			final String n5path,
 			final List< CorrespondingInterestPoints > list )
 	{
@@ -861,8 +892,6 @@ public class InterestPointsN5 extends InterestPoints
 
 		try
 		{
-			final N5Writer n5Writer = URITools.instantiateN5Writer( StorageFormat.N5, URITools.toURI( URITools.appendName( baseDir, baseN5 ) ) );
-
 			if ( n5Writer.exists( dataset ) )
 				n5Writer.remove( dataset );
 
@@ -875,7 +904,6 @@ public class InterestPointsN5 extends InterestPoints
 			if ( list == null || list.size() == 0 )
 			{
 				n5Writer.setAttribute( dataset, "idMap", new HashMap< String, Long >() );
-				n5Writer.close();
 				return true;
 			}
 
@@ -941,13 +969,42 @@ public class InterestPointsN5 extends InterestPoints
 
 			N5Utils.save( corrIdData, n5Writer, corrDataset, new int[] { 1, defaultBlockSize }, new GzipCompression() );
 
-			IOFunctions.println( "Saved: " + URITools.appendName( baseDir, baseN5 ) + "/" + dataset );
+			IOFunctions.println( "Saved: " + n5path + "/" + dataset );
 
-			n5Writer.close();
 			return true;
 		}
 		catch ( Exception e )
 		{
+			IOFunctions.println( "Couldn't write corresponding interestpoints to N5 '" + n5path + "/" + dataset + "': " + e );
+			e.printStackTrace();
+			return false;
+		}
+	}
+
+	/**
+	 * Core static method for saving correspondences to N5.
+	 * Works directly with List&lt;CorrespondingInterestPoints&gt; (the native internal format).
+	 * Opens and closes its own N5Writer. For saving many views, prefer
+	 * {@link #saveCorrespondencesStatic(N5Writer, String, List)} with a shared writer
+	 * to avoid the per-view open/close overhead.
+	 *
+	 * @param baseDir Base URI for N5 storage (parent of interestpoints.n5)
+	 * @param n5path Relative path within interestpoints.n5 (e.g., "tpId_0_viewSetupId_1/beads")
+	 * @param list List of corresponding interest points (can be empty, not null)
+	 * @return true if successful
+	 */
+	public static boolean saveCorrespondencesStatic(
+			final URI baseDir,
+			final String n5path,
+			final List< CorrespondingInterestPoints > list )
+	{
+		try ( final N5Writer n5Writer = URITools.instantiateN5Writer( StorageFormat.N5, URITools.toURI( URITools.appendName( baseDir, baseN5 ) ) ) )
+		{
+			return saveCorrespondencesStatic( n5Writer, n5path, list );
+		}
+		catch ( Exception e )
+		{
+			final String dataset = new File( n5path, "correspondences" ).getPath();
 			IOFunctions.println( "Couldn't write corresponding interestpoints to N5 '" + URITools.appendName( baseDir, baseN5 ) + "/" + dataset + "': " + e );
 			e.printStackTrace();
 			return false;
@@ -971,8 +1028,33 @@ public class InterestPointsN5 extends InterestPoints
 	}
 
 	/**
+	 * Static wrapper to save all data from an InterestPointData object using an already-open N5Writer.
+	 * The caller is responsible for opening and closing the writer.
+	 * Use this overload when saving many views to avoid the per-view open/close overhead
+	 * (e.g. in BigStitcher-Spark interest point detection).
+	 *
+	 * @param n5Writer an already-open N5Writer for interestpoints.n5
+	 * @param data InterestPointData containing all data
+	 * @return true if successful
+	 */
+	public static boolean saveInterestPointDataStatic( final N5Writer n5Writer, final InterestPointData data )
+	{
+		final String n5path = "tpId_" + data.timepointId + "_viewSetupId_" + data.setupId + "/" + data.label;
+
+		boolean success = saveInterestPointsStatic( n5Writer, n5path, data.ids, data.locations );
+
+		if ( success && data.hasCorrespondences() )
+			success = saveCorrespondencesStatic( n5Writer, n5path, data.correspondences );
+
+		return success;
+	}
+
+	/**
 	 * Static wrapper to save all data from an InterestPointData object.
 	 * Suitable for Spark RDD.foreach() operations.
+	 * Opens and closes its own N5Writer. For saving many views, prefer
+	 * {@link #saveInterestPointDataStatic(N5Writer, InterestPointData)} with a shared writer
+	 * to avoid the per-view open/close overhead.
 	 *
 	 * @param baseDir Base URI for N5 storage (parent of interestpoints.n5)
 	 * @param data InterestPointData containing all data

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/interestpoints/InterestPointsN5.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/interestpoints/InterestPointsN5.java
@@ -238,6 +238,46 @@ public class InterestPointsN5 extends InterestPoints
 		return success;
 	}
 
+	/**
+	 * Save interest points using an already-open N5Writer, clearing the modified flag on success.
+	 * Use when saving many views to avoid per-view open/close overhead.
+	 */
+	public boolean saveInterestPoints( final boolean forceWrite, final N5Writer n5Writer )
+	{
+		if ( !modifiedInterestPoints && !forceWrite )
+			return true;
+
+		if ( ids == null || locations == null )
+			return false;
+
+		final boolean success = saveInterestPointsStatic( n5Writer, n5path, ids, locations );
+
+		if ( success )
+			modifiedInterestPoints = false;
+
+		return success;
+	}
+
+	/**
+	 * Save correspondences using an already-open N5Writer, clearing the modified flag on success.
+	 * Use when saving many views to avoid per-view open/close overhead.
+	 */
+	public boolean saveCorrespondingInterestPoints( final boolean forceWrite, final N5Writer n5Writer )
+	{
+		if ( !modifiedCorrespondingInterestPoints && !forceWrite )
+			return true;
+
+		if ( correspondingInterestPoints == null )
+			return false;
+
+		final boolean success = saveCorrespondencesStatic( n5Writer, n5path, correspondingInterestPoints );
+
+		if ( success )
+			modifiedCorrespondingInterestPoints = false;
+
+		return success;
+	}
+
 	@Override
 	protected boolean loadInterestPoints()
 	{
@@ -782,7 +822,7 @@ public class InterestPointsN5 extends InterestPoints
 						DataType.FLOAT64,
 						new GzipCompression() );
 
-				IOFunctions.println( "Saved: " + n5path + "/" + dataset + " (was empty)" );
+				IOFunctions.println( "Saved: " + dataset + " (was empty)" );
 			}
 			else
 			{
@@ -811,14 +851,14 @@ public class InterestPointsN5 extends InterestPoints
 				N5Utils.save( idData, n5Writer, idDataset, new int[] { 1, defaultBlockSize }, new GzipCompression() );
 				N5Utils.save( locData, n5Writer, locDataset, new int[] { (int) locData.dimension( 0 ), defaultBlockSize }, new GzipCompression() );
 
-				IOFunctions.println( "Saved: " + n5path + "/" + dataset );
+				IOFunctions.println( "Saved: " + dataset );
 			}
 
 			return true;
 		}
 		catch ( Exception e )
 		{
-			IOFunctions.println( "Couldn't write interestpoints to N5 '" + n5path + "/" + dataset + "': " + e );
+			IOFunctions.println( "Couldn't write interestpoints to N5 '" + dataset + "': " + e );
 			e.printStackTrace();
 			return false;
 		}
@@ -969,13 +1009,13 @@ public class InterestPointsN5 extends InterestPoints
 
 			N5Utils.save( corrIdData, n5Writer, corrDataset, new int[] { 1, defaultBlockSize }, new GzipCompression() );
 
-			IOFunctions.println( "Saved: " + n5path + "/" + dataset );
+			IOFunctions.println( "Saved: " + dataset );
 
 			return true;
 		}
 		catch ( Exception e )
 		{
-			IOFunctions.println( "Couldn't write corresponding interestpoints to N5 '" + n5path + "/" + dataset + "': " + e );
+			IOFunctions.println( "Couldn't write corresponding interestpoints to N5 '" + dataset + "': " + e );
 			e.printStackTrace();
 			return false;
 		}

--- a/src/main/java/util/URITools.java
+++ b/src/main/java/util/URITools.java
@@ -220,7 +220,7 @@ public class URITools
 
 			try
 			{
-				XmlIoSpimData2.saveInterestPointsSharedWriter( data );
+				XmlIoSpimData2.saveInterestPointsInParallel( data );
 			}
 			catch ( Exception e )
 			{

--- a/src/main/java/util/URITools.java
+++ b/src/main/java/util/URITools.java
@@ -220,7 +220,7 @@ public class URITools
 
 			try
 			{
-				XmlIoSpimData2.saveInterestPointsInParallel( data );
+				XmlIoSpimData2.saveInterestPointsSharedWriter( data );
 			}
 			catch ( Exception e )
 			{


### PR DESCRIPTION
Slightly improves efficiency via only using a singular n5 writer as opposed to opening/closing an n5 writer for every tile. 

This PR:
- Overloads the following functions to take an open N5 writer as argument: instance and static versions of saveInterestPoints, saveCorrespondingInterestPoints, saveInterestPointDataStatic
- Updates saveInterestPointsInParallel to use one shared n5 writer
- Deprecates saveInterestPointsInParallelStatic as this was never called by mvrecon or BigStitcher-Spark