### PR TITLE
Zarrv3 Bug Fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,11 +115,11 @@ like Selective Plane Illumination Microscopy (SPIM) Data.</description>
 
 		<!-- N5 alpha versions for Zarr v3 shard support -->
 		<!-- See: https://imglib.github.io/imglib2-blog/posts/2025-12-22-n5-shard-dev/ -->
-		<n5.version>4.0.0-alpha-10</n5.version>
+		<n5.version>4.0.0-alpha-12</n5.version>
 		<n5-hdf5.version>2.3.0-alpha-6</n5-hdf5.version>
-		<n5-imglib2.version>7.1.0-alpha-7</n5-imglib2.version>
+		<n5-imglib2.version>7.1.0-alpha-8</n5-imglib2.version>
 		<n5-universe.version>2.4.0-alpha-6</n5-universe.version>
-		<n5-zarr.version>2.0.0-alpha-7</n5-zarr.version>
+		<n5-zarr.version>2.0.0-alpha-8</n5-zarr.version>
 		<n5-zstandard.version>2.0.0-alpha-4</n5-zstandard.version>
 		<n5-blosc.version>2.0.0-alpha-4</n5-blosc.version>
 	</properties>

--- a/src/main/java/net/preibisch/mvrecon/fiji/datasetmanager/OMEZARR.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/datasetmanager/OMEZARR.java
@@ -171,7 +171,7 @@ public class OMEZARR implements MultiViewDatasetDefinition
 
 		try
 		{
-			reader = URITools.instantiateN5Reader( StorageFormat.ZARR, baseDir );
+			reader = URITools.instantiateN5Reader( format, baseDir );
 		}
 		catch ( Exception e )
 		{
@@ -179,7 +179,7 @@ public class OMEZARR implements MultiViewDatasetDefinition
 
 			try
 			{
-				reader = URITools.instantiateN5Writer( StorageFormat.ZARR, baseDir );
+				reader = URITools.instantiateN5Writer( format, baseDir );
 			}
 			catch (Exception e2 )
 			{

--- a/src/main/java/net/preibisch/mvrecon/fiji/datasetmanager/OMEZARR.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/datasetmanager/OMEZARR.java
@@ -201,9 +201,6 @@ public class OMEZARR implements MultiViewDatasetDefinition
 		for ( final String dataset : datasets )
 		{
 			IOFunctions.println( "\nFetching metadata for " + dataset );
-//			IOFunctions.println( "Reader URI: " + reader.getURI() );
-//			IOFunctions.println( "Full dataset URI: " + reader.getURI().resolve( dataset ) );
-//			IOFunctions.println( "Available attributes: " + reader.listAttributes( dataset ) );
 
 			//org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v04.OmeNgffMetadata
 			// for this to work you need to register an adapter in the N5Factory class
@@ -755,16 +752,12 @@ public class OMEZARR implements MultiViewDatasetDefinition
 				// channel had a pattern, so it's a single channel for this dataset, still possibly multiple timepoints
 				viewIdToPath.putAll( updateViewSetup(dataset, viewSetups, meta, angleId, chId, illumId, tileId, tpId, sizeT, numDimensions ) );
 			}
-			else if ( sizeC > 0 )
-			{
-				// if the channels are inside the 4D/5D OME-ZARR, this dataset could contain more than one ViewSetup
-				for ( int c = 0; c < sizeC; ++c )
-					viewIdToPath.putAll( updateViewSetup( dataset, viewSetups, meta, angleId, c, illumId, tileId, tpId, sizeT, numDimensions ) );
-			}
 			else
 			{
-				// 3D data with no channel pattern - single channel (channelId = 0)
-				viewIdToPath.putAll( updateViewSetup( dataset, viewSetups, meta, angleId, 0, illumId, tileId, tpId, sizeT, numDimensions ) );
+				// if the channels are inside the 4D/5D OME-ZARR, this dataset could contain more than one ViewSetup
+                // if 3D OME-ZARR with no channel pattern (sizeC=0), create 1 channel (channelID 0)
+				for ( int c = 0; c < Math.max(1, sizeC); ++c )
+					viewIdToPath.putAll( updateViewSetup( dataset, viewSetups, meta, angleId, c, illumId, tileId, tpId, sizeT, numDimensions ) );
 			}
 		}
 

--- a/src/main/java/net/preibisch/mvrecon/fiji/datasetmanager/OMEZARR.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/datasetmanager/OMEZARR.java
@@ -201,15 +201,27 @@ public class OMEZARR implements MultiViewDatasetDefinition
 		for ( final String dataset : datasets )
 		{
 			IOFunctions.println( "\nFetching metadata for " + dataset );
+//			IOFunctions.println( "Reader URI: " + reader.getURI() );
+//			IOFunctions.println( "Full dataset URI: " + reader.getURI().resolve( dataset ) );
+//			IOFunctions.println( "Available attributes: " + reader.listAttributes( dataset ) );
 
 			//org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v04.OmeNgffMetadata
 			// for this to work you need to register an adapter in the N5Factory class
 			// final GsonBuilder builder = new GsonBuilder().registerTypeAdapter( CoordinateTransformation.class, new CoordinateTransformationAdapter() );
-			final OmeNgffMultiScaleMetadata[] multiscales = reader.getAttribute( dataset, "multiscales", OmeNgffMultiScaleMetadata[].class );
+
+            OmeNgffMultiScaleMetadata[] multiscales;
+            if (format == StorageFormat.ZARR2) {
+                multiscales = reader.getAttribute( dataset, "multiscales", OmeNgffMultiScaleMetadata[].class );
+            }
+
+            else {
+                IOFunctions.println( "Zarrv3 detected, trying 'ome/multiscales'" );
+                multiscales = reader.getAttribute( dataset, "ome/multiscales", OmeNgffMultiScaleMetadata[].class );
+            }
 
 			if ( multiscales == null || multiscales.length == 0 )
 			{
-				IOFunctions.println( "Could not parse OME-ZARR multiscales object. stopping." );
+				IOFunctions.println( "Could not parse OME-ZARR multiscales object (tried 'multiscales' and/or 'ome/multiscales'). stopping." );
 				return null;
 			}
 
@@ -259,18 +271,16 @@ public class OMEZARR implements MultiViewDatasetDefinition
 
 			for ( final String path : multiscales[ 0 ].getPaths() )
 			{
-				IOFunctions.println( "path '" + path + "':");
 
-				final DatasetAttributes attr = reader.getDatasetAttributes( dataset + "/" + path );
+                DatasetAttributes attr = reader.getDatasetAttributes(dataset + "/" + path);
 
-				IOFunctions.println( "NumDimensions: " + attr.getNumDimensions() );
-				IOFunctions.println( "Dimensions: " + Arrays.toString( attr.getDimensions() ) );
-				IOFunctions.println( "BlockSize: " + Arrays.toString( attr.getBlockSize() ) );
-				IOFunctions.println( "DataType: " + attr.getDataType() );
-				IOFunctions.println( "Compression: " + attr.getCompression() );
+                IOFunctions.println("NumDimensions: " + attr.getNumDimensions());
+                IOFunctions.println("Dimensions: " + Arrays.toString(attr.getDimensions()));
+                IOFunctions.println("BlockSize: " + Arrays.toString(attr.getBlockSize()));
+                IOFunctions.println("DataType: " + attr.getDataType());
 
-				if ( fullScaleAttributes == null || attr.getDimensions()[ 0 ] > fullScaleAttributes.getDimensions()[ 0 ])
-					fullScaleAttributes = attr;
+                if (fullScaleAttributes == null || attr.getDimensions()[0] > fullScaleAttributes.getDimensions()[0])
+                    fullScaleAttributes = attr;
 			}
 
 			if ( numDimensions == -1 )
@@ -598,18 +608,22 @@ public class OMEZARR implements MultiViewDatasetDefinition
 		// create timepoints
 		//
 		final ArrayList< TimePoint > tps = new ArrayList< TimePoint >();
-		if ( timepointStrings.size() == 0 )
+		if ( timepointStrings.size() == 0 && sizeT > 0 )
 		{
-			// timepoints within the 4D/5D OME-ZARR (for 4D, there is only 1 timepoint)
-			final long numTimepoints = (numDimensions == 4) ? 1 : sizeT;
-			for ( int i = 0; i < numTimepoints; ++i )
+			// timepoints within the 5D OME-ZARR
+			for ( int i = 0; i < sizeT; ++i )
 				tps.add( new TimePoint( i ) );
 		}
-		else
+		else if ( timepointStrings.size() > 0 )
 		{
 			// timepoints as pattern in 3D OME-ZARR
 			for ( int i = 0; i < timepointStrings.size(); ++i )
 				tps.add( new TimePoint( i ) );
+		}
+		else
+		{
+			// 3D or 4D data with no timepoint pattern - add single default timepoint
+			tps.add( new TimePoint( 0 ) );
 		}
 
 		final TimePoints timepoints = new TimePoints( tps );
@@ -618,17 +632,22 @@ public class OMEZARR implements MultiViewDatasetDefinition
 		// create ViewSetups
 		//
 		final ArrayList< Channel > channels = new ArrayList< Channel >();
-		if ( channelStrings.size() == 0 )
+		if ( channelStrings.size() == 0 && sizeC > 0 )
 		{
-			// channels within the 5D OME-ZARR
+			// channels within the 4D/5D OME-ZARR
 			for ( int i = 0; i < sizeC; ++i )
 				channels.add( new Channel( i ) );
 		}
-		else
+		else if ( channelStrings.size() > 0 )
 		{
 			// channels as pattern in 3D OME-ZARR
 			for ( int i = 0; i < channelStrings.size(); ++i )
 				channels.add( new Channel( i, channelStrings.get( i ) ) );
+		}
+		else
+		{
+			// 3D data with no channel pattern - add default channel
+			channels.add( new Channel( 0 ) );
 		}
 
 		final ArrayList< Tile > tiles = new ArrayList<>();
@@ -736,11 +755,16 @@ public class OMEZARR implements MultiViewDatasetDefinition
 				// channel had a pattern, so it's a single channel for this dataset, still possibly multiple timepoints
 				viewIdToPath.putAll( updateViewSetup(dataset, viewSetups, meta, angleId, chId, illumId, tileId, tpId, sizeT, numDimensions ) );
 			}
-			else
+			else if ( sizeC > 0 )
 			{
-				// if the channels are inside the 5D OME-ZARR, this dataset could contain more than one ViewSetup
+				// if the channels are inside the 4D/5D OME-ZARR, this dataset could contain more than one ViewSetup
 				for ( int c = 0; c < sizeC; ++c )
 					viewIdToPath.putAll( updateViewSetup( dataset, viewSetups, meta, angleId, c, illumId, tileId, tpId, sizeT, numDimensions ) );
+			}
+			else
+			{
+				// 3D data with no channel pattern - single channel (channelId = 0)
+				viewIdToPath.putAll( updateViewSetup( dataset, viewSetups, meta, angleId, 0, illumId, tileId, tpId, sizeT, numDimensions ) );
 			}
 		}
 
@@ -806,10 +830,18 @@ public class OMEZARR implements MultiViewDatasetDefinition
 
 				if ( tpId >= 0 )
 				{
+					// timepoint from pattern (3D OME-ZARR with tp pattern, or 4D/5D with tp pattern)
 					final ViewId viewId = new ViewId( tpId, vs.getId() );
+					// For 3D: indices = null (no higher dimensions)
 					// For 4D: indices = [channelId] (single element)
 					// For 5D with pattern tp: indices = [channelId, 0]
-					final int[] indices = (numDimensions == 4) ? new int[] { channelId } : new int[] { channelId, 0 };
+					final int[] indices;
+					if ( numDimensions == 3 )
+						indices = null;
+					else if ( numDimensions == 4 )
+						indices = new int[] { channelId };
+					else
+						indices = new int[] { channelId, 0 };
 					final OMEZARREntry entry = new OMEZARREntry( dataset, indices );
 
 					IOFunctions.println( "ViewId: " + Group.pvid( viewId ) + " @ " + entry );
@@ -817,14 +849,26 @@ public class OMEZARR implements MultiViewDatasetDefinition
 				}
 				else
 				{
-					// if the timepoints are inside the 4D/5D OME-ZARR, this dataset could contain more than one ViewId
-					final long numTimepoints = (numDimensions == 4) ? 1 : sizeT;
+					// timepoints are inside the OME-ZARR or single timepoint for 3D/4D
+					final long numTimepoints;
+					if ( numDimensions == 3 || numDimensions == 4 )
+						numTimepoints = 1; // 3D has no tp dimension, 4D has only channel dimension
+					else
+						numTimepoints = sizeT; // 5D has both channel and timepoint dimensions
+
 					for ( int t = 0; t < numTimepoints; ++t )
 					{
 						final ViewId viewId = new ViewId( t, vs.getId() );
+						// For 3D: indices = null (no higher dimensions)
 						// For 4D: indices = [channelId] (single element)
 						// For 5D: indices = [channelId, t]
-						final int[] indices = (numDimensions == 4) ? new int[] { channelId } : new int[] { channelId, t };
+						final int[] indices;
+						if ( numDimensions == 3 )
+							indices = null;
+						else if ( numDimensions == 4 )
+							indices = new int[] { channelId };
+						else
+							indices = new int[] { channelId, t };
 						final OMEZARREntry entry = new OMEZARREntry( dataset, indices );
 
 						IOFunctions.println( "ViewId: " + Group.pvid( viewId ) + " @ " + entry );

--- a/src/main/java/net/preibisch/mvrecon/fiji/plugin/resave/Resave_N5Api.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/plugin/resave/Resave_N5Api.java
@@ -28,6 +28,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -140,13 +141,16 @@ public class Resave_N5Api implements PlugIn
 		final int[][] downsamplings =
 				N5ApiTools.mipMapInfoToDownsamplings( n5Params.proposedMipmaps );
 
-		final List<long[][]> gridS0 =
-				vidsToResave.stream().map( viewId ->
-						N5ApiTools.assembleJobs(
-								viewId,
-								dimensions.get( viewId.getViewSetupId() ),
-								blockSize,
-								computeBlockSize ) ).flatMap(List::stream).collect( Collectors.toList() );
+		// Group blocks by view and process one view at a time to avoid loading
+		// multiple large images into memory simultaneously (which causes OOM)
+		final Map<ViewId, List<long[][]>> gridS0ByView = new LinkedHashMap<>();
+		for ( final ViewId viewId : vidsToResave )
+			gridS0ByView.put( viewId, N5ApiTools.assembleJobs(
+					viewId,
+					dimensions.get( viewId.getViewSetupId() ),
+					blockSize,
+					computeBlockSize ) );
+		final int totalBlocksS0 = gridS0ByView.values().stream().mapToInt( List::size ).sum();
 
 		final Map<Integer, DataType> dataTypes =
 				N5ApiTools.assembleDataTypes( data, dimensions.keySet() );
@@ -206,10 +210,10 @@ public class Resave_N5Api implements PlugIn
 						} ).collect(Collectors.toMap( e -> e.getA(), e -> e.getB() ));
 
 		IOFunctions.println( "Created BDV-metadata, took: " + (System.currentTimeMillis() - time ) + " ms." );
-		IOFunctions.println( "Number of compute blocks (s0): " + gridS0.size() );
+		IOFunctions.println( "Number of compute blocks (s0): " + totalBlocksS0 );
 
 		final AtomicInteger progress = new AtomicInteger( 0 );
-		IJ.showProgress( progress.get(), gridS0.size() );
+		IJ.showProgress( progress.get(), totalBlocksS0 );
 
 		//
 		// Save full resolution dataset (s0)
@@ -217,64 +221,60 @@ public class Resave_N5Api implements PlugIn
 		try
 		{
 			final ForkJoinPool myPool = new ForkJoinPool( n5Params.numCellCreatorThreads );
-			final RetryTracker<long[][]> retryTracker = RetryTracker.forGridBlocks("s0 resaving", gridS0.size());
 
 			time = System.currentTimeMillis();
 
-			do
+			// Process one view at a time so only one large image is in memory at once
+			for ( final Map.Entry<ViewId, List<long[][]>> viewEntry : gridS0ByView.entrySet() )
 			{
-				if (!retryTracker.beginAttempt())
-					return null;
+				final RetryTracker<long[][]> retryTracker = RetryTracker.forGridBlocks(
+						"s0 resaving tp=" + viewEntry.getKey().getTimePointId() + " setup=" + viewEntry.getKey().getViewSetupId(),
+						viewEntry.getValue().size() );
 
-				final ArrayList< Callable< long[][] > > tasks = new ArrayList<>();
+				List<long[][]> viewBlocks = viewEntry.getValue();
 
-				for ( final long[][] gridBlock : gridS0 )
-					tasks.add( () ->
-					{
-						N5ApiTools.resaveS0Block(
-								data,
-								n5Writer,
-								n5Params.format,
-								dataTypes.get( N5ApiTools.gridBlockToViewId( gridBlock ).getViewSetupId() ),
-								N5ApiTools.gridToDatasetBdv( 0, n5Params.format ), // a function mapping the gridblock to the dataset name for level 0 and N5
-								gridBlock );
-
-						IJ.showProgress( progress.incrementAndGet(), gridS0.size() );
-
-						return gridBlock.clone();
-					});
-
-				/*
-				myPool.submit(() -> grid.parallelStream().map( gridBlock -> 
+				do
 				{
-					N5ApiTools.resaveS0Block(
-						data,
-						n5Writer,
-						n5Params.format,
-						dataTypes.get( N5ApiTools.gridBlockToViewId( gridBlock ).getViewSetupId() ),
-						N5ApiTools.gridToDatasetBdv( 0, n5Params.format ), // a function mapping the gridblock to the dataset name for level 0 and N5
-						gridBlock );
+					if (!retryTracker.beginAttempt())
+					{
+						myPool.shutdown();
+						return null;
+					}
 
-					IJ.showProgress( progress.incrementAndGet(), grid.size() );
+					final ArrayList< Callable< long[][] > > tasks = new ArrayList<>();
 
-					// TOOD: add re-try logic
-					return gridBlock;
-				})).get();*/
+					for ( final long[][] gridBlock : viewBlocks )
+						tasks.add( () ->
+						{
+							N5ApiTools.resaveS0Block(
+									data,
+									n5Writer,
+									n5Params.format,
+									dataTypes.get( N5ApiTools.gridBlockToViewId( gridBlock ).getViewSetupId() ),
+									N5ApiTools.gridToDatasetBdv( 0, n5Params.format ),
+									gridBlock );
 
-				final List<Future<long[][]>> futures = myPool.invokeAll( tasks );
+							IJ.showProgress( progress.incrementAndGet(), totalBlocksS0 );
 
-				// extract all blocks that failed
-				final Set<long[][]> failedBlocksSet = retryTracker.processWithFutures( futures, gridS0 );
+							return gridBlock.clone();
+						});
 
-				// Use RetryTracker to handle retry counting and removal
-				if (!retryTracker.processFailures(failedBlocksSet))
-					return null;
+					final List<Future<long[][]>> futures = myPool.invokeAll( tasks );
 
-				// Update grid for next iteration with remaining failed blocks
-				gridS0.clear();
-				gridS0.addAll(failedBlocksSet);
+					// extract all blocks that failed
+					final Set<long[][]> failedBlocksSet = retryTracker.processWithFutures( futures, viewBlocks );
+
+					// Use RetryTracker to handle retry counting and removal
+					if (!retryTracker.processFailures(failedBlocksSet))
+					{
+						myPool.shutdown();
+						return null;
+					}
+
+					viewBlocks = new ArrayList<>( failedBlocksSet );
+				}
+				while ( viewBlocks.size() > 0 );
 			}
-			while ( gridS0.size() > 0 );
 
 			myPool.shutdown();
 			myPool.awaitTermination(Long.MAX_VALUE, TimeUnit.HOURS);
@@ -286,7 +286,7 @@ public class Resave_N5Api implements PlugIn
 			return null;
 		}
 
-		IJ.showProgress( progress.getAndSet( 0 ), gridS0.size() );
+		IJ.showProgress( progress.getAndSet( 0 ), totalBlocksS0 );
 		IOFunctions.println( "Saved level s0, took: " + (System.currentTimeMillis() - time ) + " ms." );
 
 		//

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/AllenOMEZarrProperties.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/AllenOMEZarrProperties.java
@@ -23,9 +23,11 @@
 package net.preibisch.mvrecon.fiji.spimdata.imgloaders;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.janelia.saalfeldlab.n5.DataType;
+import org.janelia.saalfeldlab.n5.DatasetAttributes;
 import org.janelia.saalfeldlab.n5.N5Reader;
 import org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v04.OmeNgffMultiScaleMetadata;
 import org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v04.OmeNgffMultiScaleMetadata.OmeNgffDataset;
@@ -44,6 +46,9 @@ public class AllenOMEZarrProperties implements N5Properties
 
 	private final Map< ViewId, OMEZARREntry > viewIdToPath;
 
+	// Cache for actual dataset paths from multiscales metadata: setupId -> (level -> datasetPath)
+	private final Map< Integer, String[] > levelPathCache = new HashMap<>();
+
 	public AllenOMEZarrProperties(
 			final AbstractSequenceDescription< ?, ?, ? > sequenceDescription,
 			final Map< ViewId, OMEZARREntry > viewIdToPath )
@@ -60,7 +65,14 @@ public class AllenOMEZarrProperties implements N5Properties
 	@Override
 	public String getDatasetPath( final int setupId, final int timepointId, final int level )
 	{
-		return String.format( getPath( setupId, timepointId )+ "/%d", level );
+		// Check if we have cached the actual paths from multiscales metadata
+		final String[] cachedPaths = levelPathCache.get( setupId );
+		if ( cachedPaths != null && level < cachedPaths.length )
+		{
+			return getPath( setupId, timepointId ) + "/" + cachedPaths[ level ];
+		}
+		// Fallback to numeric level (for v0.4 or if cache not populated)
+		return String.format( getPath( setupId, timepointId ) + "/%d", level );
 	}
 
 	@Override
@@ -106,13 +118,27 @@ public class AllenOMEZarrProperties implements N5Properties
 
 	private static DataType getDataType( final AllenOMEZarrProperties n5properties, final N5Reader n5, final int setupId )
 	{
+		// we need to make sure the cache is populated, otherwise getDatasetPath(...) might return the wrong path
+		if ( n5properties.levelPathCache.get( setupId ) == null )
+			getMipMapResolutions( n5properties, n5, setupId );
+
 		final int timePointId = getFirstAvailableTimepointId( n5properties.sequenceDescription, setupId );
+<<<<<<< HEAD
 
 		// If all timepoints are missing, return a default data type
 		if ( timePointId < 0 )
 			return DataType.UINT16;
 
 		return n5.getDatasetAttributes( n5properties.getDatasetPath( setupId, timePointId, 0 ) ).getDataType();
+=======
+		final String path = n5properties.getDatasetPath( setupId, timePointId, 0 );
+		final DatasetAttributes attributes = n5.getDatasetAttributes( path );
+
+		if ( attributes == null )
+			throw new RuntimeException( "Could not find dataset attributes for '" + path + "'. Please check if the OME-Zarr data is valid." );
+
+		return attributes.getDataType();
+>>>>>>> 1151adb7 (able to create xml from zarr3)
 	}
 
 	private static double[][] getMipMapResolutions( final AllenOMEZarrProperties n5properties, final N5Reader n5, final int setupId )
@@ -128,10 +154,16 @@ public class AllenOMEZarrProperties implements N5Properties
 		//org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v04.OmeNgffMetadata
 		// for this to work you need to register an adapter in the N5Factory class
 		// final GsonBuilder builder = new GsonBuilder().registerTypeAdapter( CoordinateTransformation.class, new CoordinateTransformationAdapter() );
-		final OmeNgffMultiScaleMetadata[] multiscales = n5.getAttribute( n5properties.getPath( setupId, timePointId ), "multiscales", OmeNgffMultiScaleMetadata[].class );
+		final String path = n5properties.getPath( setupId, timePointId );
+
+		// Try v0.4 structure first (multiscales at root), then v0.5/Zarr v3 structure (nested under ome)
+		OmeNgffMultiScaleMetadata[] multiscales = n5.getAttribute( path, "multiscales", OmeNgffMultiScaleMetadata[].class );
 
 		if ( multiscales == null || multiscales.length == 0 )
-			throw new RuntimeException( "Could not parse OME-ZARR multiscales object. stopping." );
+			multiscales = n5.getAttribute( path, "ome/multiscales", OmeNgffMultiScaleMetadata[].class );
+
+		if ( multiscales == null || multiscales.length == 0 )
+			throw new RuntimeException( "Could not parse OME-ZARR multiscales object (tried 'multiscales' and 'ome/multiscales'). stopping." );
 
 		if ( multiscales.length != 1 )
 			System.out.println( "This dataset has " + multiscales.length + " objects, we expected 1. Picking the first one." );
@@ -141,9 +173,15 @@ public class AllenOMEZarrProperties implements N5Properties
 		double[][] mipMapResolutions = new double[ multiscales[ 0 ].datasets.length ][ 3 ];
 		double[] firstScale = null;
 
+		// Cache the actual dataset paths from metadata (they may not be just "0", "1", "2")
+		final String[] levelPaths = new String[ multiscales[ 0 ].datasets.length ];
+
 		for ( int i = 0; i < multiscales[ 0 ].datasets.length; ++i )
 		{
 			final OmeNgffDataset ds = multiscales[ 0 ].datasets[ i ];
+
+			// Store the actual path for this resolution level
+			levelPaths[ i ] = ds.path;
 
 			for ( final CoordinateTransformation< ? > c : ds.coordinateTransformations )
 			{
@@ -163,6 +201,9 @@ public class AllenOMEZarrProperties implements N5Properties
 				}
 			}
 		}
+
+		// Cache the level paths for this setup
+		n5properties.levelPathCache.put( setupId, levelPaths );
 
 		return mipMapResolutions;
 	}

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/AllenOMEZarrProperties.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/AllenOMEZarrProperties.java
@@ -123,14 +123,11 @@ public class AllenOMEZarrProperties implements N5Properties
 			getMipMapResolutions( n5properties, n5, setupId );
 
 		final int timePointId = getFirstAvailableTimepointId( n5properties.sequenceDescription, setupId );
-<<<<<<< HEAD
 
 		// If all timepoints are missing, return a default data type
 		if ( timePointId < 0 )
 			return DataType.UINT16;
 
-		return n5.getDatasetAttributes( n5properties.getDatasetPath( setupId, timePointId, 0 ) ).getDataType();
-=======
 		final String path = n5properties.getDatasetPath( setupId, timePointId, 0 );
 		final DatasetAttributes attributes = n5.getDatasetAttributes( path );
 
@@ -138,7 +135,6 @@ public class AllenOMEZarrProperties implements N5Properties
 			throw new RuntimeException( "Could not find dataset attributes for '" + path + "'. Please check if the OME-Zarr data is valid." );
 
 		return attributes.getDataType();
->>>>>>> 1151adb7 (able to create xml from zarr3)
 	}
 
 	private static double[][] getMipMapResolutions( final AllenOMEZarrProperties n5properties, final N5Reader n5, final int setupId )

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/OMEZarrAttibutes.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/OMEZarrAttibutes.java
@@ -164,10 +164,15 @@ public class OMEZarrAttibutes
 		//org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v04.OmeNgffMetadata
 		// for this to work you need to register an adapter in the N5Factory class
 		// final GsonBuilder builder = new GsonBuilder().registerTypeAdapter( CoordinateTransformation.class, new CoordinateTransformationAdapter() );
-		final OmeNgffMultiScaleMetadata[] multiscales = n5.getAttribute( dataset, "multiscales", OmeNgffMultiScaleMetadata[].class );
+
+		// Try v0.4 structure first (multiscales at root), then v0.5/Zarr v3 structure (nested under ome)
+		OmeNgffMultiScaleMetadata[] multiscales = n5.getAttribute( dataset, "multiscales", OmeNgffMultiScaleMetadata[].class );
 
 		if ( multiscales == null || multiscales.length == 0 )
-			throw new RuntimeException( "Could not parse OME-ZARR multiscales object. stopping." );
+			multiscales = n5.getAttribute( dataset, "attributes/ome/multiscales", OmeNgffMultiScaleMetadata[].class );
+
+		if ( multiscales == null || multiscales.length == 0 )
+			throw new RuntimeException( "Could not parse OME-ZARR multiscales object (tried 'multiscales' and 'ome/multiscales'). stopping." );
 
 		if ( multiscales.length != 1 )
 			System.out.println( "This dataset has " + multiscales.length + " objects, we expected 1. Picking the first one." );

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/OMEZarrAttributes.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/OMEZarrAttributes.java
@@ -44,7 +44,7 @@ import net.imglib2.realtransform.AffineTransform3D;
 import net.preibisch.mvrecon.process.interestpointregistration.TransformationTools;
 import util.URITools;
 
-public class OMEZarrAttibutes
+public class OMEZarrAttributes
 {
 	/*
 	 * 

--- a/src/main/java/net/preibisch/mvrecon/process/export/ExportN5Api.java
+++ b/src/main/java/net/preibisch/mvrecon/process/export/ExportN5Api.java
@@ -80,7 +80,7 @@ import net.preibisch.mvrecon.fiji.plugin.fusion.FusionExportInterface;
 import net.preibisch.mvrecon.fiji.plugin.util.GUIHelper;
 import net.preibisch.mvrecon.fiji.plugin.util.PluginHelper;
 import net.preibisch.mvrecon.fiji.spimdata.imgloaders.AllenOMEZarrLoader.OMEZARREntry;
-import net.preibisch.mvrecon.fiji.spimdata.imgloaders.OMEZarrAttibutes;
+import net.preibisch.mvrecon.fiji.spimdata.imgloaders.OMEZarrAttributes;
 import net.preibisch.mvrecon.process.interestpointregistration.pairwise.constellation.grouping.Group;
 import net.preibisch.mvrecon.process.n5api.N5ApiTools;
 import net.preibisch.mvrecon.process.n5api.N5ApiTools.MultiResolutionLevelInfo;
@@ -259,7 +259,7 @@ public class ExportN5Api implements ImgExport, Calibrateable
 						IOFunctions.println( "Resolution of level 0: " + Util.printCoordinates( cal ) + " " + unit ); //vx.unit() might not be OME-ZARR compatible
 
 						// create metadata
-						final OmeNgffMultiScaleMetadata[] meta = OMEZarrAttibutes.createOMEZarrMetadata(
+						final OmeNgffMultiScaleMetadata[] meta = OMEZarrAttributes.createOMEZarrMetadata(
 								5, // int n
 								"/", // String name, I also saw "/"
 								cal, // double[] resolutionS0,
@@ -378,7 +378,7 @@ public class ExportN5Api implements ImgExport, Calibrateable
 			IOFunctions.println( "Resolution of level 0: " + Util.printCoordinates( cal ) + " micrometer" );
 
 			// create metadata
-			final OmeNgffMultiScaleMetadata[] meta = OMEZarrAttibutes.createOMEZarrMetadata(
+			final OmeNgffMultiScaleMetadata[] meta = OMEZarrAttributes.createOMEZarrMetadata(
 					3, // int n
 					omeZarrSubContainer, // String name, I also saw "/"
 					cal, // double[] resolutionS0,

--- a/src/main/java/net/preibisch/mvrecon/process/n5api/N5ApiTools.java
+++ b/src/main/java/net/preibisch/mvrecon/process/n5api/N5ApiTools.java
@@ -156,13 +156,13 @@ public class N5ApiTools
 		{
 			path = "t" + String.format("%05d", viewId.getTimePointId()) + "/" + "s" + String.format("%02d", viewId.getViewSetupId()) + "/" + level + "/cells";
 		}
-		else if ( StorageFormat.ZARR.equals( storageType ) )
+		else if ( StorageFormat.ZARR.equals( storageType ) || StorageFormat.ZARR2.equals( storageType ) )
 		{
 			path = "s" + viewId.getViewSetupId() + "-t" + viewId.getTimePointId() + ".zarr/" + level;
 		}
 		else
 		{
-			new RuntimeException( "BDV-compatible dataset cannot be written for " + storageType + " (yet).");
+			throw new RuntimeException( "BDV-compatible dataset cannot be written for " + storageType + " (yet).");
 		}
 
 		return path;

--- a/src/main/java/net/preibisch/mvrecon/process/n5api/N5ApiTools.java
+++ b/src/main/java/net/preibisch/mvrecon/process/n5api/N5ApiTools.java
@@ -76,7 +76,7 @@ import net.imglib2.util.Util;
 import net.imglib2.view.Views;
 import net.preibisch.legacy.io.IOFunctions;
 import net.preibisch.mvrecon.fiji.spimdata.SpimData2;
-import net.preibisch.mvrecon.fiji.spimdata.imgloaders.OMEZarrAttibutes;
+import net.preibisch.mvrecon.fiji.spimdata.imgloaders.OMEZarrAttributes;
 import net.preibisch.mvrecon.process.interestpointregistration.pairwise.constellation.grouping.Group;
 import util.Grid;
 
@@ -499,10 +499,10 @@ public class N5ApiTools
 
 		// extract the resolution of the s0 export
 		//final VoxelDimensions vx = fusionGroup.iterator().next().getViewSetup().getVoxelSize();
-		//final double[] resolutionS0 = OMEZarrAttibutes.getResolutionS0( vx, anisoF, downsamplingF );
+		//final double[] resolutionS0 = OMEZarrAttributes.getResolutionS0( vx, anisoF, downsamplingF );
 
 		// create metadata
-		final OmeNgffMultiScaleMetadata[] meta = OMEZarrAttibutes.createOMEZarrMetadata(
+		final OmeNgffMultiScaleMetadata[] meta = OMEZarrAttributes.createOMEZarrMetadata(
 				5, // int n
 				"/", // String name, I also saw "/"
 				new double[] { 1, 1, 1 }, //resolutionS0, // double[] resolutionS0,

--- a/src/main/java/util/URITools.java
+++ b/src/main/java/util/URITools.java
@@ -28,6 +28,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -43,6 +44,7 @@ import org.janelia.saalfeldlab.googlecloud.GoogleCloudUtils;
 import org.janelia.saalfeldlab.n5.FileSystemKeyValueAccess;
 import org.janelia.saalfeldlab.n5.GsonKeyValueN5Reader;
 import org.janelia.saalfeldlab.n5.KeyValueAccess;
+import org.janelia.saalfeldlab.n5.LockedChannel;
 import org.janelia.saalfeldlab.n5.N5FSReader;
 import org.janelia.saalfeldlab.n5.N5FSWriter;
 import org.janelia.saalfeldlab.n5.N5Reader;
@@ -516,7 +518,22 @@ public class URITools
 
 	public static OutputStream openFileWriteCloudStream( final KeyValueAccess kva, final URI uri ) throws IOException
 	{
-		return kva.lockForWriting( toNormalPath( kva, uri ) ).newOutputStream();
+		final LockedChannel channel = kva.lockForWriting( toNormalPath( kva, uri ) );
+		final OutputStream inner = channel.newOutputStream();
+		// In n5 alpha-10+, lockForWriting returns a BufferedKvaLockedChannel whose
+		// newOutputStream() returns an in-memory ByteArrayOutputStream. The actual
+		// disk write only happens in channel.close(). Wrap the stream so that
+		// closing it also closes the channel (flushing to disk).
+		return new FilterOutputStream(inner) {
+			@Override
+			public void close() throws IOException {
+				try {
+					super.close();
+				} finally {
+					channel.close();
+				}
+			}
+		};
 	}
 
 	/*

--- a/src/main/java/util/URITools.java
+++ b/src/main/java/util/URITools.java
@@ -380,6 +380,33 @@ public class URITools
 		{
 			return io.load( URITools.fromURI( xmlURI ) ); // method from XmlIoAbstractSpimData
 		}
+		else if ( HTTPS_SCHEME.asPredicate().test( xmlURI.getScheme() ) )
+		{
+			// Plain HTTP/HTTPS web server - fetch XML directly via URL
+			// Note: this also handles public S3/GC data served over https://
+			final SAXBuilder sax = new SAXBuilder();
+			Document doc;
+
+			try
+			{
+				final InputStream is = xmlURI.toURL().openStream();
+				doc = sax.build( is );
+				is.close();
+			}
+			catch ( final Exception e )
+			{
+				throw new SpimDataIOException( e );
+			}
+
+			final Element docRoot = doc.getRootElement();
+
+			if ( docRoot.getName() != SPIMDATA_TAG )
+				throw new RuntimeException( "expected <" + SPIMDATA_TAG + "> root element. wrong file?" );
+
+			final SpimData2 data = io.fromXml( docRoot, xmlURI );
+
+			return data;
+		}
 		else if ( URITools.isS3( xmlURI ) || URITools.isGC( xmlURI ) )
 		{
 			final KeyValueAccess kva = getKeyValueAccess( xmlURI );
@@ -517,7 +544,8 @@ public class URITools
 	// TODO: does not work for Windows
 	public static boolean isKnownScheme( URI uri )
 	{
-		return isFile( uri ) || isS3( uri ) || isGC( uri );
+		return isFile( uri ) || isS3( uri ) || isGC( uri )
+				|| ( uri.getScheme() != null && HTTPS_SCHEME.asPredicate().test( uri.getScheme() ) );
 	}
 
 	public static boolean isGC( URI uri )

--- a/src/test/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/ExampleOMEZarrXMLGeneration.java
+++ b/src/test/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/ExampleOMEZarrXMLGeneration.java
@@ -191,7 +191,7 @@ public class ExampleOMEZarrXMLGeneration
 		if ( datasetBaseName.isEmpty() )
 		{
 			org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v04.OmeNgffMultiScaleMetadata[] metadata =
-				OMEZarrAttibutes.createOMEZarrMetadata(
+				OMEZarrAttributes.createOMEZarrMetadata(
 					is3D ? 3 : 4,
 					"/",
 					is3D ? new double[] { voxelSizeX, voxelSizeY, voxelSizeZ } :


### PR DESCRIPTION
This PR aims to fix minor bugs, mostly relating to the loading / creation of zarrv3 datasets.

In a bit more detail:
- Updates n5 versions.
- Allows reading multiscales metadata from OME-ZARR 0.5 datasets. Note that in OME-ZARR 0.5, the multiscales data is stored at ome/multiscales (compared to multiscales for OME-ZARR 0.4).
- **NOTE**: the resave API still saves 0.4 metadata. The loading code has been adjusted so that it can read 0.4 metadata from datasets that should be using 0.5, but I aim to change this in the near future. 
- Channel and timepoint fallback options are added so that 3D data can be loaded / created (as opposed to just 4D/5D).
- Reads actual pyramid level paths from the data so as not to assume a particular format. (Previously, it assumed that the pyramid level paths were always 0,1,2..., while some tools generate s0,s1,s2...)
- Ensures Zarr2 backcompatibility (in some cases, `StorageFormat.ZARR` was being assumed)
- Added a new code path for loading XML files over plain HTTP/HTTPS
- While resaving, OOM errors could occur because all blocks were submitted to the thread pool at the same time. The new approach processes one view at a time, which eases memory pressure for large datasets.
- N5 alpha-10+ necessitates explicitly closing channels (not just the inner OutputStream) to flush new data to disk. 
- Fixed file name typo by renaming OMEZarrAttibutes to be OMEZarrAttributes and updating all calls to it.