### PR TITLE
split views bug fix: add multi channel support

### DIFF
--- a/src/main/java/net/preibisch/mvrecon/fiji/plugin/Split_Views.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/plugin/Split_Views.java
@@ -22,14 +22,20 @@
  */
 package net.preibisch.mvrecon.fiji.plugin;
 
+import java.awt.Color;
 import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
 
 import fiji.util.gui.GenericDialogPlus;
 import ij.ImageJ;
 import ij.gui.GenericDialog;
 import ij.plugin.PlugIn;
 import mpicbg.spim.data.SpimDataException;
+import mpicbg.spim.data.sequence.Channel;
 import net.preibisch.legacy.io.IOFunctions;
+import net.preibisch.mvrecon.fiji.plugin.util.GUIHelper;
 import net.preibisch.mvrecon.fiji.plugin.queryXML.GenericLoadParseQueryXML;
 import net.preibisch.mvrecon.fiji.plugin.queryXML.LoadParseQueryXML;
 import net.preibisch.mvrecon.fiji.spimdata.SpimData2;
@@ -64,6 +70,8 @@ public class Split_Views implements PlugIn
 
 	public static int defaultMethodChoice = 1;
 	private static final String[] methodChoices = new String[] { "Uniform splitting", "Oct-tree based adaptive splitting" };
+
+	public static int defaultChannelChoice = 0;
 
 	@Override
 	public void run(String arg)
@@ -110,7 +118,27 @@ public class Split_Views implements PlugIn
 			final SplittingTools.InterestPointSaver saver,
 			final SplittingTools.CorrespondenceSaver corrSaver )
 	{
-		final SpimData2 newSD = SplittingTools.splitImages( data, splitting, assingIlluminationsFromTileIds, ipAdding, pointDensity, minPoints, maxPoints, error, excludeRadius, fakeLabel, saver, corrSaver );
+		return split( data, saveAs, splitting, assingIlluminationsFromTileIds, ipAdding, pointDensity, minPoints, maxPoints, error, excludeRadius, display, fakeLabel, saver, corrSaver, null );
+	}
+
+	public static boolean split(
+			final SpimData2 data,
+			final URI saveAs,
+			final SplitView splitting,
+			final boolean assingIlluminationsFromTileIds,
+			final InterestPointAdding ipAdding,
+			final double pointDensity,
+			final int minPoints,
+			final int maxPoints,
+			final double error,
+			final double excludeRadius,
+			final boolean display,
+			final String fakeLabel,
+			final SplittingTools.InterestPointSaver saver,
+			final SplittingTools.CorrespondenceSaver corrSaver,
+			final Set< Integer > driveByChannelIds )
+	{
+		final SpimData2 newSD = SplittingTools.splitImages( data, splitting, assingIlluminationsFromTileIds, ipAdding, pointDensity, minPoints, maxPoints, error, excludeRadius, fakeLabel, saver, corrSaver, driveByChannelIds );
 
 		if ( display )
 		{
@@ -127,12 +155,45 @@ public class Split_Views implements PlugIn
 
 	public static boolean split( final SpimData2 data, final URI filePath )
 	{
+		// Only datasets with more than one channel can drive the split from a single channel.
+		final List< Channel > channels = data.getSequenceDescription().getAllChannelsOrdered();
+		final boolean multipleChannels = channels.size() > 1;
+
+		final String[] channelChoices = new String[ channels.size() + 1 ];
+		channelChoices[ 0 ] = "All channels (split each independently)";
+		for ( int i = 0; i < channels.size(); ++i )
+			channelChoices[ i + 1 ] = "Channel " + channels.get( i ).getName();
+
+		if ( defaultChannelChoice >= channelChoices.length )
+			defaultChannelChoice = 0;
+
 		final GenericDialog gdInit = new GenericDialogPlus( "Dataset splitting/subdividing method" );
 		gdInit.addChoice("splitting_method", methodChoices, methodChoices[ defaultMethodChoice ] );
+		if ( multipleChannels )
+		{
+			gdInit.addChoice( "Drive_split_by_channel", channelChoices, channelChoices[ defaultChannelChoice ] );
+			gdInit.addMessage(
+					"The selected channel will be split according to its own interest points.\n" +
+					"All other channels will be virtually split to match the tiling of the selected channel\n",
+					GUIHelper.smallStatusFont, Color.DARK_GRAY );
+		}
 		gdInit.showDialog();
 		if ( gdInit.wasCanceled() )
 			return false;
 		final int method = defaultMethodChoice = gdInit.getNextChoiceIndex();
+
+		// channel that drives the split geometry; all other channels mirror it
+		// (null = split every setup independently, the original behaviour)
+		final Set< Integer > driveByChannelIds;
+		if ( multipleChannels )
+		{
+			final int channelChoice = defaultChannelChoice = gdInit.getNextChoiceIndex();
+			driveByChannelIds = ( channelChoice == 0 ) ? null : Collections.singleton( channels.get( channelChoice - 1 ).getId() );
+		}
+		else
+		{
+			driveByChannelIds = null;
+		}
 
 		final long[] minStepSize = SplittingTools.findMinStepSize( data );
 
@@ -142,7 +203,7 @@ public class Split_Views implements PlugIn
 			SplitDistributeEvenly.setupGUI( gd, data, minStepSize );
 		else if ( method == 1 )
 		{
-			if ( !SplitOctTree.setupGUI( gd, data, minStepSize ) )
+			if ( !SplitOctTree.setupGUI( gd, data, minStepSize, driveByChannelIds ) )
 				return false;
 		}
 		else
@@ -179,7 +240,7 @@ public class Split_Views implements PlugIn
 		if ( method == 0 )
 			splittingMethod = SplitDistributeEvenly.queryGUI( gd, data, minStepSize );
 		else if ( method == 1 )
-			splittingMethod = SplitOctTree.queryGUI( gd, data, minStepSize );
+			splittingMethod = SplitOctTree.queryGUI( gd, data, minStepSize, driveByChannelIds );
 		else
 			throw new RuntimeException( "Unknown splitting method: " + method );
 
@@ -253,7 +314,7 @@ public class Split_Views implements PlugIn
 				ips.saveCorrespondingInterestPoints( false );
 		} : null;
 
-		return split( data, URITools.toURI( saveAs ), splittingMethod, assignIllum, ipAdding, density, minPoints, maxPoints, error, exclusionRadius, choice == 0, fakeLabel, saver, corrSaver );
+		return split( data, URITools.toURI( saveAs ), splittingMethod, assignIllum, ipAdding, density, minPoints, maxPoints, error, exclusionRadius, choice == 0, fakeLabel, saver, corrSaver, driveByChannelIds );
 	}
 
 	public static void main( String[] args ) throws SpimDataException

--- a/src/main/java/net/preibisch/mvrecon/process/splitting/ConsensusSetCriterion.java
+++ b/src/main/java/net/preibisch/mvrecon/process/splitting/ConsensusSetCriterion.java
@@ -309,11 +309,20 @@ public class ConsensusSetCriterion implements OctTreeSplitCriterion
 	 */
 	public static boolean setupGUI( final GenericDialog gd, final SpimData2 data )
 	{
-		// Get available interest point labels
-		final List< ViewId > allViewIds = new ArrayList<>();
-		for ( final ViewDescription vd : data.getSequenceDescription().getViewDescriptions().values() )
-			if ( vd.isPresent() )
-				allViewIds.add( vd );
+		return setupGUI( gd, data, null );
+	}
+
+	/**
+	 * Setup GUI components for consensus set criterion.
+	 *
+	 * @param driveByChannelIds if non-null, label availability counts are computed only over
+	 *        views of these driving channels (so labels that exist in every driving view are
+	 *        not flagged as "only available for X/Y Views" because of mirrored channels).
+	 */
+	public static boolean setupGUI( final GenericDialog gd, final SpimData2 data, final Set< Integer > driveByChannelIds )
+	{
+		// Get available interest point labels (restricted to the driving channels if requested)
+		final List< ViewId > allViewIds = collectViewIds( data, driveByChannelIds );
 
 		final String[] labels = InterestPointTools.getAllInterestPointLabels( data, allViewIds );
 
@@ -354,11 +363,19 @@ public class ConsensusSetCriterion implements OctTreeSplitCriterion
 	 */
 	public static ConsensusSetCriterion queryGUI( final GenericDialog gd, final SpimData2 data )
 	{
-		// Get labels again for parsing
-		final List< ViewId > allViewIds = new ArrayList<>();
-		for ( final ViewDescription vd : data.getSequenceDescription().getViewDescriptions().values() )
-			if ( vd.isPresent() )
-				allViewIds.add( vd );
+		return queryGUI( gd, data, null );
+	}
+
+	/**
+	 * Query GUI components and create ConsensusSetCriterion instance.
+	 *
+	 * @param driveByChannelIds must match the value passed to {@link #setupGUI} so the label
+	 *        choices are parsed against the same (channel-restricted) view set.
+	 */
+	public static ConsensusSetCriterion queryGUI( final GenericDialog gd, final SpimData2 data, final Set< Integer > driveByChannelIds )
+	{
+		// Get labels again for parsing (must use the same view set as setupGUI)
+		final List< ViewId > allViewIds = collectViewIds( data, driveByChannelIds );
 
 		final String[] labelsRaw = InterestPointTools.getAllInterestPointLabels( data, allViewIds );
 
@@ -417,5 +434,19 @@ public class ConsensusSetCriterion implements OctTreeSplitCriterion
 		}
 
 		return new ConsensusSetCriterion( data, selectedLabels, minCorrespondences, toleranceMode, toleranceValue );
+	}
+
+	/**
+	 * Collect all present view ids, optionally restricted to the given driving channels.
+	 *
+	 * @param driveByChannelIds if non-null, only views whose channel id is contained are returned
+	 */
+	private static List< ViewId > collectViewIds( final SpimData2 data, final Set< Integer > driveByChannelIds )
+	{
+		final List< ViewId > viewIds = new ArrayList<>();
+		for ( final ViewDescription vd : data.getSequenceDescription().getViewDescriptions().values() )
+			if ( vd.isPresent() && ( driveByChannelIds == null || driveByChannelIds.contains( vd.getViewSetup().getChannel().getId() ) ) )
+				viewIds.add( vd );
+		return viewIds;
 	}
 }

--- a/src/main/java/net/preibisch/mvrecon/process/splitting/CrossViewCorrespondenceCriterion.java
+++ b/src/main/java/net/preibisch/mvrecon/process/splitting/CrossViewCorrespondenceCriterion.java
@@ -124,11 +124,20 @@ public class CrossViewCorrespondenceCriterion implements OctTreeSplitCriterion
 	 */
 	public static boolean setupGUI( final GenericDialog gd, final SpimData2 data )
 	{
-		// Get available interest point labels
-		final List< ViewId > allViewIds = new ArrayList<>();
-		for ( final ViewDescription vd : data.getSequenceDescription().getViewDescriptions().values() )
-			if ( vd.isPresent() )
-				allViewIds.add( vd );
+		return setupGUI( gd, data, null );
+	}
+
+	/**
+	 * Setup GUI components for cross-view correspondence criterion.
+	 *
+	 * @param driveByChannelIds if non-null, label availability counts are computed only over
+	 *        views of these driving channels (so labels that exist in every driving view are
+	 *        not flagged as "only available for X/Y Views" because of mirrored channels).
+	 */
+	public static boolean setupGUI( final GenericDialog gd, final SpimData2 data, final Set< Integer > driveByChannelIds )
+	{
+		// Get available interest point labels (restricted to the driving channels if requested)
+		final List< ViewId > allViewIds = collectViewIds( data, driveByChannelIds );
 
 		final String[] labels = InterestPointTools.getAllInterestPointLabels( data, allViewIds );
 
@@ -166,11 +175,19 @@ public class CrossViewCorrespondenceCriterion implements OctTreeSplitCriterion
 	 */
 	public static CrossViewCorrespondenceCriterion queryGUI( final GenericDialog gd, final SpimData2 data )
 	{
-		// Get labels again for parsing
-		final List< ViewId > allViewIds = new ArrayList<>();
-		for ( final ViewDescription vd : data.getSequenceDescription().getViewDescriptions().values() )
-			if ( vd.isPresent() )
-				allViewIds.add( vd );
+		return queryGUI( gd, data, null );
+	}
+
+	/**
+	 * Query GUI components and create CrossViewCorrespondenceCriterion instance.
+	 *
+	 * @param driveByChannelIds must match the value passed to {@link #setupGUI} so the label
+	 *        choices are parsed against the same (channel-restricted) view set.
+	 */
+	public static CrossViewCorrespondenceCriterion queryGUI( final GenericDialog gd, final SpimData2 data, final Set< Integer > driveByChannelIds )
+	{
+		// Get labels again for parsing (must use the same view set as setupGUI)
+		final List< ViewId > allViewIds = collectViewIds( data, driveByChannelIds );
 
 		final String[] labelsRaw = InterestPointTools.getAllInterestPointLabels( data, allViewIds );
 
@@ -204,5 +221,19 @@ public class CrossViewCorrespondenceCriterion implements OctTreeSplitCriterion
 		final int maxCorrespondences = defaultMaxCorrespondences = (int) Math.round( gd.getNextNumber() );
 
 		return new CrossViewCorrespondenceCriterion( data, selectedLabels, maxCorrespondences );
+	}
+
+	/**
+	 * Collect all present view ids, optionally restricted to the given driving channels.
+	 *
+	 * @param driveByChannelIds if non-null, only views whose channel id is contained are returned
+	 */
+	private static List< ViewId > collectViewIds( final SpimData2 data, final Set< Integer > driveByChannelIds )
+	{
+		final List< ViewId > viewIds = new ArrayList<>();
+		for ( final ViewDescription vd : data.getSequenceDescription().getViewDescriptions().values() )
+			if ( vd.isPresent() && ( driveByChannelIds == null || driveByChannelIds.contains( vd.getViewSetup().getChannel().getId() ) ) )
+				viewIds.add( vd );
+		return viewIds;
 	}
 }

--- a/src/main/java/net/preibisch/mvrecon/process/splitting/SplitOctTree.java
+++ b/src/main/java/net/preibisch/mvrecon/process/splitting/SplitOctTree.java
@@ -843,6 +843,18 @@ public class SplitOctTree implements SplitView
 	 */
 	public static boolean setupGUI( final GenericDialog gd, final SpimData2 data, final long[] minStepSize )
 	{
+		return setupGUI( gd, data, minStepSize, null );
+	}
+
+	/**
+	 * Setup GUI components for oct-tree splitting parameters.
+	 *
+	 * @param driveByChannelIds if non-null, interest-point label statistics (e.g. the
+	 *        "available for X/Y Views" counts) are restricted to views of these channels,
+	 *        which are the only ones whose own correspondences drive the split.
+	 */
+	public static boolean setupGUI( final GenericDialog gd, final SpimData2 data, final long[] minStepSize, final Set< Integer > driveByChannelIds )
+	{
 		final GenericDialog gdCriterion = new GenericDialog( "Oct-Tree Split Criterion" );
 		gdCriterion.addChoice( "Split_criterion", CRITERION_NAMES, CRITERION_NAMES[ defaultCriterionChoice ] );
 		gdCriterion.showDialog();
@@ -858,9 +870,9 @@ public class SplitOctTree implements SplitView
 
 		boolean success = false;
 		if ( selectedCriterion.equals( CrossViewCorrespondenceCriterion.CRITERION_NAME ) )
-			success = CrossViewCorrespondenceCriterion.setupGUI( gd, data );
+			success = CrossViewCorrespondenceCriterion.setupGUI( gd, data, driveByChannelIds );
 		else if ( selectedCriterion.equals( ConsensusSetCriterion.CRITERION_NAME ) )
-			success = ConsensusSetCriterion.setupGUI( gd, data );
+			success = ConsensusSetCriterion.setupGUI( gd, data, driveByChannelIds );
 
 		if ( !success )
 			return false;
@@ -915,14 +927,25 @@ public class SplitOctTree implements SplitView
 	 */
 	public static SplitOctTree queryGUI( final GenericDialog gd, final SpimData2 data, final long[] minStepSize )
 	{
+		return queryGUI( gd, data, minStepSize, null );
+	}
+
+	/**
+	 * Query GUI components and create SplitOctTree instance.
+	 *
+	 * @param driveByChannelIds must match the value passed to {@link #setupGUI} so the label
+	 *        choices are parsed against the same (channel-restricted) view set.
+	 */
+	public static SplitOctTree queryGUI( final GenericDialog gd, final SpimData2 data, final long[] minStepSize, final Set< Integer > driveByChannelIds )
+	{
 		final String criterionName = CRITERION_NAMES[ defaultCriterionChoice ];
 
 		OctTreeSplitCriterion criterion = null;
 
 		if ( criterionName.equals( CrossViewCorrespondenceCriterion.CRITERION_NAME ) )
-			criterion = CrossViewCorrespondenceCriterion.queryGUI( gd, data );
+			criterion = CrossViewCorrespondenceCriterion.queryGUI( gd, data, driveByChannelIds );
 		else if ( criterionName.equals( ConsensusSetCriterion.CRITERION_NAME ) )
-			criterion = ConsensusSetCriterion.queryGUI( gd, data );
+			criterion = ConsensusSetCriterion.queryGUI( gd, data, driveByChannelIds );
 
 		if ( criterion == null )
 			return null;

--- a/src/main/java/net/preibisch/mvrecon/process/splitting/SplittingTools.java
+++ b/src/main/java/net/preibisch/mvrecon/process/splitting/SplittingTools.java
@@ -67,6 +67,7 @@ import mpicbg.spim.data.sequence.ViewSetup;
 import mpicbg.spim.data.sequence.VoxelDimensions;
 import net.imglib2.Dimensions;
 import net.imglib2.FinalDimensions;
+import net.imglib2.FinalInterval;
 import net.imglib2.Interval;
 import net.imglib2.KDTree;
 import net.imglib2.neighborsearch.RadiusNeighborSearch;
@@ -201,6 +202,16 @@ public class SplittingTools
 		return "splitPoints_" + ( System.currentTimeMillis() % 10000 );
 	}
 
+	/**
+	 * Group key identifying "the same view across channels": setups sharing angle, illumination and
+	 * tile differ only in channel and thus describe the same physical region, so they must be tiled
+	 * identically.
+	 */
+	private static String attributeGroupKey( final ViewSetup s )
+	{
+		return s.getAngle().getId() + "_" + s.getIllumination().getId() + "_" + s.getTile().getId();
+	}
+
 	public static ViewId findFirstPresentViewId( final SpimData2 spimData, final int setupId )
 	{
 		final TimePoints timepoints = spimData.getSequenceDescription().getTimePoints();
@@ -229,6 +240,36 @@ public class SplittingTools
 			final String fakeLabel,
 			final InterestPointSaver saver,
 			final CorrespondenceSaver corrSaver )
+	{
+		return splitImages( spimData, splitting, assingIlluminationsFromTileIds, ipAdding, pointDensity, minPoints, maxPoints, error, excludeRadius, fakeLabel, saver, corrSaver, null );
+	}
+
+	/**
+	 * Split all ViewSetups of the dataset, optionally <i>driving</i> the split geometry from a
+	 * single channel.
+	 *
+	 * @param driveByChannelIds if non-null, only ViewSetups whose channel id is contained in this
+	 *        set are split based on their own correspondences/criterion. Every other ViewSetup
+	 *        reuses ("mirrors") the intervals of the matching (same angle/illumination/tile and
+	 *        equal dimensions) driving setup, so all channels are tiled identically - required for
+	 *        downstream fusion. {@code null} splits every setup independently (original behaviour).
+	 *        Typical use: only one channel was registered (e.g. multi-consensus RANSAC), so only
+	 *        that channel can drive the split, but all channels must be subdivided consistently.
+	 */
+	public static SpimData2 splitImages(
+			final SpimData2 spimData,
+			final SplitView splitting,
+			final boolean assingIlluminationsFromTileIds,
+			final InterestPointAdding ipAdding,
+			final double pointDensity,
+			final int minPoints,
+			final int maxPoints,
+			final double error,
+			final double excludeRadius,
+			final String fakeLabel,
+			final InterestPointSaver saver,
+			final CorrespondenceSaver corrSaver,
+			final Set< Integer > driveByChannelIds )
 	{
 		final TimePoints timepoints = spimData.getSequenceDescription().getTimePoints();
 
@@ -272,17 +313,33 @@ public class SplittingTools
 		final Map< ViewSetup, ArrayList< Interval > > splitResults = new HashMap<>();
 
 		final int nThreads = Threads.numThreads();
-		IOFunctions.println( "Parallel splitting with " + nThreads + " threads for " + oldSetups.size() + " setups..." );
 
-		// Build ViewIds for each setup (find first present timepoint)
-		final List< ViewId > viewIds = new ArrayList<>();
+		// When a driving channel is selected, only that channel's setups are split based on their
+		// own correspondences; every other channel mirrors the intervals of the matching
+		// (same angle/illumination/tile) driving setup, so all channels are tiled identically
+		// (required for downstream fusion). Otherwise every setup is split independently.
+		final boolean driveByChannel = driveByChannelIds != null;
+
+		final List< ViewSetup > setupsToSplit = new ArrayList<>();
 		for ( final ViewSetup oldSetup : oldSetups )
-			viewIds.add( findFirstPresentViewId( spimData, oldSetup.getId() ) );
+			if ( !driveByChannel || driveByChannelIds.contains( oldSetup.getChannel().getId() ) )
+				setupsToSplit.add( oldSetup );
 
-		// Create parallel tasks
+		if ( setupsToSplit.isEmpty() )
+			throw new IllegalArgumentException( "No ViewSetups match the selected driving channel(s) " + driveByChannelIds + " - nothing to split." );
+
+		IOFunctions.println( "Parallel splitting with " + nThreads + " threads for " + setupsToSplit.size() +
+				( driveByChannel
+					? " driving setup(s) of channel " + driveByChannelIds + "; the remaining " + ( oldSetups.size() - setupsToSplit.size() ) + " setup(s) will mirror them."
+					: " setups..." ) );
+
+		// Create parallel tasks (only for the setups we split directly)
 		final List< Callable< SplitResult > > tasks = new ArrayList<>();
-		for ( final ViewId viewId : viewIds )
+		for ( final ViewSetup setup : setupsToSplit )
+		{
+			final ViewId viewId = findFirstPresentViewId( spimData, setup.getId() );
 			tasks.add( () -> splitting.split( viewId ) );
+		}
 
 		// Execute
 		final List< SplitResult > allResults = new ArrayList<>();
@@ -293,7 +350,7 @@ public class SplittingTools
 
 			for ( int i = 0; i < futures.size(); i++ )
 			{
-				final ViewSetup setup = oldSetups.get( i );
+				final ViewSetup setup = setupsToSplit.get( i );
 				final SplitResult result = futures.get( i ).get();
 
 				if ( result == null )
@@ -321,6 +378,41 @@ public class SplittingTools
 		finally
 		{
 			taskExecutor.shutdown();
+		}
+
+		// Mirror the driving channel's split geometry onto all remaining setups so every channel
+		// is tiled identically (the intervals are in image-local [0..size-1] coordinates, so they
+		// transfer directly to a setup of equal dimensions).
+		if ( driveByChannel )
+		{
+			// group key (angle, illumination, tile) -> a driving setup that was split
+			final Map< String, ViewSetup > drivingByGroup = new HashMap<>();
+			for ( final ViewSetup s : setupsToSplit )
+				drivingByGroup.putIfAbsent( attributeGroupKey( s ), s );
+
+			for ( final ViewSetup s : oldSetups )
+			{
+				if ( splitResults.containsKey( s ) )
+					continue; // a driving setup, already split
+
+				final ViewSetup driver = drivingByGroup.get( attributeGroupKey( s ) );
+
+				if ( driver != null && Intervals.equalDimensions( driver.getSize(), s.getSize() ) )
+				{
+					splitResults.put( s, new ArrayList<>( splitResults.get( driver ) ) );
+					IOFunctions.println( "ViewSetup " + s.getId() + " mirrors split of driving ViewSetup " +
+							driver.getId() + " (" + splitResults.get( s ).size() + " tiles)" );
+				}
+				else
+				{
+					// no matching driving setup (or differing dimensions): keep as a single un-split tile
+					IOFunctions.printErr( "WARNING: ViewSetup " + s.getId() + " has no matching driving setup" +
+							( driver != null ? " of equal dimensions" : "" ) + "; keeping it as a single (un-split) tile." );
+					final ArrayList< Interval > single = new ArrayList<>();
+					single.add( new FinalInterval( s.getSize() ) );
+					splitResults.put( s, single );
+				}
+			}
 		}
 
 		// ==================== Process Split Results in Parallel ====================

--- a/src/main/java/net/preibisch/mvrecon/process/splitting/SplittingTools.java
+++ b/src/main/java/net/preibisch/mvrecon/process/splitting/SplittingTools.java
@@ -780,9 +780,14 @@ public class SplittingTools
 				final ViewInterestPointLists newVipl = new ViewInterestPointLists( newViewId.getTimePointId(), newViewId.getViewSetupId() );
 				final ViewInterestPointLists oldVipl = spimData.getViewInterestPoints().getViewInterestPointLists( oldViewId );
 
-				// only update interest points for present views
-				// oldVipl may be null for missing views
-				if ( spimData.getSequenceDescription().getMissingViews() != null && !spimData.getSequenceDescription().getMissingViews().getMissingViews().contains( oldViewId ) )
+				// only update interest points for present views.
+				// A null MissingViews (or null inner set) means NO views are missing, i.e. all are present -
+				// e.g. datasets whose XML has no <MissingViews> element (such as this OME-ZARR dataset) load
+				// it as null. The old guard ( getMissingViews() != null && !contains(..) ) short-circuited to
+				// false in that case and silently skipped ALL interest-point splitting, producing an empty
+				// <ViewInterestPoints/>. Treat null as "present".
+				final MissingViews mvSetup = spimData.getSequenceDescription().getMissingViews();
+				if ( mvSetup == null || mvSetup.getMissingViews() == null || !mvSetup.getMissingViews().contains( oldViewId ) )
 				{
 					for ( final String label : oldVipl.getHashMap().keySet() )
 					{
@@ -1096,9 +1101,13 @@ public class SplittingTools
 		final ViewInterestPointLists oldVipl = spimData.getViewInterestPoints().getViewInterestPointLists( oldViewId );
 		final ViewInterestPointLists newVipl = newInterestpoints.get( newViewId );
 
-		// only update interest points for present views
-		// oldVipl may be null for missing views
-		if ( spimData.getSequenceDescription().getMissingViews() != null && !spimData.getSequenceDescription().getMissingViews().getMissingViews().contains( oldViewId ) )
+		// only update interest points for present views.
+		// A null MissingViews (or null inner set) means NO views are missing, i.e. all are present
+		// (e.g. datasets whose XML has no <MissingViews> element load it as null). Treat null as "present",
+		// otherwise correspondences would be silently skipped for the whole dataset (mirrors the guard in
+		// processSetupStatic).
+		final MissingViews mvCorr = spimData.getSequenceDescription().getMissingViews();
+		if ( mvCorr == null || mvCorr.getMissingViews() == null || !mvCorr.getMissingViews().contains( oldViewId ) )
 		{
 			// Lazy cache for interest point maps, either caller-supplied (amortized across calls) or fresh per call.
 			// Key: "timepointId_setupId_label" -> Map of detection IDs


### PR DESCRIPTION
Previously, multi-channel datasets would error during multiconsensus virtual splitting because not all viewIDs were registered with the multiconsensus algorithm. This PR adds an option to drive the split via a single channel (therefore, only one channel needs to be registered via multiconsensus). ViewIDs in other channels are split such that they mirror the corresponding viewID in the driving channel. The fix presumes that tiles with the same id and differing channels occupy the same location.